### PR TITLE
add ocaml support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -73,6 +73,7 @@ inputs: let
         go.enable = isMaximal;
         elixir.enable = isMaximal;
         zig.enable = isMaximal;
+        ocaml.enable = isMaximal;
         python.enable = isMaximal;
         dart.enable = isMaximal;
         bash.enable = isMaximal;

--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -38,3 +38,7 @@ Release notes for release 0.7
 
 - Cleaned up Lualine module to reduce theme dependency on Catppuccin, and fixed
   blending issues in component separators.
+
+[jacekpoz](https://github.com/jacekpoz):
+
+- Added [ocaml-lsp](https://github.com/ocaml/ocaml-lsp) support.

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -14,6 +14,7 @@ in {
     ./markdown.nix
     ./nim.nix
     ./nix.nix
+    ./ocaml.nix
     ./php.nix
     ./python.nix
     ./rust.nix

--- a/modules/plugins/languages/ocaml.nix
+++ b/modules/plugins/languages/ocaml.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.meta) getExe;
+  inherit (lib.lists) isList;
+  inherit (lib.types) either listOf package str;
+  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.nvim.lua) expToLua;
+
+  cfg = config.vim.languages.ocaml;
+in {
+  options.vim.languages.ocaml = {
+    enable = mkEnableOption "OCaml language support";
+
+    treesitter = {
+      enable = mkEnableOption "OCaml treesitter" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "ocaml";
+    };
+
+    lsp = {
+      enable = mkEnableOption "OCaml LSP support (ocaml-lsp)" // {default = config.vim.languages.enableLSP;};
+      package = mkOption {
+        description = "ocaml language server package, or the command to run as a list of strings";
+        type = either package (listOf str);
+        default = pkgs.ocamlPackages.ocaml-lsp;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.ocaml-lsp = ''
+        lspconfig.ocamllsp.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+            cmd = ${
+            if isList cfg.lsp.package
+            then expToLua cfg.lsp.package
+            else ''{"${getExe cfg.lsp.package}"}''
+          };
+        }
+      '';
+    })
+
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+  ]);
+}

--- a/modules/plugins/languages/ocaml.nix
+++ b/modules/plugins/languages/ocaml.nix
@@ -30,6 +30,15 @@ in {
         default = pkgs.ocamlPackages.ocaml-lsp;
       };
     };
+
+    format = {
+      enable = mkEnableOption "OCaml formatting support (ocamlformat)" // {default = config.vim.languages.enableFormat;};
+      package = mkOption {
+        description = "OCaml formatter package";
+        type = package;
+        default = pkgs.ocamlPackages.ocamlformat;
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -51,6 +60,18 @@ in {
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
       vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.format.enable {
+      vim.lsp.null-ls.enable = true;
+      vim.lsp.null-ls.sources.ocamlformat = ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.formatting.ocamlformat.with({
+            command = "${cfg.format.package}/bin/ocamlformat",
+          })
+        )
+      '';
     })
   ]);
 }

--- a/modules/plugins/languages/ocaml.nix
+++ b/modules/plugins/languages/ocaml.nix
@@ -24,10 +24,10 @@
           capabilities = capabilities,
           on_attach = default_on_attach,
             cmd = ${
-            if isList cfg.lsp.package
-            then expToLua cfg.lsp.package
-            else ''{"${getExe cfg.lsp.package}"}''
-          };
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${getExe cfg.lsp.package}"}''
+        };
         }
       '';
     };
@@ -99,7 +99,7 @@ in {
     (mkIf cfg.format.enable {
       vim.lsp.null-ls.enable = true;
       vim.lsp.null-ls.sources.ocamlformat = formats.${cfg.format.type}.nullConfig;
-      vim.extraPackages = [ formats.${cfg.format.type}.package ];
+      vim.extraPackages = [formats.${cfg.format.type}.package];
     })
   ]);
 }

--- a/modules/plugins/languages/ocaml.nix
+++ b/modules/plugins/languages/ocaml.nix
@@ -99,6 +99,7 @@ in {
     (mkIf cfg.format.enable {
       vim.lsp.null-ls.enable = true;
       vim.lsp.null-ls.sources.ocamlformat = formats.${cfg.format.type}.nullConfig;
+      vim.extraPackages = [ formats.${cfg.format.type}.package ];
     })
   ]);
 }


### PR DESCRIPTION
this adds support for the ocaml lsp and formatter

everything seems to be working, the only issue is the lsp gives me a warning about not being able to find the formatter on format:
![image](https://github.com/NotAShelf/nvf/assets/64381190/4a5b5a9d-b609-4c52-83e2-c48d21099e51)
but it still formats so ¯\\\_(ツ)\_/¯

I think it could be fixed by adding `ocamlformat` to nvf's environment but I don't know how to do that sowwy uwu