### PR TITLE
Surround setupopts

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -150,6 +150,8 @@ everyone.
 - Replace `vim.lsp.nvimCodeActionMenu` with `vim.ui.fastaction`, see the
   breaking changes section above for more details
 
+- Add a `setupOpts` option to nvim-surround, which allows modifying options that aren't defined in nvf. Move the alternate nvim-surround keybinds to use `setupOpts`.
+
 [Neovim documentation on `vim.cmd`]: https://neovim.io/doc/user/lua.html#vim.cmd()
 
 - Make Neovim's configuration file entirely Lua based. This comes with a few

--- a/modules/plugins/utility/surround/surround.nix
+++ b/modules/plugins/utility/surround/surround.nix
@@ -1,11 +1,7 @@
-{
-  lib,
-  config,
-  ...
-}: let
-  inherit (lib.modules) mkIf mkDefault;
+{lib, ...}: let
   inherit (lib.options) mkOption;
-  inherit (lib.types) bool nullOr str;
+  inherit (lib.types) bool;
+  inherit (lib.nvim.types) mkPluginSetupOption;
 in {
   options.vim.utility.surround = {
     enable = mkOption {
@@ -13,78 +9,12 @@ in {
       default = false;
       description = "nvim-surround: add/change/delete surrounding delimiter pairs with ease. Note that the default mappings deviate from upstreeam to avoid conflicts with nvim-leap.";
     };
+    setupOpts = mkPluginSetupOption "nvim-surround" {};
+
     useVendoredKeybindings = mkOption {
       type = bool;
       default = true;
       description = "Use alternative set of keybindings that avoids conflicts with other popular plugins, e.g. nvim-leap";
     };
-    mappings = {
-      insert = mkOption {
-        type = nullOr str;
-        default = "<C-g>z";
-        description = "Add surround character around the cursor";
-      };
-      insertLine = mkOption {
-        type = nullOr str;
-        default = "<C-g>Z";
-        description = "Add surround character around the cursor on new lines";
-      };
-      normal = mkOption {
-        type = nullOr str;
-        default = "gz";
-        description = "Surround motion with character";
-      };
-      normalCur = mkOption {
-        type = nullOr str;
-        default = "gZ";
-        description = "Surround motion with character on new lines";
-      };
-      normalLine = mkOption {
-        type = nullOr str;
-        default = "gzz";
-        description = "Surround line with character";
-      };
-      normalCurLine = mkOption {
-        type = nullOr str;
-        default = "gZZ";
-        description = "Surround line with character on new lines";
-      };
-      visual = mkOption {
-        type = nullOr str;
-        default = "gz";
-        description = "Surround selection with character";
-      };
-      visualLine = mkOption {
-        type = nullOr str;
-        default = "gZ";
-        description = "Surround selection with character on new lines";
-      };
-      delete = mkOption {
-        type = nullOr str;
-        default = "gzd";
-        description = "Delete surrounding character";
-      };
-      change = mkOption {
-        type = nullOr str;
-        default = "gzr";
-        description = "Change surrounding character";
-      };
-    };
-  };
-  config.vim.utility.surround = let
-    cfg = config.vim.utility.surround;
-  in {
-    mappings = mkIf (! cfg.useVendoredKeybindings) (mkDefault {
-      insert = null;
-      insertLine = null;
-      normal = null;
-      normalCur = null;
-      normalLine = null;
-      normalCurLine = null;
-      visual = null;
-      visualLine = null;
-      delete = null;
-      change = null;
-    });
   };
 }

--- a/modules/plugins/utility/surround/surround.nix
+++ b/modules/plugins/utility/surround/surround.nix
@@ -7,7 +7,11 @@ in {
     enable = mkOption {
       type = bool;
       default = false;
-      description = "nvim-surround: add/change/delete surrounding delimiter pairs with ease. Note that the default mappings deviate from upstreeam to avoid conflicts with nvim-leap.";
+      description = ''
+        nvim-surround: add/change/delete surrounding delimiter pairs with ease.
+        Note that the default mappings deviate from upstreeam to avoid conflicts
+        with nvim-leap.
+      '';
     };
     setupOpts = mkPluginSetupOption "nvim-surround" {};
 


### PR DESCRIPTION
Modifies the nvim-surround module to use setupOpts, and define the alternate binds in setupOpts as well.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [x] I have updated the [changelog] as per my changes.
- [x] I have tested, and self-reviewed my code.
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`).
  - [x] My code conforms to the [editorconfig] configuration of the project.
  - [x] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [ ] `.#nix` (default package)
  - [ ] `.#maximal`
  - [ ] `.#docs-html`
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
