### PR TITLE
binds/which-key: changing to the new spec

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -309,6 +309,7 @@ To migrate to `nixfmt`, simply change `vim.languages.nix.format.type` to
 - Add [Tinymist](https://github.com/Myriad-Dreamin/tinymist] as a formatter for
   the Typst language module.
 - Add LSP and Treesitter support for Assembly under `vim.languages.assembly`
+- Move [which-key](https://github.com/folke/which-key.nvim) to the new spec
 
 [Bloxx12](https://github.com/Bloxx12)
 

--- a/modules/plugins/utility/binds/which-key/config.nix
+++ b/modules/plugins/utility/binds/which-key/config.nix
@@ -5,9 +5,12 @@
 }: let
   inherit (lib.modules) mkIf;
   inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.binds.whichKey;
+  register = mapAttrsToList (n: v: mkLuaInline "{ '${n}', desc = '${v}' }") cfg.register;
 in {
   config = mkIf cfg.enable {
     vim = {
@@ -16,7 +19,7 @@ in {
       pluginRC.whichkey = entryAnywhere ''
         local wk = require("which-key")
         wk.setup (${toLuaObject cfg.setupOpts})
-        wk.register(${toLuaObject cfg.register})
+        wk.add(${toLuaObject register})
       '';
     };
   };


### PR DESCRIPTION
Changes which-key to the new spec

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [X] I have updated the [changelog] as per my changes.
- [X] I have tested, and self-reviewed my code.
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`).
  - [X] My code conforms to the [editorconfig] configuration of the project.
  - [X] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [X] `.#nix` (default package)
  - [X] `.#maximal`
  - [X] `.#docs-html`
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
