### PR TITLE
treewide: remove the theme section from the DAG order dependance

### DIFF
--- a/docs/manual/configuring/dag-entries.md
+++ b/docs/manual/configuring/dag-entries.md
@@ -11,7 +11,7 @@ entries in nvf:
    inserted before the rest of the DAG
 2. `globalsScript` - used to set globals defined in `vim.globals`
 3. `basic` - used to set basic configuration options
-4. `theme` (this is simply placed between `basic` and `pluginConfigs`, so surrounding entries don't depend on it) - used to set up the theme, which has to be done before other plugins
+4. `theme` (this is simply placed before `pluginConfigs`, meaning that surrounding entries don't depend on it) - used to set up the theme, which has to be done before other plugins
 5. `pluginConfigs` - the result of the nested `vim.pluginRC` (internal option,
    see the [Custom Plugins](/index.xhtml#ch-custom-plugins) page for adding your own
    plugins) DAG, used to set up internal plugins

--- a/docs/manual/configuring/dag-entries.md
+++ b/docs/manual/configuring/dag-entries.md
@@ -11,7 +11,7 @@ entries in nvf:
    inserted before the rest of the DAG
 2. `globalsScript` - used to set globals defined in `vim.globals`
 3. `basic` - used to set basic configuration options
-4. `theme` - used to set up the theme, which has to be done before other plugins
+4. `theme` (this is simply placed between `basic` and `pluginConfigs`, so surrounding entries don't depend on it) - used to set up the theme, which has to be done before other plugins
 5. `pluginConfigs` - the result of the nested `vim.pluginRC` (internal option,
    see the [Custom Plugins](/index.xhtml#ch-custom-plugins) page for adding your own
    plugins) DAG, used to set up internal plugins

--- a/modules/plugins/theme/theme.nix
+++ b/modules/plugins/theme/theme.nix
@@ -7,7 +7,7 @@
   inherit (lib.attrsets) attrNames;
   inherit (lib.types) bool lines enum;
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.dag) entryAfter;
+  inherit (lib.nvim.dag) entryBefore;
 
   cfg = config.vim.theme;
   supportedThemes = import ./supported-themes.nix {
@@ -45,7 +45,7 @@ in {
   config = mkIf cfg.enable {
     vim = {
       startPlugins = [cfg.name];
-      luaConfigRC.theme = entryAfter ["basic"] ''
+      luaConfigRC.theme = entryBefore ["pluginConfigs"] ''
         ${cfg.extraConfig}
         ${supportedThemes.${cfg.name}.setup {inherit (cfg) style transparent;}}
       '';

--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -133,8 +133,8 @@ in {
     vim = {
       luaConfigRC = {
         globalsScript = entryAnywhere (concatLines globalsScript);
-        # basic, theme
-        pluginConfigs = entryAfter ["theme"] pluginConfigs;
+        # basic
+        pluginConfigs = entryAfter ["basic"] pluginConfigs;
         extraPluginConfigs = entryAfter ["pluginConfigs"] extraPluginConfigs;
         mappings = entryAfter ["extraPluginConfigs"] mappings;
       };


### PR DESCRIPTION
This is needed, since the DAG order breaks for users who don't use the builtin theming options.