### PR TITLE
ui/smartcolumn: change `custom_colorcolumn` type to expected type string

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -222,10 +222,10 @@ inputs: let
           enable = true;
           setupOpts.custom_colorcolumn = {
             # this is a freeform module, it's `buftype = int;` for configuring column position
-            nix = 110;
-            ruby = 120;
-            java = 130;
-            go = [90 130];
+            nix = "110";
+            ruby = "120";
+            java = "130";
+            go = ["90" "130"];
           };
         };
       };

--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -12,12 +12,17 @@ Release notes for release 0.7
 [frothymarrow](https://github.com/frothymarrow):
 
 - Modified type for
-  [](#opt-vim.visuals.fidget-nvim.setupOpts.progress.display.overrides) from
-  `anything` to a `submodule` for better type checking.
+  [vim.visuals.fidget-nvim.setupOpts.progress.display.overrides](#opt-vim.visuals.fidget-nvim.setupOpts.progress.display.overrides)
+  from `anything` to a `submodule` for better type checking.
+
 - Fix null `vim.lsp.mappings` generating an error and not being filtered out.
+
 - Add basic transparency support for `oxocarbon` theme by setting the highlight
   group for `Normal`, `NormalFloat`, `LineNr`, `SignColumn` and optionally
   `NvimTreeNormal` to `none`.
+
+- Fix [vim.ui.smartcolumn.setupOpts.custom_colorcolumn](#opt-vim.ui.smartcolumn.setupOpts.custom_colorcolumn)
+  using the wrong type `int` instead of the expected type `string`.
 
 [horriblename](https://github.com/horriblename):
 
@@ -37,7 +42,7 @@ Release notes for release 0.7
 
 - Add rustfmt as the default formatter for Rust
 
-[NotAShelf](https://github.com/notashelf)
+[NotAShelf](https://github.com/notashelf):
 
 - Add `deno fmt` as the default Markdown formatter. This will be enabled
   automatically if you have autoformatting enabled, but can be disabled manually

--- a/modules/plugins/ui/smartcolumn/smartcolumn.nix
+++ b/modules/plugins/ui/smartcolumn/smartcolumn.nix
@@ -31,15 +31,15 @@ in {
 
       custom_colorcolumn = mkOption {
         description = "The position at which smart column should be displayed for each individual buffer type";
-        type = attrsOf (either int (listOf int));
+        type = attrsOf (either str (listOf str));
         default = {};
 
         example = literalExpression ''
           vim.ui.smartcolumn.setupOpts.custom_colorcolumn = {
-            nix = 110;
-            ruby = 120;
-            java = 130;
-            go = [90 130];
+            nix = "110";
+            ruby = "120";
+            java = "130";
+            go = ["90" "130"];
           };
         '';
       };


### PR DESCRIPTION
Fixes #312 