### PR TITLE
languages/r: added formatters

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -285,6 +285,7 @@ To migrate to `nixfmt`, simply change `vim.languages.nix.format.type` to
 [Soliprem](https://github.com/Soliprem):
 
 - Add LSP and Treesitter support for R under `vim.languages.R`.
+  - Add formatter suppoort for R, with styler and formatR as options
 - Add Otter support under `vim.lsp.otter` and an assert to prevent conflict with
   ccc
 - Fixed typo in Otter's setupOpts


### PR DESCRIPTION
Adds Formatters for the R module

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [X] I have updated the [changelog] as per my changes.
- [X] I have tested, and self-reviewed my code.
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`).
  - [X] My code conforms to the [editorconfig] configuration of the project.
  - [X] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [X] `.#nix` (default package)
  - [X] `.#maximal`
  - [X] `.#docs-html`
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
