### PR TITLE
nvim-cmp: move text and snippet completions to the bottom

### DIFF
--- a/modules/plugins/completion/nvim-cmp/config.nix
+++ b/modules/plugins/completion/nvim-cmp/config.nix
@@ -42,6 +42,20 @@ in {
             after = ''
               ${optionalString luasnipEnable "local luasnip = require('luasnip')"}
               local cmp = require("cmp")
+
+              local kinds = require("cmp.types").lsp.CompletionItemKind
+              local deprio = function(kind)
+                return function(e1, e2)
+                  if e1:get_kind() == kind then
+                    return false
+                  end
+                  if e2:get_kind() == kind then
+                    return true
+                  end
+                  return nil
+                end
+              end
+
               cmp.setup(${toLuaObject cfg.setupOpts})
 
               ${optionalString config.vim.lazy.enable

--- a/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
+++ b/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
@@ -29,6 +29,8 @@ in {
       sorting.comparators = mkOption {
         type = mergelessListOf (either str luaInline);
         default = [
+          (mkLuaInline "deprio(kinds.Text)")
+          (mkLuaInline "deprio(kinds.Snippet)")
           "offset"
           "exact"
           "score"
@@ -43,6 +45,12 @@ in {
           (see `:help cmp-config.sorting.comparators`),
           or a string, in which case the builtin comparator with that name will
           be used.
+
+          A `deprio` function and a `kinds`
+          (`require("cmp.types").lsp.CompletionItemKind`) variable is provided
+          above `setupOpts`. By passing a type to the funcion, the returned
+          function will be a comparator that always ranks the specified kind the
+          lowest.
         '';
         apply = map (
           c:


### PR DESCRIPTION
Moves text and snippet completions to the bottom by default. It feels like a hack to do this, but I can't find a better way to get around this. If anyone has suggestions on what the ordering should look like, please let me know.

I was thinking about adding the `recently_used` and `locality` comparators to the defaults, but they seem a little too opinionated/performance-heavy, so I didn't.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [ ] I have updated the [changelog] as per my changes.
- [ ] I have tested, and self-reviewed my code.
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`).
  - [ ] My code conforms to the [editorconfig] configuration of the project.
  - [ ] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [ ] `.#nix` (default package)
  - [ ] `.#maximal`
  - [ ] `.#docs-html`
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
