### PR TITLE
wrapper: fix additionalRuntimePaths lua script

### DIFF
--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -155,11 +155,7 @@ in {
           -- The following list is generated from `vim.additionalRuntimePaths`
           -- and is used to append additional runtime paths to the
           -- `runtimepath` option.
-          local additionalRuntimePaths = ${listToLuaTable cfg.additionalRuntimePaths};
-
-          for _, path in ipairs(additionalRuntimePaths) do
-            vim.opt.runtimepath:append(path)
-          end
+          vim.opt.runtimepath:append(${listToLuaTable cfg.additionalRuntimePaths})
         ''}
 
         ${optionalString cfg.disableDefaultRuntimePaths ''


### PR DESCRIPTION
while the previous solution did add the additional paths to runtimepath, their `plugin/` dir was not sourced for whatever reason. This is the intended usage according to the help file anyway so I'm following it