### PR TITLE
modules: fix unused src and version attrs in buildPlug

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -25,6 +25,8 @@ Release notes for release 0.7
   [vim.ui.smartcolumn.setupOpts.custom_colorcolumn](#opt-vim.ui.smartcolumn.setupOpts.custom_colorcolumn)
   using the wrong type `int` instead of the expected type `string`.
 
+- Fix unused src and version attributes in `buildPlug`.
+
 [horriblename](https://github.com/horriblename):
 
 - Fix broken treesitter-context keybinds in visual mode

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -36,14 +36,10 @@ inputs: {
   buildPlug = {pname, ...} @ attrs: let
     src = getAttr ("plugin-" + pname) inputs;
   in
-    pkgs.runCommand pname ({
-        inherit src;
-        version = src.shortRev or src.shortDirtyRev or "dirty";
-      }
-      // attrs)
+    pkgs.runCommand "${pname}-${src.shortRev or src.shortDirtyRev or "dirty"}" attrs
     ''
       mkdir -p $out
-      cp -r . $out
+      cp -r ${src}/. $out
     '';
 
   noBuildPlug = {pname, ...} @ attrs: let


### PR DESCRIPTION
The `runCommand` doesn't pass src and version attributes to its underlying `mkDerivation`. This causes the `flutter-tools` source to be empty, and thus Neovim fails to load the module at runtime.

Here is the error and directory contents for reference:
```
Error detected while processing pre-vimrc command line:
E5113: Error while calling lua chunk: vim/_editor.lua:0: pre-vimrc command line..script nvim_exec2() called at pre-vimrc command line:0../nix/store/n3cwd61i9mg0yc5f8303yg1hrfqnhpyh-init.vim, line
 1507: Vim(lua):E5108: Error executing lua [string ":lua"]:580: module 'flutter-tools' not found:
        no field package.preload['flutter-tools']
        no file '/nix/store/dd95xbhig1gplwzhr1vi98cgjfwfm41v-luajit-2.1.1713773202-env/share/lua/5.1/flutter-tools.lua'
        no file '/nix/store/dd95xbhig1gplwzhr1vi98cgjfwfm41v-luajit-2.1.1713773202-env/share/lua/5.1/flutter-tools/init.lua'
        no file '/nix/store/dd95xbhig1gplwzhr1vi98cgjfwfm41v-luajit-2.1.1713773202-env/lib/lua/5.1/flutter-tools.so'
stack traceback:
        [C]: in function 'require'
        [string ":lua"]:580: in main chunk
        [C]: in function 'nvim_exec2'
        vim/_editor.lua: in function 'cmd'
        .../3gg19ippn0zcbksianqa17c09j6907s4-neovim-0.10.0/init.lua:16: in main chunk
stack traceback:
        [C]: in function 'nvim_exec2'
        vim/_editor.lua: in function 'cmd'
        .../3gg19ippn0zcbksianqa17c09j6907s4-neovim-0.10.0/init.lua:16: in main chunk
```
```
$ ls -la /nix/store/jqf9fql3ad3l8aiw2jik0019gqniwmpm-flutter-tools
total 32
dr-xr-xr-x      5 root  wheel       160 31 Dec  1969 .
drwxrwxr-t  32517 root  nixbld  1040544 15 Jul 12:23 ..
-r--r--r--      1 root  wheel        27 31 Dec  1969 .attr-0l2nkwhif96f51f4amnlf414lhl4rv9vh8iffyp431v6s28gsr90
-r--r--r--      1 root  wheel       158 31 Dec  1969 .sandbox.sb
-r--r--r--      1 root  wheel      4993 31 Dec  1969 env-vars
```