### PR TITLE
lib: remove pointless type restriction

### DIFF
--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -97,7 +97,7 @@ in {
 
       default = {};
       type = submodule {
-        freeformType = attrsOf anything;
+        freeformType = anything;
         options = opts;
       };
     };


### PR DESCRIPTION
idk why I made setupOpts `attrsOf anything` instead of `anything`