### PR TITLE
nvim-web-devicons: re-enable icon color

### DIFF
--- a/modules/plugins/visuals/nvim-web-devicons/nvim-web-devicons.nix
+++ b/modules/plugins/visuals/nvim-web-devicons/nvim-web-devicons.nix
@@ -16,7 +16,7 @@ in {
     enable = mkEnableOption "Neovim dev icons [nvim-web-devicons]";
 
     setupOpts = mkPluginSetupOption "nvim-web-devicons" {
-      color_icons = mkEnableOption "different highlight colors per icon";
+      color_icons = mkEnableOption "different highlight colors per icon" // {default = true;};
       variant = mkOption {
         type = nullOr (enum ["light" "dark"]);
         default = null;


### PR DESCRIPTION
accidentally disabled in a6bb6e1b3e360a1222bdc877633ac37440f1d4d2