### PR TITLE
ui/breadcrumbs: allow lualine winbar component to be disabled

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -71,7 +71,8 @@ configuration formats.
 
 - Fix "Emac" typo
 
-- Add [new-file-template.nvim] to automatically fill new file contents using templates.
+- Add [new-file-template.nvim] to automatically fill new file contents using
+  templates.
 
 [diniamo](https://github.com/diniamo):
 
@@ -146,10 +147,21 @@ configuration formats.
 - Add `nvf-print-config` & `nvf-print-config-path` helper scripts to Neovim
   closure. Both of those scripts have been automatically added to your PATH upon
   using neovimConfig or `programs.nvf.enable`.
+
   - `nvf-print-config` will display your `init.lua`, in full.
   - `nvf-print-config-path` will display the path to _a clone_ of your
     `init.lua`. This is not the path used by the Neovim wrapper, but an
     identical clone.
+
+- Add `vim.ui.breadcrumbs.lualine` to allow fine-tuning breadcrumbs behaviour on
+  Lualine. Only `vim.ui.breadcrumbs.lualine.winbar` is supported for the time
+  being.
+  - [](#opt-vim.ui.breadcrumbs.lualine.winbar.enable) has been added to allow
+    controlling the default behaviour of the `nvim-navic` component on Lualine,
+    which used to occupy `winbar.lualine_c` as long as breadcrumbs are enabled.
+  - `vim.ui.breadcrumbs.alwaysRender` has been renamed to
+    [](#opt-vim.ui.breadcrumbs.lualine.winbar.alwaysRender) to be conform to the
+    new format.
 
 [ppenguin](https://github.com/ppenguin):
 

--- a/modules/plugins/statusline/lualine/config.nix
+++ b/modules/plugins/statusline/lualine/config.nix
@@ -11,7 +11,7 @@
   inherit (lib.generators) mkLuaInline;
 
   cfg = config.vim.statusline.lualine;
-  breadcrumbsCfg = config.vim.ui.breadcrumbs;
+  bCfg = config.vim.ui.breadcrumbs;
 in {
   config = mkMerge [
     # TODO: move into nvim-tree file
@@ -20,13 +20,14 @@ in {
         extensions = ["nvim-tree"];
       };
     })
-    (mkIf (breadcrumbsCfg.enable && breadcrumbsCfg.source == "nvim-navic") {
+
+    (mkIf (bCfg.enable && bCfg.lualine.winbar.enable && bCfg.source == "nvim-navic") {
       vim.statusline.lualine.setupOpts = {
         # TODO: rewrite in new syntax
         winbar.lualine_c = mkDefault [
           [
             "navic"
-            (mkLuaInline "draw_empty = ${boolToString config.vim.ui.breadcrumbs.alwaysRender}")
+            (mkLuaInline "draw_empty = ${boolToString bCfg.lualine.winbar.alwaysRender}")
           ]
         ];
       };
@@ -34,7 +35,6 @@ in {
     (mkIf cfg.enable {
       vim = {
         startPlugins = ["lualine"];
-
         pluginRC.lualine = entryAnywhere ''
           local lualine = require('lualine')
           lualine.setup ${toLuaObject cfg.setupOpts}

--- a/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
+++ b/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
@@ -31,6 +31,8 @@ in {
     (renameSetupOpt ["sourceBuffer" "scrolloff"] ["source_buffer" "scrolloff"])
     # TODO: every option under icon is renamed to first letter capitalized
     (renameSetupOpt ["icon"] ["icon"])
+
+    (mkRenamedOptionModule ["vim" "ui" "breadcrumbs" "alwaysRender"] ["vim" "ui" "breadcrumbs" "lualine" "winbar" "alwaysRender"])
   ];
 
   options.vim.ui.breadcrumbs = {
@@ -43,17 +45,43 @@ in {
       '';
     };
 
-    # maybe this should be an option to *disable* alwaysRender optionally but oh well
-    # too late
-    alwaysRender = mkOption {
-      type = bool;
-      default = true;
-      description = "Whether to always display the breadcrumbs component on winbar (always renders winbar)";
+    # Options for configuring Lualine integration of nvim-navic
+    lualine.winbar = {
+      enable = mkOption {
+        type = bool;
+        default = true; # for retaining previous behaviour
+        example = false;
+        description = ''
+          Whether to automatically configure a winbar component for
+          Lualine on the Winbar section.
+
+          ::: {.note}
+          This is **set to `true` by default**, which means nvim-navic
+          will occupy `winbar.lualine_c` for the breadcrumbs feature
+          unless this option is set to `false`.
+          :::
+        '';
+      };
+
+      alwaysRender = mkOption {
+        type = bool;
+        default = true;
+        example = false;
+        description = ''
+          Whether to always display the breadcrumbs component
+          on winbar.
+
+          ::: {.note}
+          This will pass `draw_empty` to the `nvim_navic` winbar
+          component, which causes the component to be drawn even
+          if it's empty
+          :::
+        '';
+      };
     };
 
     navbuddy = {
       enable = mkEnableOption "navbuddy LSP helper UI. Enabling this option automatically loads and enables nvim-navic";
-
       mappings = {
         close = mkOption {
           type = str;


### PR DESCRIPTION
Adds `vim.ui.breadcrumbs.lualine.winbar.enable` to control winbar component behaviour, and moves `vim.ui.breadcrumbs.alwaysRender` (whether to always render the winbar compontent) to `vim.ui.breadcrumbs.lualine.winbar.alwaysRender`