### PR TITLE
typst: added tinymist and activated formatters

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -302,6 +302,7 @@ To migrate to `nixfmt`, simply change `vim.languages.nix.format.type` to
   `vim.languages.kotlin`
 - changed default keybinds for leap.nvim to avoid altering expected behavior
 - Add LSP, formatter and Treesitter support for Vala under `vim.languages.vala`
+- added tinymist to Typst, enabled typst formatters
 
 [Bloxx12](https://github.com/Bloxx12)
 

--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -302,7 +302,7 @@ To migrate to `nixfmt`, simply change `vim.languages.nix.format.type` to
   `vim.languages.kotlin`
 - changed default keybinds for leap.nvim to avoid altering expected behavior
 - Add LSP, formatter and Treesitter support for Vala under `vim.languages.vala`
-- added tinymist to Typst, enabled typst formatters
+- Add [Tinymist](https://github.com/Myriad-Dreamin/tinymist] as a formatter for the Typst language module.
 
 [Bloxx12](https://github.com/Bloxx12)
 

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -35,7 +35,7 @@
       lspConfig = ''
         lspconfig.tinymist.setup {
           capabilities = capabilities,
-          on_attach=default_on_attach,
+          on_attach = default_on_attach,
           cmd = ${
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -14,6 +14,38 @@
 
   cfg = config.vim.languages.typst;
 
+  defaultServer = "tinymist";
+  servers = {
+    typst-lsp = {
+      package = pkgs.typst-lsp;
+      lspConfig = ''
+        lspconfig.typst_lsp.setup {
+          capabilities = capabilities,
+          on_attach=default_on_attach,
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/typst-lsp"}''
+        },
+        }
+      '';
+    };
+    tinymist = {
+      package = pkgs.tinymist;
+      lspConfig = ''
+        lspconfig.tinymist.setup {
+          capabilities = capabilities,
+          on_attach=default_on_attach,
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/tinymist"}''
+        },
+        }
+      '';
+    };
+  };
+
   defaultFormat = "typstfmt";
   formats = {
     typstfmt = {
@@ -52,11 +84,17 @@ in {
     lsp = {
       enable = mkEnableOption "Typst LSP support (typst-lsp)" // {default = config.vim.languages.enableLSP;};
 
+      server = mkOption {
+        description = "Typst LSP server to use";
+        type = enum (attrNames servers);
+        default = defaultServer;
+      };
+
       package = mkOption {
         description = "typst-lsp package, or the command to run as a list of strings";
         example = ''[lib.getExe pkgs.jdt-language-server "-data" "~/.cache/jdtls/workspace"]'';
         type = either package (listOf str);
-        default = pkgs.typst-lsp;
+        default = servers.${cfg.lsp.server}.package;
       };
     };
 
@@ -82,19 +120,14 @@ in {
       vim.treesitter.grammars = [cfg.treesitter.package];
     })
 
+    (mkIf cfg.format.enable {
+      vim.lsp.null-ls.enable = true;
+      vim.lsp.null-ls.sources.typst-format = formats.${cfg.format.type}.nullConfig;
+    })
+
     (mkIf cfg.lsp.enable {
       vim.lsp.lspconfig.enable = true;
-      vim.lsp.lspconfig.sources.typst-lsp = ''
-        lspconfig.typst_lsp.setup {
-          capabilities = capabilities,
-          on_attach=default_on_attach,
-          cmd = ${
-          if isList cfg.lsp.package
-          then expToLua cfg.lsp.package
-          else ''{"${cfg.lsp.package}/bin/typst-lsp"}''
-        },
-        }
-      '';
+      vim.lsp.lspconfig.sources.typst-lsp = servers.${cfg.lsp.server}.lspConfig;
     })
   ]);
 }

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -21,7 +21,7 @@
       lspConfig = ''
         lspconfig.typst_lsp.setup {
           capabilities = capabilities,
-          on_attach=default_on_attach,
+          on_attach = default_on_attach,
           cmd = ${
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package


### PR DESCRIPTION
Added tinymist and enabled formatters

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [X] I have updated the [changelog] as per my changes.
- [X] I have tested, and self-reviewed my code.
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`).
  - [X] My code conforms to the [editorconfig] configuration of the project.
  - [X] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [X] `.#nix` (default package)
  - [X] `.#maximal`
  - [X] `.#docs-html`
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
