### PR TITLE
fix markdown-preview config error

### DIFF
--- a/modules/plugins/utility/preview/markdown-preview/config.nix
+++ b/modules/plugins/utility/preview/markdown-preview/config.nix
@@ -4,9 +4,8 @@
   lib,
   ...
 }: let
-  inherit (lib.strings) stringLength concatMapStringsSep;
+  inherit (lib.strings) concatMapStringsSep;
   inherit (lib.modules) mkIf;
-
   cfg = config.vim.utility.preview.markdownPreview;
 in {
   config = mkIf cfg.enable {
@@ -19,8 +18,8 @@ in {
       mkdp_filetypes = [(concatMapStringsSep ", " (x: "'" + x + "'") cfg.filetypes)];
       mkdp_command_for_global = cfg.alwaysAllowPreview;
       mkdp_open_to_the_world = cfg.broadcastServer;
-      mkdp_open_ip = mkIf (stringLength cfg.customIP > 0) cfg.customIP;
-      mkdp_port = mkIf (stringLength cfg.customPort > 0) cfg.customPort;
+      mkdp_open_ip = cfg.customIP;
+      mkdp_port = cfg.customPort;
     };
   };
 }


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment.
-->

`MarkdownPreview` has not been working for some time now, even with a standard config:

```nix
          utility = {
            preview.markdownPreview = {
              enable = true;
              autoStart = true;
              lazyRefresh = true;
            };
           ...
         };
```

I would consistently get this error:
![image](https://github.com/user-attachments/assets/43adb6dd-7c92-4efc-bf9b-031fa79e46b9)

The changes in this PR simplify the nix module while at the same time adhering better to the upstream documented config (i.e. empty strings as "unconfigured" values for `mkdp_open_ip` and `mkdp_port`).

With the included fix `mkdp` works again.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [ ] I have updated the [changelog] as per my changes.
- [x] I have tested, and self-reviewed my code.
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`).
  - [ ] My code conforms to the [editorconfig] configuration of the project.
  - [x] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [ ] `.#nix` (default package)
  - [ ] `.#maximal`
  - [ ] `.#docs-html`
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
