### PR TITLE
Telescope: fix projects binding, add Telescope resume in default

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -150,3 +150,9 @@ configuration formats.
   - `nvf-print-config-path` will display the path to _a clone_ of your
     `init.lua`. This is not the path used by the Neovim wrapper, but an
     identical clone.
+
+[ppenguin](https://github.com/ppenguin):
+
+- Telescope:
+  - Fixed `project-nvim` command and keybinding
+  - Added default ikeybind/command for `Telescope resume` (`<leader>fr`)

--- a/modules/plugins/utility/telescope/config.nix
+++ b/modules/plugins/utility/telescope/config.nix
@@ -17,75 +17,78 @@
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
 in {
   config = mkIf cfg.enable {
-    vim.startPlugins = [
-      "telescope"
-      "plenary-nvim"
-    ];
+    vim = {
+      startPlugins = [
+        "telescope"
+        "plenary-nvim"
+      ];
 
-    vim.maps.normal = mkMerge [
-      (mkSetBinding mappings.findFiles "<cmd> Telescope find_files<CR>")
-      (mkSetBinding mappings.liveGrep "<cmd> Telescope live_grep<CR>")
-      (mkSetBinding mappings.buffers "<cmd> Telescope buffers<CR>")
-      (mkSetBinding mappings.helpTags "<cmd> Telescope help_tags<CR>")
-      (mkSetBinding mappings.open "<cmd> Telescope<CR>")
+      maps.normal = mkMerge [
+        (mkSetBinding mappings.findFiles "<cmd> Telescope find_files<CR>")
+        (mkSetBinding mappings.liveGrep "<cmd> Telescope live_grep<CR>")
+        (mkSetBinding mappings.buffers "<cmd> Telescope buffers<CR>")
+        (mkSetBinding mappings.helpTags "<cmd> Telescope help_tags<CR>")
+        (mkSetBinding mappings.open "<cmd> Telescope<CR>")
+        (mkSetBinding mappings.resume "<cmd> Telescope resume<CR>")
 
-      (mkSetBinding mappings.gitCommits "<cmd> Telescope git_commits<CR>")
-      (mkSetBinding mappings.gitBufferCommits "<cmd> Telescope git_bcommits<CR>")
-      (mkSetBinding mappings.gitBranches "<cmd> Telescope git_branches<CR>")
-      (mkSetBinding mappings.gitStatus "<cmd> Telescope git_status<CR>")
-      (mkSetBinding mappings.gitStash "<cmd> Telescope git_stash<CR>")
+        (mkSetBinding mappings.gitCommits "<cmd> Telescope git_commits<CR>")
+        (mkSetBinding mappings.gitBufferCommits "<cmd> Telescope git_bcommits<CR>")
+        (mkSetBinding mappings.gitBranches "<cmd> Telescope git_branches<CR>")
+        (mkSetBinding mappings.gitStatus "<cmd> Telescope git_status<CR>")
+        (mkSetBinding mappings.gitStash "<cmd> Telescope git_stash<CR>")
 
-      (mkIf config.vim.lsp.enable (mkMerge [
-        (mkSetBinding mappings.lspDocumentSymbols "<cmd> Telescope lsp_document_symbols<CR>")
-        (mkSetBinding mappings.lspWorkspaceSymbols "<cmd> Telescope lsp_workspace_symbols<CR>")
+        (mkIf config.vim.lsp.enable (mkMerge [
+          (mkSetBinding mappings.lspDocumentSymbols "<cmd> Telescope lsp_document_symbols<CR>")
+          (mkSetBinding mappings.lspWorkspaceSymbols "<cmd> Telescope lsp_workspace_symbols<CR>")
 
-        (mkSetBinding mappings.lspReferences "<cmd> Telescope lsp_references<CR>")
-        (mkSetBinding mappings.lspImplementations "<cmd> Telescope lsp_implementations<CR>")
-        (mkSetBinding mappings.lspDefinitions "<cmd> Telescope lsp_definitions<CR>")
-        (mkSetBinding mappings.lspTypeDefinitions "<cmd> Telescope lsp_type_definitions<CR>")
-        (mkSetBinding mappings.diagnostics "<cmd> Telescope diagnostics<CR>")
-      ]))
+          (mkSetBinding mappings.lspReferences "<cmd> Telescope lsp_references<CR>")
+          (mkSetBinding mappings.lspImplementations "<cmd> Telescope lsp_implementations<CR>")
+          (mkSetBinding mappings.lspDefinitions "<cmd> Telescope lsp_definitions<CR>")
+          (mkSetBinding mappings.lspTypeDefinitions "<cmd> Telescope lsp_type_definitions<CR>")
+          (mkSetBinding mappings.diagnostics "<cmd> Telescope diagnostics<CR>")
+        ]))
 
-      (
-        mkIf config.vim.treesitter.enable
-        (mkSetBinding mappings.treesitter "<cmd> Telescope treesitter<CR>")
-      )
+        (
+          mkIf config.vim.treesitter.enable
+          (mkSetBinding mappings.treesitter "<cmd> Telescope treesitter<CR>")
+        )
 
-      (
-        mkIf config.vim.projects.project-nvim.enable
-        (mkSetBinding mappings.findProjects "<cmd Telescope projects<CR>")
-      )
-    ];
+        (
+          mkIf config.vim.projects.project-nvim.enable
+          (mkSetBinding mappings.findProjects "<cmd> Telescope projects<CR>")
+        )
+      ];
 
-    vim.binds.whichKey.register = pushDownDefault {
-      "<leader>f" = "+Telescope";
-      "<leader>fl" = "Telescope LSP";
-      "<leader>fm" = "Cellular Automaton";
-      "<leader>fv" = "Telescope Git";
-      "<leader>fvc" = "Commits";
+      binds.whichKey.register = pushDownDefault {
+        "<leader>f" = "+Telescope";
+        "<leader>fl" = "Telescope LSP";
+        "<leader>fm" = "Cellular Automaton";
+        "<leader>fv" = "Telescope Git";
+        "<leader>fvc" = "Commits";
+      };
+
+      pluginRC.telescope = entryAnywhere ''
+        local telescope = require('telescope')
+        telescope.setup(${toLuaObject cfg.setupOpts})
+
+        ${
+          if config.vim.ui.noice.enable
+          then "telescope.load_extension('noice')"
+          else ""
+        }
+
+        ${
+          if config.vim.notify.nvim-notify.enable
+          then "telescope.load_extension('notify')"
+          else ""
+        }
+
+        ${
+          if config.vim.projects.project-nvim.enable
+          then "telescope.load_extension('projects')"
+          else ""
+        }
+      '';
     };
-
-    vim.pluginRC.telescope = entryAnywhere ''
-      local telescope = require('telescope')
-      telescope.setup(${toLuaObject cfg.setupOpts})
-
-      ${
-        if config.vim.ui.noice.enable
-        then "telescope.load_extension('noice')"
-        else ""
-      }
-
-      ${
-        if config.vim.notify.nvim-notify.enable
-        then "telescope.load_extension('notify')"
-        else ""
-      }
-
-      ${
-        if config.vim.projects.project-nvim.enable
-        then "telescope.load_extension('projects')"
-        else ""
-      }
-    '';
   };
 }

--- a/modules/plugins/utility/telescope/telescope.nix
+++ b/modules/plugins/utility/telescope/telescope.nix
@@ -150,13 +150,13 @@
 in {
   options.vim.telescope = {
     mappings = {
-      findProjects = mkMappingOption "Find files [Telescope]" "<leader>fp";
-
+      findProjects = mkMappingOption "Find projects [Telescope]" "<leader>fp";
       findFiles = mkMappingOption "Find files [Telescope]" "<leader>ff";
       liveGrep = mkMappingOption "Live grep [Telescope]" "<leader>fg";
       buffers = mkMappingOption "Buffers [Telescope]" "<leader>fb";
       helpTags = mkMappingOption "Help tags [Telescope]" "<leader>fh";
       open = mkMappingOption "Open [Telescope]" "<leader>ft";
+      resume = mkMappingOption "Resume (previous search) [Telescope]" "<leader>fr";
 
       gitCommits = mkMappingOption "Git commits [Telescope]" "<leader>fvcw";
       gitBufferCommits = mkMappingOption "Git buffer commits [Telescope]" "<leader>fvcb";


### PR DESCRIPTION
The projects command had a typo preventing it from working; the keybinding description was the same as for Telescope files. 

Added `<leader>fr` for Telescope resume per default.

Oh, and refactored duplicate top level `vim.` attributes, which is a "style" error flagged by `statix` and didn't seem to have a reason in this case.