### PR TITLE
Use dap-go for dap configurations

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -29,6 +29,7 @@ Release notes for release 0.7
 - Fix broken treesitter-context keybinds in visual mode
 - Deprecate use of `__empty` to define empty tables in lua. Empty attrset are no
   longer filtered and thus should be used instead.
+- Add dap-go for better dap configurations
 
 [jacekpoz](https://github.com/jacekpoz):
 

--- a/flake.lock
+++ b/flake.lock
@@ -1069,6 +1069,22 @@
         "type": "github"
       }
     },
+    "plugin-nvim-dap-go": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716775637,
+        "narHash": "sha256-B8A+ven18YgePLxAN3Q/j5NFb0FeTHCQak1uzaNDX9c=",
+        "owner": "leoluz",
+        "repo": "nvim-dap-go",
+        "rev": "a0c5a2b991d7e9304a9a032cf177e22a4b0acda1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "leoluz",
+        "repo": "nvim-dap-go",
+        "type": "github"
+      }
+    },
     "plugin-nvim-dap-ui": {
       "flake": false,
       "locked": {
@@ -1823,6 +1839,7 @@
         "plugin-nvim-colorizer-lua": "plugin-nvim-colorizer-lua",
         "plugin-nvim-cursorline": "plugin-nvim-cursorline",
         "plugin-nvim-dap": "plugin-nvim-dap",
+        "plugin-nvim-dap-go": "plugin-nvim-dap-go",
         "plugin-nvim-dap-ui": "plugin-nvim-dap-ui",
         "plugin-nvim-docs-view": "plugin-nvim-docs-view",
         "plugin-nvim-lightbulb": "plugin-nvim-lightbulb",

--- a/flake.nix
+++ b/flake.nix
@@ -216,6 +216,11 @@
       flake = false;
     };
 
+    plugin-nvim-dap-go = {
+      url = "github:leoluz/nvim-dap-go";
+      flake = false;
+    };
+
     # Filetrees
     plugin-nvim-tree-lua = {
       url = "github:nvim-tree/nvim-tree.lua";


### PR DESCRIPTION
The previous configuration is pretty much useless, relying on dap-go gives us a better out-of-the-box experience