### PR TITLE
plugins/orgmode: remove deprecated ts setup call

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718983919,
-        "narHash": "sha256-+1xgeIow4gJeiwo4ETvMRvWoircnvb0JOt7NS9kUhoM=",
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "90338afd6177fc683a04d934199d693708c85a3b",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
         "type": "github"
       },
       "original": {

--- a/modules/plugins/notes/orgmode/config.nix
+++ b/modules/plugins/notes/orgmode/config.nix
@@ -22,9 +22,6 @@ in {
         };
 
         luaConfigRC.orgmode = entryAnywhere ''
-          -- Load custom treesitter grammar for org filetype
-          require('orgmode').setup_ts_grammar()
-
           -- Treesitter configuration
           require('nvim-treesitter.configs').setup {
 


### PR DESCRIPTION
removes the deprecation warning and shit, treesitter for org files still works