### PR TITLE
modules: clean up plugins directory

### DIFF
--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -10,6 +10,7 @@
   # Contains configuration for core neovim features
   # such as spellchecking, mappings, and the init script (init.vim).
   neovim = map (p: ./neovim + "/${p}") [
+    "global"
     "init"
     "mappings"
   ];

--- a/modules/neovim/global/default.nix
+++ b/modules/neovim/global/default.nix
@@ -1,0 +1,6 @@
+{lib}: {
+  imports = lib.concatLists [
+    # Configuration options for Neovim UI
+    (lib.filesystem.listFilesRecursive ./ui)
+  ];
+}

--- a/modules/neovim/global/default.nix
+++ b/modules/neovim/global/default.nix
@@ -1,6 +1,12 @@
-{lib}: {
-  imports = lib.concatLists [
+{lib, ...}: let
+  inherit (lib.lists) concatLists;
+  inherit (lib.filesystem) listFilesRecursive;
+in {
+  imports = concatLists [
     # Configuration options for Neovim UI
-    (lib.filesystem.listFilesRecursive ./ui)
+    (listFilesRecursive ./ui)
+
+    # vim.diagnostics
+    [./diagnostics.nix]
   ];
 }

--- a/modules/neovim/global/diagnostics.nix
+++ b/modules/neovim/global/diagnostics.nix
@@ -1,0 +1,115 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) str bool enum either;
+in {
+  options.vim.diagnostics = {
+    virtual_text = mkOption {
+      type = bool;
+      default = true;
+      description = ''
+        Whether to use virtual text for diagnostics.
+
+        If multiple diagnostics are set for a namespace, one
+        prefix per diagnostic + the last diagnostic message
+        are shown.
+      '';
+    };
+
+    update_in_insert = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to update diagnostics in insert mode.
+
+        This is useful for slow diagnostics sources, but can
+        also cause lag in insert mode.
+      '';
+    };
+
+    underline = mkOption {
+      type = bool;
+      default = true;
+      description = ''
+        Whether to underline diagnostics.
+      '';
+    };
+
+    severity_sort = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to sort diagnostics by severity.
+
+        This affects the order in which signs and
+        virtual text are displayed. When true, higher
+        severities are displayed before lower severities (e.g.
+        ERROR is displayed before WARN)
+      '';
+    };
+
+    float = {
+      focusable = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Whether the floating window is focusable.
+          When true, the floating window can be focused and
+          interacted with. When false, the floating window is
+          not focusable and will not receive input.
+        '';
+      };
+
+      border = mkOption {
+        type = enum ["none" "single" "double" "rounded" "solid" "shadow"];
+        default = config.vim.ui.border.globalStyle;
+        description = ''
+          The border style of the floating window.
+
+          Possible values:
+            - none
+            - single
+            - double
+            - rounded
+            - solid
+            - shadow
+
+          See `:h nvim_open_win` for the available border
+          styles and their definitions.
+        '';
+      };
+
+      source = mkOption {
+        type = either bool (enum ["always" "if_many"]);
+        default = "auto";
+        description = ''
+            The source of the floating window.
+            Possible values:
+          - auto: Use the same source as the diagnostics
+            window.
+          - window: Use the window source.
+          - buffer: Use the buffer source.
+        '';
+      };
+
+      prefix = mkOption {
+        type = str;
+        default = "";
+        description = ''
+          Prefix string for each diagnostic in the floating window
+        '';
+      };
+
+      suffix = mkOption {
+        type = str;
+        default = "";
+        description = ''
+          Suffix string for each diagnostic in the floating window
+        '';
+      };
+    };
+  };
+}

--- a/modules/neovim/global/ui/borders.nix
+++ b/modules/neovim/global/ui/borders.nix
@@ -10,14 +10,18 @@
 
   cfg = config.vim.ui.borders;
 
