### PR TITLE
plugins/lsp: filter out null mappings

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -13,7 +13,8 @@ Release notes for release 0.7
 
 - Modified type for [](#opt-vim.visuals.fidget-nvim.setupOpts.progress.display.overrides)
   from `anything` to a `submodule` for better type checking.
+- Fix null `vim.lsp.mappings` generating an error and not being filtered out.
 
-[horriblename](https://github.com/horriblename)
+[horriblename](https://github.com/horriblename):
 
 - Fix broken treesitter-context keybinds in visual mode

--- a/modules/plugins/lsp/config.nix
+++ b/modules/plugins/lsp/config.nix
@@ -16,7 +16,10 @@
 
   mappingDefinitions = self.options.vim.lsp.mappings;
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
-  mkBinding = binding: action: "vim.api.nvim_buf_set_keymap(bufnr, 'n', '${binding.value}', '<cmd>lua ${action}<CR>', {noremap=true, silent=true, desc='${binding.description}'})";
+  mkBinding = binding: action:
+    if binding.value != null
+    then "vim.api.nvim_buf_set_keymap(bufnr, 'n', '${binding.value}', '<cmd>lua ${action}<CR>', {noremap=true, silent=true, desc='${binding.description}'})"
+    else "";
 in {
   config = mkIf cfg.enable {
     vim = {


### PR DESCRIPTION
Adds a check to filter out null mappings in local function `mkBinding`.

It is only an issue with the LSP module because it doesn't use `genMaps` to generate the mappings and therefore doesn't filter them out automatically.

Fixes #281