### PR TITLE
which-key: allow null in registers

### DIFF
--- a/modules/plugins/utility/binds/which-key/which-key.nix
+++ b/modules/plugins/utility/binds/which-key/which-key.nix
@@ -4,14 +4,14 @@
   ...
 }: let
   inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) attrsOf str;
+  inherit (lib.types) attrsOf nullOr str;
 in {
   options.vim.binds.whichKey = {
     enable = mkEnableOption "which-key keybind helper menu";
 
     register = mkOption {
       description = "Register label for which-key keybind helper menu";
-      type = attrsOf str;
+      type = attrsOf (nullOr str);
       default = {};
     };
   };


### PR DESCRIPTION
Useful for disabling registers defined by nvf. Although that shouldn't be needed in the first place, since defining static registers doesn't account for the user changing the keymaps. For example, if I change all my telescope binds to start with `<leader>s` instead of `<leader>f, then I'll have both prefixes appear in which-key.

See https://github.com/diniamo/niqs/blob/72039800e859e4f790c3a0d8a7759c06d9c222b9/home/nvf/plugins/telescope.nix