-  defaultStyles = ["none" "single" "double" "rounded"];
+  # See `:h nvim_open_win` for the available border styles
+  # this list can be updated if additional styles are added.
+  defaultStyles = ["none" "single" "double" "rounded" "solid" "shadow"];
 in {
   options.vim.ui.borders = {
-    enable = mkEnableOption "visible borders for most windows";
+    enable = mkEnableOption "visible borders for windows that support configurable borders";
 
+    # TODO: support configurable border elements with a lua table converted from a list of str
+    # e.g. [ "╔" "═" "╗" "║" "╝" "═" "╚" "║" ]
     globalStyle = mkOption {
       type = enum defaultStyles;
-      default = "rounded";
+      default = "single";
       description = ''
         The global border style to use.
       '';
@@ -37,11 +41,11 @@ in {
       mapAttrs (_: mkPluginStyleOption) {
         # despite not having it listed in example configuration, which-key does support the rounded type
         # additionally, it supports a "shadow" type that is similar to none but is of higher contrast
-        which-key = mkPluginStyleOption "which-key";
-        lspsaga = mkPluginStyleOption "lspsaga";
-        nvim-cmp = mkPluginStyleOption "nvim-cmp";
-        lsp-signature = mkPluginStyleOption "lsp-signature";
-        code-action-menu = mkPluginStyleOption "code-actions-menu";
+        which-key = "which-key";
+        lspsaga = "lspsaga";
+        nvim-cmp = "nvim-cmp";
+        lsp-signature = "lsp-signature";
+        code-action-menu = "code-actions-menu";
       };
   };
 }

--- a/modules/neovim/global/ui/borders.nix
+++ b/modules/neovim/global/ui/borders.nix
@@ -4,6 +4,7 @@
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.attrsets) mapAttrs;
   inherit (lib.lists) optionals;
   inherit (lib.types) enum;
 
@@ -22,7 +23,6 @@ in {
       '';
     };
 
-    # TODO: make per-plugin borders configurable
     plugins = let
       mkPluginStyleOption = name: {
         enable = mkEnableOption "borders for the ${name} plugin" // {default = cfg.enable;};
@@ -33,14 +33,15 @@ in {
           description = "The border style to use for the ${name} plugin";
         };
       };
-    in {
-      # despite not having it listed in example configuration, which-key does support the rounded type
-      # additionally, it supports a "shadow" type that is similar to none but is of higher contrast
-      which-key = mkPluginStyleOption "which-key";
-      lspsaga = mkPluginStyleOption "lspsaga";
-      nvim-cmp = mkPluginStyleOption "nvim-cmp";
-      lsp-signature = mkPluginStyleOption "lsp-signature";
-      code-action-menu = mkPluginStyleOption "code-actions-menu";
-    };
+    in
+      mapAttrs (_: mkPluginStyleOption) {
+        # despite not having it listed in example configuration, which-key does support the rounded type
+        # additionally, it supports a "shadow" type that is similar to none but is of higher contrast
+        which-key = mkPluginStyleOption "which-key";
+        lspsaga = mkPluginStyleOption "lspsaga";
+        nvim-cmp = mkPluginStyleOption "nvim-cmp";
+        lsp-signature = mkPluginStyleOption "lsp-signature";
+        code-action-menu = mkPluginStyleOption "code-actions-menu";
+      };
   };
 }

--- a/modules/neovim/global/ui/icons.nix
+++ b/modules/neovim/global/ui/icons.nix
@@ -3,28 +3,30 @@
   inherit (lib.types) str;
 in {
   options.vim.ui.icons = {
-    ERROR = mkOption {
-      type = str;
-      default = " ";
-      description = "The icon to use for error messages";
-    };
+    diagnostics = {
+      ERROR = mkOption {
+        type = str;
+        default = " ";
+        description = "The icon to use for error messages";
+      };
 
-    WARN = mkOption {
-      type = str;
-      default = " ";
-      description = "The icon to use for warning messages";
-    };
+      WARN = mkOption {
+        type = str;
+        default = " ";
+        description = "The icon to use for warning messages";
+      };
 
-    INFO = mkOption {
-      type = str;
-      default = " ";
-      description = "The icon to use for info messages";
-    };
+      INFO = mkOption {
+        type = str;
+        default = " ";
+        description = "The icon to use for info messages";
+      };
 
-    HINT = mkOption {
-      type = str;
-      default = " ";
-      description = "The icon to use for hint messages";
+      HINT = mkOption {
+        type = str;
+        default = " ";
+        description = "The icon to use for hint messages";
+      };
     };
   };
 }

--- a/modules/neovim/global/ui/icons.nix
+++ b/modules/neovim/global/ui/icons.nix
@@ -1,0 +1,30 @@
+{lib, ...}: let
+  inherit (lib.options) mkOption;
+  inherit (lib.types) str;
+in {
+  options.vim.ui.icons = {
+    ERROR = mkOption {
+      type = str;
+      default = " ";
+      description = "The icon to use for error messages";
+    };
+
+    WARN = mkOption {
+      type = str;
+      default = " ";
+      description = "The icon to use for warning messages";
+    };
+
+    INFO = mkOption {
+      type = str;
+      default = " ";
+      description = "The icon to use for info messages";
+    };
+
+    HINT = mkOption {
+      type = str;
+      default = " ";
+      description = "The icon to use for hint messages";
+    };
+  };
+}

--- a/modules/plugins/ui/borders/default.nix
+++ b/modules/plugins/ui/borders/default.nix
@@ -1,5 +1,0 @@
-{
-  imports = [
-    ./borders.nix
-  ];
-}

--- a/modules/plugins/ui/default.nix
+++ b/modules/plugins/ui/default.nix
@@ -1,8 +1,9 @@
 {
   imports = [
-    ./breadcumbs
+    ./breadcrumbs
     ./colorizer
     ./illuminate
+    ./modes
     ./noice
     ./notifications
     ./smartcolumn

--- a/modules/plugins/ui/default.nix
+++ b/modules/plugins/ui/default.nix
@@ -1,12 +1,10 @@
 {
   imports = [
-    ./noice
-    ./modes
-    ./notifications
-    ./smartcolumn
+    ./breadcumbs
     ./colorizer
     ./illuminate
-    ./breadcrumbs
-    ./borders
+    ./noice
+    ./notifications
+    ./smartcolumn
   ];
 }


### PR DESCRIPTION
- Move border configuration from `plugins` to `neovim/global`
- Make icons configurable. The icons can be written to a lua table at the beginning of the lua config to make it accessible within lua files.
- Make `vim.diagnostics` configurable