### PR TITLE
modules/wrapper: add `vim.options`

### DIFF
--- a/docs/manual/configuring/dag-entries.md
+++ b/docs/manual/configuring/dag-entries.md
@@ -5,16 +5,19 @@ can add code that relies on other code. However, if you don't know what the
 entries are called, it's hard to do that, so here is a list of the internal
 entries in nvf:
 
-`vim.luaConfigRC` (top-level DAG):
+## `vim.luaConfigRC` (top-level DAG) {#ch-vim-luaconfigrc}
 
 1. (`luaConfigPre`) - not a part of the actual DAG, instead, it's simply
    inserted before the rest of the DAG
 2. `globalsScript` - used to set globals defined in `vim.globals`
 3. `basic` - used to set basic configuration options
-4. `theme` (this is simply placed before `pluginConfigs`, meaning that surrounding entries don't depend on it) - used to set up the theme, which has to be done before other plugins
-5. `pluginConfigs` - the result of the nested `vim.pluginRC` (internal option,
-   see the [Custom Plugins](/index.xhtml#ch-custom-plugins) page for adding your own
-   plugins) DAG, used to set up internal plugins
-6. `extraPluginConfigs` - the result of `vim.extraPlugins`, which is not a
+4. `optionsScript` - used to set options defined in `vim.o`
+5. `theme` (this is simply placed before `pluginConfigs`, meaning that
+   surrounding entries don't depend on it) - used to set up the theme, which has
+   to be done before other plugins
+6. `pluginConfigs` - the result of the nested `vim.pluginRC` (internal option,
+   see the [Custom Plugins](/index.xhtml#ch-custom-plugins) page for adding your
+   own plugins) DAG, used to set up internal plugins
+7. `extraPluginConfigs` - the result of `vim.extraPlugins`, which is not a
    direct DAG, but is converted to, and resolved as one internally
-7. `mappings` - the result of `vim.maps`
+8. `mappings` - the result of `vim.maps`

--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -85,6 +85,10 @@ in {
       mapAttrsToList (name: value: "vim.g.${name} = ${toLuaObject value}")
       (filterNonNull cfg.globals);
 
+    optionsScript =
+      mapAttrsToList (name: value: "vim.o.${name} = ${toLuaObject value}")
+      (filterNonNull cfg.options);
+
     extraPluginConfigs = resolveDag {
       name = "extra plugin configs";
       dag = mapAttrs (_: value: entryAfter value.after value.setup) cfg.extraPlugins;
@@ -132,9 +136,12 @@ in {
   in {
     vim = {
       luaConfigRC = {
+        # `vim.g` and `vim.o`
         globalsScript = entryAnywhere (concatLines globalsScript);
-        # basic
-        pluginConfigs = entryAfter ["basic"] pluginConfigs;
+        optionsScript = entryAfter ["basic"] (concatLines optionsScript);
+
+        # Basic
+        pluginConfigs = entryAfter ["optionsScript"] pluginConfigs;
         extraPluginConfigs = entryAfter ["pluginConfigs"] extraPluginConfigs;
         mappings = entryAfter ["extraPluginConfigs"] mappings;
       };

--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -80,14 +80,11 @@
       maps);
 in {
   config = let
-    filterNonNull = attrs: filterAttrs (_: value: value != null) attrs;
     globalsScript =
-      mapAttrsToList (name: value: "vim.g.${name} = ${toLuaObject value}")
-      (filterNonNull cfg.globals);
+      mapAttrsToList (name: value: "vim.g.${name} = ${toLuaObject value}") cfg.globals;
 
     optionsScript =
-      mapAttrsToList (name: value: "vim.o.${name} = ${toLuaObject value}")
-      (filterNonNull cfg.options);
+      mapAttrsToList (name: value: "vim.o.${name} = ${toLuaObject value}") cfg.options;
 
     extraPluginConfigs = resolveDag {
       name = "extra plugin configs";

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -129,6 +129,7 @@ in {
     globals = mkOption {
       type = attrs;
       default = {};
+      example = {"some_variable" = 42;};
       description = ''
         An attribute set containing global variable values
         for storing vim variables as early as possible. If
@@ -136,10 +137,10 @@ in {
         built luaConfigRC as the first item.
 
         ::: {.note}
-        `{foo = "bar";}` will set `vim.g.foo` to "bar" where
+        `{foo = "bar";}` will set `vim.g.foo` to "bar", where
         the type of `bar` in the resulting Lua value will be
-        infered from the type of the value in the `{name = value;}`
-        pair.
+        inferred from the type of the value in the `{name = value;}`
+        pair passed to the option.
         :::
       '';
     };
@@ -147,6 +148,7 @@ in {
     options = mkOption {
       type = attrs;
       default = {};
+      example = {visualbell = true;};
       description = ''
         An attribute set containing vim options to be set
         as early as possible. If populated, this option will
@@ -154,10 +156,10 @@ in {
         and before `pluginConfigs` DAG entries.
 
         ::: {.note}
-        `{foo = "bar"}` will set `vim.o.foo` to "bar" where
+        `{foo = "bar";}` will set `vim.o.foo` to "bar", where
         the type of `bar` in the resulting Lua value will be
-        infered from the type of the value in the `{name = value}`
-        pair.
+        inferred from the type of the value in the`{name = value;}`
+        pair passed to the option.
         :::
       '';
     };

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -135,10 +135,30 @@ in {
         populated, this option will set vim variables in the
         built luaConfigRC as the first item.
 
-        E.g. {foo = "bar"} will set `vim.g.foo` to "bar" where
-        the type of `bar` in the resulting vimscript will be
+        ::: {.note}
+        `{foo = "bar";}` will set `vim.g.foo` to "bar" where
+        the type of `bar` in the resulting Lua value will be
+        infered from the type of the value in the `{name = value;}`
+        pair.
+        :::
+      '';
+    };
+
+    options = mkOption {
+      type = attrs;
+      default = {};
+      description = ''
+        An attribute set containing vim options to be set
+        as early as possible. If populated, this option will
+        set vim options in the built luaConfigRC after `basic`
+        and before `pluginConfigs` DAG entries.
+
+        ::: {.note}
+        `{foo = "bar"}` will set `vim.o.foo` to "bar" where
+        the type of `bar` in the resulting Lua value will be
         infered from the type of the value in the `{name = value}`
         pair.
+        :::
       '';
     };
 


### PR DESCRIPTION
- **wrapper/rc: add `vim.options`**
- **docs: document addition of optionsScript**

Adds `vim.options` to easily configure `vim.o` values.
