### PR TITLE
configuration: disable wakatime in maximal output

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -175,7 +175,7 @@ inputs: let
 
       utility = {
         ccc.enable = isMaximal;
-        vim-wakatime.enable = isMaximal;
+        vim-wakatime.enable = false;
         icon-picker.enable = isMaximal;
         surround.enable = isMaximal;
         diffview-nvim.enable = true;


### PR DESCRIPTION
Wakatime errors on startup because it requires an API key and gets in the way when testing out your changes. So I suggest we disable it in the maximal output.