### PR TITLE
Fix typo in otter setupOpts

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -262,6 +262,7 @@ everyone.
 - Add LSP and Treesitter support for R under `vim.languages.R`.
 - Add Otter support under `vim.lsp.otter` and an assert to prevent conflict with
   ccc
+- Fixed typo in Otter's setupOpts
 - Add Neorg support under `vim.notes.neorg`
 - Add LSP, diagnostics, formatter and Treesitter support for Kotlin under
   `vim.languages.kotlin`

--- a/modules/plugins/lsp/otter/config.nix
+++ b/modules/plugins/lsp/otter/config.nix
@@ -32,7 +32,7 @@ in {
 
       pluginRC.otter-nvim = entryAnywhere ''
         -- Enable otter diagnostics viewer
-        require("otter").setup({${toLuaObject cfg.otter-nvim.setupOpts}})
+        require("otter").setup(${toLuaObject cfg.otter-nvim.setupOpts})
       '';
     };
   };

--- a/modules/plugins/utility/motion/leap/leap.nix
+++ b/modules/plugins/utility/motion/leap/leap.nix
@@ -9,22 +9,22 @@ in {
       leapForwardTo = mkOption {
         type = nullOr str;
         description = "Leap forward to";
-        default = "s";
+        default = "<leader>ss";
       };
       leapBackwardTo = mkOption {
         type = nullOr str;
         description = "Leap backward to";
-        default = "S";
+        default = "<leader>sS";
       };
       leapForwardTill = mkOption {
         type = nullOr str;
         description = "Leap forward till";
-        default = "x";
+        default = "<leader>sx";
       };
       leapBackwardTill = mkOption {
         type = nullOr str;
         description = "Leap backward till";
-        default = "X";
+        default = "<leader>sX";
       };
       leapFromWindow = mkOption {
         type = nullOr str;

--- a/modules/plugins/utility/motion/leap/leap.nix
+++ b/modules/plugins/utility/motion/leap/leap.nix
@@ -9,22 +9,22 @@ in {
       leapForwardTo = mkOption {
         type = nullOr str;
         description = "Leap forward to";
-        default = "<leader>ss";
+        default = "s";
       };
       leapBackwardTo = mkOption {
         type = nullOr str;
         description = "Leap backward to";
-        default = "<leader>sS";
+        default = "S";
       };
       leapForwardTill = mkOption {
         type = nullOr str;
         description = "Leap forward till";
-        default = "<leader>sx";
+        default = "x";
       };
       leapBackwardTill = mkOption {
         type = nullOr str;
         description = "Leap backward till";
-        default = "<leader>sX";
+        default = "X";
       };
       leapFromWindow = mkOption {
         type = nullOr str;


### PR DESCRIPTION
Fixed typo in otter's setupOpts

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [X] I have updated the [changelog] as per my changes.
- [X] I have tested, and self-reviewed my code.
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`).
  - [X] My code conforms to the [editorconfig] configuration of the project.
  - [X] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [X] My code includes comments in particularly complex areas
  - [X] I have added a section in the manual.
  - [X] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [X] `.#nix` (default package)
  - [X] `.#maximal`
  - [X] `.#docs-html`
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
