### PR TITLE
modules/autopairs: use boolToString instead of toLuaObject

### DIFF
--- a/modules/plugins/autopairs/nvim-autopairs/config.nix
+++ b/modules/plugins/autopairs/nvim-autopairs/config.nix
@@ -4,8 +4,8 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
+  inherit (lib.trivial) boolToString;
   inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.autopairs;
 in {
@@ -13,7 +13,7 @@ in {
     vim.startPlugins = ["nvim-autopairs"];
 
     vim.luaConfigRC.autopairs = entryAnywhere ''
-      require("nvim-autopairs").setup({ map_cr = ${toLuaObject (!config.vim.autocomplete.enable)} })
+      require("nvim-autopairs").setup({ map_cr = ${boolToString (!config.vim.autocomplete.enable)} })
     '';
   };
 }


### PR DESCRIPTION
Not that important, but I didn't realize that function existed before