### PR TITLE
nvim-cmp: fix use of mkDefault for borders

### DIFF
--- a/modules/plugins/completion/nvim-cmp/config.nix
+++ b/modules/plugins/completion/nvim-cmp/config.nix
@@ -3,7 +3,7 @@
   config,
   ...
 }: let
-  inherit (lib.modules) mkIf mkMerge mkDefault;
+  inherit (lib.modules) mkIf mkMerge;
   inherit (lib.strings) optionalString;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.lua) toLuaObject;
@@ -11,17 +11,6 @@
   inherit (builtins) attrNames typeOf tryEval concatStringsSep;
 
   borders = config.vim.ui.borders.plugins.nvim-cmp;
-  # From https://github.com/hrsh7th/nvim-cmp/blob/main/lua/cmp/config/window.lua
-  # This way users can still override the options
-  windowOpts = {
-    border = borders.style;
-    winhighlight = "Normal:Normal,FloatBorder:FloatBorder,CursorLine:Visual,Search:None";
-    zindex = 1001;
-    scrolloff = 0;
-    col_offset = 0;
-    side_padding = 1;
-    scrollbar = true;
-  };
 
   cfg = config.vim.autocomplete.nvim-cmp;
   luasnipEnable = config.vim.snippets.luasnip.enable;
@@ -95,8 +84,8 @@ in {
           sources = map (s: {name = s;}) (attrNames cfg.sources);
 
           window = mkIf borders.enable {
-            completion = mkDefault windowOpts;
-            documentation = mkDefault windowOpts;
+            completion.border = borders.style;
+            documentation.border = borders.style;
           };
 
           formatting.format = cfg.format;


### PR DESCRIPTION
Fix oopsie in #466