### PR TITLE
lib: do not filter out empty attrs in toLuaObject

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -19,6 +19,8 @@ Release notes for release 0.7
 [horriblename](https://github.com/horriblename):
 
 - Fix broken treesitter-context keybinds in visual mode
+- Depcrecate use of `__empty` to define empty tables in lua. Empty attrset are
+  no longer filtered and thus should be used instead.
 
 [NotAShelf](https://github.com/notashelf)
 

--- a/lib/lua.nix
+++ b/lib/lua.nix
@@ -3,7 +3,7 @@
   inherit (builtins) hasAttr head throw typeOf isList isAttrs isBool isInt isString isPath isFloat toJSON;
   inherit (lib.attrsets) mapAttrsToList filterAttrs;
   inherit (lib.strings) concatStringsSep concatMapStringsSep stringToCharacters;
-  inherit (lib.trivial) boolToString;
+  inherit (lib.trivial) boolToString warn;
 in rec {
   wrapLuaConfig = {
     luaBefore ? "",
@@ -67,7 +67,7 @@ in rec {
       then args.expr
       else if hasAttr "__empty" args
       then
-        lib.warn ''
+        warn ''
           Using `__empty` to define an empty lua table is deprecated. Use an empty attrset instead.
         '' "{ }"
       else

--- a/lib/lua.nix
+++ b/lib/lua.nix
@@ -65,9 +65,6 @@ in rec {
     then
       if isLuaInline args
       then args.expr
-      # if nobody is using this we should get rid of this
-      else if hasAttr "__empty" args
-      then "{ }"
       else
         "{"
         + (concatStringsSep ","

--- a/lib/lua.nix
+++ b/lib/lua.nix
@@ -65,6 +65,11 @@ in rec {
     then
       if isLuaInline args
       then args.expr
+      else if hasAttr "__empty" args
+      then
+        lib.warn ''
+          Using `__empty` to define an empty lua table is deprecated. Use an empty attrset instead.
+        '' "{ }"
       else
         "{"
         + (concatStringsSep ","

--- a/lib/lua.nix
+++ b/lib/lua.nix
@@ -65,6 +65,7 @@ in rec {
     then
       if isLuaInline args
       then args.expr
+      # if nobody is using this we should get rid of this
       else if hasAttr "__empty" args
       then "{ }"
       else
@@ -76,10 +77,7 @@ in rec {
               then toLuaObject v
               else "[${toLuaObject n}] = " + (toLuaObject v))
             (filterAttrs
-              (
-                _: v:
-                  (v != null) && (toLuaObject v != "{}")
-              )
+              (_: v: v != null)
               args)))
         + "}"
     else if isList args

--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -60,16 +60,11 @@
       config = (attrs) the configuration options for this mapping (noremap, silent...)
     }
     */
-    normalizeAction = action: let
+    normalizeAction = action: {
       # Extract the values of the config options that have been explicitly set by the user
       config =
         filterAttrs (_: v: v != null)
         (getAttrs (attrNames mapConfigOptions) action);
-    in {
-      config =
-        if config == {}
-        then {"__empty" = null;}
-        else config;
       action =
         if action.lua
         then mkLuaInline action.action


### PR DESCRIPTION
there is a single use of `__empty` in the codebase, I need to double check what it's doing before I remove it