### PR TITLE
languages/vala: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -73,6 +73,7 @@ isMaximal: {
       };
       csharp.enable = isMaximal;
       julia.enable = isMaximal;
+      vala.enable = isMaximal;
     };
 
     visuals = {

--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -292,6 +292,7 @@ To migrate to `nixfmt`, simply change `vim.languages.nix.format.type` to
 - Add LSP, diagnostics, formatter and Treesitter support for Kotlin under
   `vim.languages.kotlin`
 - changed default keybinds for leap.nvim to avoid altering expected behavior
+- Add LSP, formatter and Treesitter support for Vala under `vim.languages.vala`
 
 [Bloxx12](https://github.com/Bloxx12)
 

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -14,6 +14,7 @@ in {
     ./lua.nix
     ./markdown.nix
     ./nim.nix
+    ./vala.nix
     ./nix.nix
     ./ocaml.nix
     ./php.nix

--- a/modules/plugins/languages/vala.nix
+++ b/modules/plugins/languages/vala.nix
@@ -20,6 +20,8 @@
   servers = {
     vala_ls = {
       package = pkgs.vala-language-server;
+      runtimeInputs = pkgs.uncrustify;
+      internalFormatter = true;
       lspConfig = ''
         lspconfig.vala_ls.setup {
           capabilities = capabilities;
@@ -41,7 +43,7 @@
       nullConfig = pkg: ''
         table.insert(
           ls_sources,
-          null_ls.builtins.diagnostics.eslint_d.with({
+          null_ls.builtins.diagnostics.vala_lint.with({
             command = "${getExe pkg}",
           })
         )
@@ -54,13 +56,11 @@ in {
 
     treesitter = {
       enable = mkEnableOption "Vala treesitter" // {default = config.vim.languages.enableTreesitter;};
-
       package = mkGrammarOption pkgs "vala";
     };
 
     lsp = {
       enable = mkEnableOption "Vala LSP support" // {default = config.vim.languages.enableLSP;};
-
       server = mkOption {
         description = "Vala LSP server to use";
         type = enum (attrNames servers);
@@ -69,7 +69,7 @@ in {
 
       package = mkOption {
         description = "Vala LSP server package, or the command to run as a list of strings";
-        example = ''[lib.getExe pkgs.jdt-language-server " - data " " ~/.cache/jdtls/workspace "]'';
+        example = ''[lib.getExe pkgs.vala-language-server]'';
         type = either package (listOf str);
         default = servers.${cfg.lsp.server}.package;
       };
@@ -77,7 +77,6 @@ in {
 
     extraDiagnostics = {
       enable = mkEnableOption "extra Vala diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
-
       types = diagnostics {
         langDesc = "Vala";
         inherit diagnosticsProviders;

--- a/modules/plugins/languages/vala.nix
+++ b/modules/plugins/languages/vala.nix
@@ -6,7 +6,6 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.types) enum either listOf package str;

--- a/modules/plugins/languages/vala.nix
+++ b/modules/plugins/languages/vala.nix
@@ -1,0 +1,109 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.meta) getExe;
+  inherit (lib.nvim.languages) diagnosticsToLua;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.lists) isList;
+  inherit (lib.types) enum either listOf package str;
+  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.lua) expToLua;
+
+  cfg = config.vim.languages.vala;
+
+  defaultServer = "vala_ls";
+  servers = {
+    vala_ls = {
+      package = pkgs.vala-language-server;
+      lspConfig = ''
+        lspconfig.vala_ls.setup {
+          capabilities = capabilities;
+          on_attach = default_on_attach;
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/vala-language-server"}''
+        },
+        }
+      '';
+    };
+  };
+
+  defaultDiagnosticsProvider = ["vala-lint"];
+  diagnosticsProviders = {
+    vala-lint = {
+      package = pkgs.vala-lint;
+      nullConfig = pkg: ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.diagnostics.eslint_d.with({
+            command = "${getExe pkg}",
+          })
+        )
+      '';
+    };
+  };
+in {
+  options.vim.languages.vala = {
+    enable = mkEnableOption "Vala language support";
+
+    treesitter = {
+      enable = mkEnableOption "Vala treesitter" // {default = config.vim.languages.enableTreesitter;};
+
+      package = mkGrammarOption pkgs "vala";
+    };
+
+    lsp = {
+      enable = mkEnableOption "Vala LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        description = "Vala LSP server to use";
+        type = enum (attrNames servers);
+        default = defaultServer;
+      };
+
+      package = mkOption {
+        description = "Vala LSP server package, or the command to run as a list of strings";
+        example = ''[lib.getExe pkgs.jdt-language-server " - data " " ~/.cache/jdtls/workspace "]'';
+        type = either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
+    };
+
+    extraDiagnostics = {
+      enable = mkEnableOption "extra Vala diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+
+      types = diagnostics {
+        langDesc = "Vala";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.lsp.null-ls.enable = true;
+      vim.lsp.null-ls.sources = diagnosticsToLua {
+        lang = "Vala";
+        config = cfg.extraDiagnostics.types;
+        inherit diagnosticsProviders;
+      };
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.vala_ls = servers.${cfg.lsp.server}.lspConfig;
+    })
+  ]);
+}

--- a/modules/plugins/utility/preview/markdown-preview/config.nix
+++ b/modules/plugins/utility/preview/markdown-preview/config.nix
@@ -4,8 +4,9 @@
   lib,
   ...
 }: let
-  inherit (lib.strings) concatMapStringsSep;
+  inherit (lib.strings) stringLength concatMapStringsSep;
   inherit (lib.modules) mkIf;
+
   cfg = config.vim.utility.preview.markdownPreview;
 in {
   config = mkIf cfg.enable {
@@ -18,8 +19,8 @@ in {
       mkdp_filetypes = [(concatMapStringsSep ", " (x: "'" + x + "'") cfg.filetypes)];
       mkdp_command_for_global = cfg.alwaysAllowPreview;
       mkdp_open_to_the_world = cfg.broadcastServer;
-      mkdp_open_ip = cfg.customIP;
-      mkdp_port = cfg.customPort;
+      mkdp_open_ip = mkIf (stringLength cfg.customIP > 0) cfg.customIP;
+      mkdp_port = mkIf (stringLength cfg.customPort > 0) cfg.customPort;
     };
   };
 }

--- a/modules/plugins/utility/preview/markdown-preview/config.nix
+++ b/modules/plugins/utility/preview/markdown-preview/config.nix
@@ -4,9 +4,8 @@
   lib,
   ...
 }: let
-  inherit (lib.strings) stringLength concatMapStringsSep;
+  inherit (lib.strings) concatMapStringsSep;
   inherit (lib.modules) mkIf;
-
   cfg = config.vim.utility.preview.markdownPreview;
 in {
   config = mkIf cfg.enable {
@@ -19,8 +18,8 @@ in {
       mkdp_filetypes = [(concatMapStringsSep ", " (x: "'" + x + "'") cfg.filetypes)];
       mkdp_command_for_global = cfg.alwaysAllowPreview;
       mkdp_open_to_the_world = cfg.broadcastServer;
-      mkdp_open_ip = mkIf (stringLength cfg.customIP > 0) cfg.customIP;
-      mkdp_port = mkIf (stringLength cfg.customPort > 0) cfg.customPort;
+      mkdp_open_ip = cfg.customIP;
+      mkdp_port = cfg.customPort;
     };
   };
 }


### PR DESCRIPTION
Add support for Vala language

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [X] I have updated the [changelog] as per my changes.
- [X] I have tested, and self-reviewed my code.
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`).
  - [X] My code conforms to the [editorconfig] configuration of the project.
  - [X] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [X] `.#nix` (default package)
  - [X] `.#maximal`
  - [X] `.#docs-html`
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
