### PR TITLE
internal: simpler helper functions for keymaps

### DIFF
--- a/docs/release-notes/rl-0.7.md
+++ b/docs/release-notes/rl-0.7.md
@@ -137,6 +137,8 @@ it to something other than `mapleader` to avoid conflicts.
 
 [lz.n]: https://github.com/mrcjkb/lz.n
 
+- Add simpler helper functions for making keymaps
+
 [jacekpoz](https://jacekpoz.pl):
 
 [ocaml-lsp]: https://github.com/ocaml/ocaml-lsp

--- a/lib/binds.nix
+++ b/lib/binds.nix
@@ -68,19 +68,6 @@
 
     pushDownDefault = attr: mapAttrs (_: mkDefault) attr;
 
-    mkSetLznBinding = mode: binding: action: {
-      inherit action mode;
-      key = binding.value;
-      desc = binding.description;
-    };
-
-    mkSetLuaLznBinding = mode: binding: action: {
-      inherit action mode;
-      key = binding.value;
-      lua = true;
-      desc = binding.description;
-    };
-
     mkKeymap = mode: key: action: opt: opt // {inherit mode key action;};
   };
 in

--- a/lib/binds.nix
+++ b/lib/binds.nix
@@ -68,17 +68,6 @@
 
     pushDownDefault = attr: mapAttrs (_: mkDefault) attr;
 
-    mkLznBinding = mode: key: action: desc: {
-      inherit mode desc key action;
-    };
-
-    mkLznExprBinding = mode: key: action: desc: {
-      inherit mode desc key action;
-      lua = true;
-      silent = true;
-      expr = true;
-    };
-
     mkSetLznBinding = mode: binding: action: {
       inherit action mode;
       key = binding.value;

--- a/lib/binds.nix
+++ b/lib/binds.nix
@@ -91,6 +91,8 @@
       lua = true;
       desc = binding.description;
     };
+
+    mkKeymap = mode: key: action: opt: opt // {inherit mode key action;};
   };
 in
   binds

--- a/modules/plugins/comments/comment-nvim/config.nix
+++ b/modules/plugins/comments/comment-nvim/config.nix
@@ -1,14 +1,14 @@
 {
+  options,
   config,
   lib,
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.binds) mkLznExprBinding mkLznBinding;
+  inherit (lib.nvim.binds) mkKeymap;
 
   cfg = config.vim.comments.comment-nvim;
-  self = import ./comment-nvim.nix {inherit lib;};
-  inherit (self.options.vim.comments.comment-nvim) mappings;
+  inherit (options.vim.comments.comment-nvim) mappings;
 in {
   config = mkIf cfg.enable {
     vim.lazy.plugins.comment-nvim = {
@@ -16,24 +16,28 @@ in {
       setupModule = "Comment";
       inherit (cfg) setupOpts;
       keys = [
-        (mkLznBinding ["n"] cfg.mappings.toggleOpLeaderLine "<Plug>(comment_toggle_linewise)" mappings.toggleOpLeaderLine.description)
-        (mkLznBinding ["n"] cfg.mappings.toggleOpLeaderBlock "<Plug>(comment_toggle_blockwise)" mappings.toggleOpLeaderBlock.description)
-        (mkLznExprBinding ["n"] cfg.mappings.toggleCurrentLine ''
+        (mkKeymap ["n"] cfg.mappings.toggleOpLeaderLine "<Plug>(comment_toggle_linewise)" {desc = mappings.toggleOpLeaderLine.description;})
+        (mkKeymap ["n"] cfg.mappings.toggleOpLeaderBlock "<Plug>(comment_toggle_blockwise)" {desc = mappings.toggleOpLeaderBlock.description;})
+        (mkKeymap ["n"] cfg.mappings.toggleCurrentLine ''
             function()
               return vim.api.nvim_get_vvar('count') == 0 and '<Plug>(comment_toggle_linewise_current)'
                       or '<Plug>(comment_toggle_linewise_count)'
             end
-          ''
-          mappings.toggleCurrentLine.description)
-        (mkLznExprBinding ["n"] cfg.mappings.toggleCurrentBlock ''
+          '' {
+            expr = true;
+            desc = mappings.toggleCurrentLine.description;
+          })
+        (mkKeymap ["n"] cfg.mappings.toggleCurrentBlock ''
             function()
               return vim.api.nvim_get_vvar('count') == 0 and '<Plug>(comment_toggle_blockwise_current)'
                       or '<Plug>(comment_toggle_blockwise_count)'
             end
-          ''
-          mappings.toggleCurrentBlock.description)
-        (mkLznBinding ["x"] cfg.mappings.toggleSelectedLine "<Plug>(comment_toggle_linewise_visual)" mappings.toggleSelectedLine.description)
-        (mkLznBinding ["x"] cfg.mappings.toggleSelectedBlock "<Plug>(comment_toggle_blockwise_visual)" mappings.toggleSelectedBlock.description)
+          '' {
+            expr = true;
+            desc = mappings.toggleCurrentBlock.description;
+          })
+        (mkKeymap ["x"] cfg.mappings.toggleSelectedLine "<Plug>(comment_toggle_linewise_visual)" {desc = mappings.toggleSelectedLine.description;})
+        (mkKeymap ["x"] cfg.mappings.toggleSelectedBlock "<Plug>(comment_toggle_blockwise_visual)" {desc = mappings.toggleSelectedBlock.description;})
       ];
     };
   };

--- a/modules/plugins/comments/comment-nvim/config.nix
+++ b/modules/plugins/comments/comment-nvim/config.nix
@@ -36,8 +36,8 @@ in {
             expr = true;
             desc = mappings.toggleCurrentBlock.description;
           })
-        (mkKeymap ["x"] cfg.mappings.toggleSelectedLine "<Plug>(comment_toggle_linewise_visual)" {desc = mappings.toggleSelectedLine.description;})
-        (mkKeymap ["x"] cfg.mappings.toggleSelectedBlock "<Plug>(comment_toggle_blockwise_visual)" {desc = mappings.toggleSelectedBlock.description;})
+        (mkKeymap "x" cfg.mappings.toggleSelectedLine "<Plug>(comment_toggle_linewise_visual)" {desc = mappings.toggleSelectedLine.description;})
+        (mkKeymap "x" cfg.mappings.toggleSelectedBlock "<Plug>(comment_toggle_blockwise_visual)" {desc = mappings.toggleSelectedBlock.description;})
       ];
     };
   };

--- a/modules/plugins/comments/comment-nvim/config.nix
+++ b/modules/plugins/comments/comment-nvim/config.nix
@@ -16,9 +16,9 @@ in {
       setupModule = "Comment";
       inherit (cfg) setupOpts;
       keys = [
-        (mkKeymap ["n"] cfg.mappings.toggleOpLeaderLine "<Plug>(comment_toggle_linewise)" {desc = mappings.toggleOpLeaderLine.description;})
-        (mkKeymap ["n"] cfg.mappings.toggleOpLeaderBlock "<Plug>(comment_toggle_blockwise)" {desc = mappings.toggleOpLeaderBlock.description;})
-        (mkKeymap ["n"] cfg.mappings.toggleCurrentLine ''
+        (mkKeymap "n" cfg.mappings.toggleOpLeaderLine "<Plug>(comment_toggle_linewise)" {desc = mappings.toggleOpLeaderLine.description;})
+        (mkKeymap "n" cfg.mappings.toggleOpLeaderBlock "<Plug>(comment_toggle_blockwise)" {desc = mappings.toggleOpLeaderBlock.description;})
+        (mkKeymap "n" cfg.mappings.toggleCurrentLine ''
             function()
               return vim.api.nvim_get_vvar('count') == 0 and '<Plug>(comment_toggle_linewise_current)'
                       or '<Plug>(comment_toggle_linewise_count)'

--- a/modules/plugins/debugger/nvim-dap/config.nix
+++ b/modules/plugins/debugger/nvim-dap/config.nix
@@ -1,4 +1,5 @@
 {
+  options,
   config,
   lib,
   ...
@@ -6,13 +7,11 @@
   inherit (lib.strings) optionalString;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.attrsets) mapAttrs;
-  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetLuaBinding mkSetLuaLznBinding;
+  inherit (lib.nvim.binds) mkKeymap;
   inherit (lib.nvim.dag) entryAnywhere entryAfter;
 
   cfg = config.vim.debugger.nvim-dap;
-  self = import ./nvim-dap.nix {inherit lib;};
-  mappingDefinitions = self.options.vim.debugger.nvim-dap.mappings;
-  mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
+  inherit (options.vim.debugger.nvim-dap) mappings;
 in {
   config = mkMerge [
     (mkIf cfg.enable {
@@ -30,23 +29,23 @@ in {
           // mapAttrs (_: v: (entryAfter ["nvim-dap"] v)) cfg.sources;
 
         maps.normal = mkMerge [
-          (mkSetLuaBinding mappings.continue "require('dap').continue")
-          (mkSetLuaBinding mappings.restart "require('dap').restart")
-          (mkSetLuaBinding mappings.terminate "require('dap').terminate")
-          (mkSetLuaBinding mappings.runLast "require('dap').run_last")
+          (mkKeymap "n" cfg.mappings.continue "require('dap').continue" {desc = mappings.continue.description;})
+          (mkKeymap "n" cfg.mappings.restart "require('dap').restart" {desc = mappings.restart.description;})
+          (mkKeymap "n" cfg.mappings.terminate "require('dap').terminate" {desc = mappings.terminate.description;})
+          (mkKeymap "n" cfg.mappings.runLast "require('dap').run_last" {desc = mappings.runLast.description;})
 
-          (mkSetLuaBinding mappings.toggleRepl "require('dap').repl.toggle")
-          (mkSetLuaBinding mappings.hover "require('dap.ui.widgets').hover")
-          (mkSetLuaBinding mappings.toggleBreakpoint "require('dap').toggle_breakpoint")
+          (mkKeymap "n" cfg.mappings.toggleRepl "require('dap').repl.toggle" {desc = mappings.toggleRepl.description;})
+          (mkKeymap "n" cfg.mappings.hover "require('dap.ui.widgets').hover" {desc = mappings.hover.description;})
+          (mkKeymap "n" cfg.mappings.toggleBreakpoint "require('dap').toggle_breakpoint" {desc = mappings.toggleBreakpoint.description;})
 
-          (mkSetLuaBinding mappings.runToCursor "require('dap').run_to_cursor")
-          (mkSetLuaBinding mappings.stepInto "require('dap').step_into")
-          (mkSetLuaBinding mappings.stepOut "require('dap').step_out")
-          (mkSetLuaBinding mappings.stepOver "require('dap').step_over")
-          (mkSetLuaBinding mappings.stepBack "require('dap').step_back")
+          (mkKeymap "n" cfg.mappings.runToCursor "require('dap').run_to_cursor" {desc = mappings.runToCursor.description;})
+          (mkKeymap "n" cfg.mappings.stepInto "require('dap').step_into" {desc = mappings.stepInto.description;})
+          (mkKeymap "n" cfg.mappings.stepOut "require('dap').step_out" {desc = mappings.stepOut.description;})
+          (mkKeymap "n" cfg.mappings.stepOver "require('dap').step_over" {desc = mappings.stepOver.description;})
+          (mkKeymap "n" cfg.mappings.stepBack "require('dap').step_back" {desc = mappings.stepBack.description;})
 
-          (mkSetLuaBinding mappings.goUp "require('dap').up")
-          (mkSetLuaBinding mappings.goDown "require('dap').down")
+          (mkKeymap "n" cfg.mappings.goUp "require('dap').up" {desc = mappings.goUp.description;})
+          (mkKeymap "n" cfg.mappings.goDown "require('dap').down" {desc = mappings.goDown.description;})
         ];
       };
     })
@@ -60,7 +59,7 @@ in {
           inherit (cfg.ui) setupOpts;
 
           keys = [
-            (mkSetLuaLznBinding "n" mappings.toggleDapUI "function() require('dapui').toggle() end")
+            (mkKeymap "n" cfg.mappings.toggleDapUI "function() require('dapui').toggle() end" {desc = mappings.toggleDapUI.descritpion;})
           ];
         };
 

--- a/modules/plugins/debugger/nvim-dap/config.nix
+++ b/modules/plugins/debugger/nvim-dap/config.nix
@@ -28,7 +28,7 @@ in {
           }
           // mapAttrs (_: v: (entryAfter ["nvim-dap"] v)) cfg.sources;
 
-        maps.normal = mkMerge [
+        keymaps = [
           (mkKeymap "n" cfg.mappings.continue "require('dap').continue" {desc = mappings.continue.description;})
           (mkKeymap "n" cfg.mappings.restart "require('dap').restart" {desc = mappings.restart.description;})
           (mkKeymap "n" cfg.mappings.terminate "require('dap').terminate" {desc = mappings.terminate.description;})

--- a/modules/plugins/debugger/nvim-dap/config.nix
+++ b/modules/plugins/debugger/nvim-dap/config.nix
@@ -59,7 +59,7 @@ in {
           inherit (cfg.ui) setupOpts;
 
           keys = [
-            (mkKeymap "n" cfg.mappings.toggleDapUI "function() require('dapui').toggle() end" {desc = mappings.toggleDapUI.descritpion;})
+            (mkKeymap "n" cfg.mappings.toggleDapUI "function() require('dapui').toggle() end" {desc = mappings.toggleDapUI.description;})
           ];
         };
 

--- a/modules/plugins/filetree/nvimtree/config.nix
+++ b/modules/plugins/filetree/nvimtree/config.nix
@@ -27,10 +27,10 @@ in {
 
         cmd = ["NvimTreeClipboard" "NvimTreeClose" "NvimTreeCollapse" "NvimTreeCollapseKeepBuffers" "NvimTreeFindFile" "NvimTreeFindFileToggle" "NvimTreeFocus" "NvimTreeHiTest" "NvimTreeOpen" "NvimTreeRefresh" "NvimTreeResize" "NvimTreeToggle"];
         keys = [
-          (mkKeymap ["n"] cfg.mappings.toggle ":NvimTreeToggle<cr>" {desc = mappings.toggle.description;})
-          (mkKeymap ["n"] cfg.mappings.refresh ":NvimTreeRefresh<cr>" {desc = mappings.refresh.description;})
-          (mkKeymap ["n"] cfg.mappings.findFile ":NvimTreeFindFile<cr>" {desc = mappings.findFile.description;})
-          (mkKeymap ["n"] cfg.mappings.focus ":NvimTreeFocus<cr>" {desc = mappings.focus.description;})
+          (mkKeymap "n" cfg.mappings.toggle ":NvimTreeToggle<cr>" {desc = mappings.toggle.description;})
+          (mkKeymap "n" cfg.mappings.refresh ":NvimTreeRefresh<cr>" {desc = mappings.refresh.description;})
+          (mkKeymap "n" cfg.mappings.findFile ":NvimTreeFindFile<cr>" {desc = mappings.findFile.description;})
+          (mkKeymap "n" cfg.mappings.focus ":NvimTreeFocus<cr>" {desc = mappings.focus.description;})
         ];
       };
 

--- a/modules/plugins/filetree/nvimtree/config.nix
+++ b/modules/plugins/filetree/nvimtree/config.nix
@@ -6,7 +6,7 @@
 }: let
   inherit (lib.strings) optionalString;
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.binds) mkLznBinding;
+  inherit (lib.nvim.binds) mkKeymap;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.binds) pushDownDefault;
 
@@ -27,10 +27,10 @@ in {
 
         cmd = ["NvimTreeClipboard" "NvimTreeClose" "NvimTreeCollapse" "NvimTreeCollapseKeepBuffers" "NvimTreeFindFile" "NvimTreeFindFileToggle" "NvimTreeFocus" "NvimTreeHiTest" "NvimTreeOpen" "NvimTreeRefresh" "NvimTreeResize" "NvimTreeToggle"];
         keys = [
-          (mkLznBinding ["n"] cfg.mappings.toggle ":NvimTreeToggle<cr>" mappings.toggle.description)
-          (mkLznBinding ["n"] cfg.mappings.refresh ":NvimTreeRefresh<cr>" mappings.refresh.description)
-          (mkLznBinding ["n"] cfg.mappings.findFile ":NvimTreeFindFile<cr>" mappings.findFile.description)
-          (mkLznBinding ["n"] cfg.mappings.focus ":NvimTreeFocus<cr>" mappings.focus.description)
+          (mkKeymap ["n"] cfg.mappings.toggle ":NvimTreeToggle<cr>" {desc = mappings.toggle.description;})
+          (mkKeymap ["n"] cfg.mappings.refresh ":NvimTreeRefresh<cr>" {desc = mappings.refresh.description;})
+          (mkKeymap ["n"] cfg.mappings.findFile ":NvimTreeFindFile<cr>" {desc = mappings.findFile.description;})
+          (mkKeymap ["n"] cfg.mappings.focus ":NvimTreeFocus<cr>" {desc = mappings.focus.description;})
         ];
       };
 

--- a/modules/plugins/lsp/trouble/config.nix
+++ b/modules/plugins/lsp/trouble/config.nix
@@ -5,12 +5,11 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetLznBinding pushDownDefault;
+  inherit (lib.nvim.binds) mkKeymap pushDownDefault;
 
   cfg = config.vim.lsp;
 
-  mappingDefinitions = options.vim.lsp.trouble.mappings;
-  mappings = addDescriptionsToMappings cfg.trouble.mappings mappingDefinitions;
+  inherit (options.vim.lsp.trouble) mappings;
 in {
   config = mkIf (cfg.enable && cfg.trouble.enable) {
     vim = {
@@ -21,12 +20,12 @@ in {
 
         cmd = "Trouble";
         keys = [
-          (mkSetLznBinding "n" mappings.workspaceDiagnostics "<cmd>Trouble toggle diagnostics<CR>")
-          (mkSetLznBinding "n" mappings.documentDiagnostics "<cmd>Trouble toggle diagnostics filter.buf=0<CR>")
-          (mkSetLznBinding "n" mappings.lspReferences "<cmd>Trouble toggle lsp_references<CR>")
-          (mkSetLznBinding "n" mappings.quickfix "<cmd>Trouble toggle quickfix<CR>")
-          (mkSetLznBinding "n" mappings.locList "<cmd>Trouble toggle loclist<CR>")
-          (mkSetLznBinding "n" mappings.symbols "<cmd>Trouble toggle symbols<CR>")
+          (mkKeymap "n" cfg.trouble.mappings.workspaceDiagnostics "<cmd>Trouble toggle diagnostics<CR>" {desc = mappings.workspaceDiagnostics.description;})
+          (mkKeymap "n" cfg.trouble.mappings.documentDiagnostics "<cmd>Trouble toggle diagnostics filter.buf=0<CR>" {desc = mappings.documentDiagnostics.description;})
+          (mkKeymap "n" cfg.trouble.mappings.lspReferences "<cmd>Trouble toggle lsp_references<CR>" {desc = mappings.lspReferences.description;})
+          (mkKeymap "n" cfg.trouble.mappings.quickfix "<cmd>Trouble toggle quickfix<CR>" {desc = mappings.quickfix.description;})
+          (mkKeymap "n" cfg.trouble.mappings.locList "<cmd>Trouble toggle loclist<CR>" {desc = mappings.locList.description;})
+          (mkKeymap "n" cfg.trouble.mappings.symbols "<cmd>Trouble toggle symbols<CR>" {desc = mappings.symbols.description;})
         ];
       };
 

--- a/modules/plugins/terminal/toggleterm/config.nix
+++ b/modules/plugins/terminal/toggleterm/config.nix
@@ -7,7 +7,7 @@
   inherit (lib.lists) optional;
   inherit (lib.modules) mkIf;
   inherit (lib.meta) getExe;
-  inherit (lib.nvim.binds) mkLznBinding;
+  inherit (lib.nvim.binds) mkKeymap;
   inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.terminal.toggleterm;
@@ -19,7 +19,7 @@ in {
         package = "toggleterm-nvim";
         cmd = ["ToggleTerm" "ToggleTermSendCurrentLine" "ToggleTermSendVisualLines" "ToggleTermSendVisualSelection" "ToggleTermSetName" "ToggleTermToggleAll"];
         keys =
-          [(mkLznBinding ["n"] cfg.mappings.open "<Cmd>execute v:count . \"ToggleTerm\"<CR>" "Toggle terminal")]
+          [(mkKeymap "n" cfg.mappings.open "<Cmd>execute v:count . \"ToggleTerm\"<CR>" {desc = "Toggle terminal";})]
           ++ optional cfg.lazygit.enable {
             key = cfg.lazygit.mappings.open;
             mode = "n";

--- a/modules/plugins/utility/motion/leap/config.nix
+++ b/modules/plugins/utility/motion/leap/config.nix
@@ -4,7 +4,7 @@
   ...
 }: let
   inherit (lib.modules) mkIf mkDefault;
-  inherit (lib.nvim.binds) mkLznBinding;
+  inherit (lib.nvim.binds) mkKeymap;
 
   cfg = config.vim.utility.motion.leap;
 in {
@@ -14,11 +14,11 @@ in {
       lazy.plugins.leap-nvim = {
         package = "leap-nvim";
         keys = [
-          (mkLznBinding ["n" "o" "x"] cfg.mappings.leapForwardTo "<Plug>(leap-forward-to)" "Leap forward to")
-          (mkLznBinding ["n" "o" "x"] cfg.mappings.leapBackwardTo "<Plug>(leap-backward-to)" "Leap backward to")
-          (mkLznBinding ["n" "o" "x"] cfg.mappings.leapForwardTill "<Plug>(leap-forward-till)" "Leap forward till")
-          (mkLznBinding ["n" "o" "x"] cfg.mappings.leapBackwardTill "<Plug>(leap-backward-till)" "Leap backward till")
-          (mkLznBinding ["n" "o" "x"] cfg.mappings.leapFromWindow "<Plug>(leap-from-window)" "Leap from window")
+          (mkKeymap ["n" "o" "x"] cfg.mappings.leapForwardTo "<Plug>(leap-forward-to)" {desc = "Leap forward to";})
+          (mkKeymap ["n" "o" "x"] cfg.mappings.leapBackwardTo "<Plug>(leap-backward-to)" {desc = "Leap backward to";})
+          (mkKeymap ["n" "o" "x"] cfg.mappings.leapForwardTill "<Plug>(leap-forward-till)" {desc = "Leap forward till";})
+          (mkKeymap ["n" "o" "x"] cfg.mappings.leapBackwardTill "<Plug>(leap-backward-till)" {desc = "Leap backward till";})
+          (mkKeymap ["n" "o" "x"] cfg.mappings.leapFromWindow "<Plug>(leap-from-window)" {desc = "Leap from window";})
         ];
 
         after = ''

--- a/modules/plugins/utility/telescope/config.nix
+++ b/modules/plugins/utility/telescope/config.nix
@@ -5,15 +5,14 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.binds) addDescriptionsToMappings;
   inherit (lib.strings) optionalString;
   inherit (lib.lists) optionals;
-  inherit (lib.nvim.binds) pushDownDefault mkSetLznBinding;
+  inherit (lib.nvim.binds) pushDownDefault mkKeymap;
 
   cfg = config.vim.telescope;
-  mappingDefinitions = options.vim.telescope.mappings;
 
-  mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
+  keys = cfg.mappings;
+  inherit (options.vim.telescope) mappings;
 in {
   config = mkIf cfg.enable {
     vim = {
@@ -34,39 +33,35 @@ in {
 
         keys =
           [
-            (mkSetLznBinding "n" mappings.findFiles "<cmd>Telescope find_files<CR>")
-            (mkSetLznBinding "n" mappings.liveGrep "<cmd>Telescope live_grep<CR>")
-            (mkSetLznBinding "n" mappings.buffers "<cmd>Telescope buffers<CR>")
-            (mkSetLznBinding "n" mappings.helpTags "<cmd>Telescope help_tags<CR>")
-            (mkSetLznBinding "n" mappings.open "<cmd>Telescope<CR>")
-            (mkSetLznBinding "n" mappings.resume "<cmd>Telescope resume<CR>")
+            (mkKeymap "n" keys.findFiles "<cmd>Telescope find_files<CR>" {desc = mappings.findFiles.description;})
+            (mkKeymap "n" keys.liveGrep "<cmd>Telescope live_grep<CR>" {desc = mappings.liveGrep.description;})
+            (mkKeymap "n" keys.buffers "<cmd>Telescope buffers<CR>" {desc = mappings.buffers.description;})
+            (mkKeymap "n" keys.helpTags "<cmd>Telescope help_tags<CR>" {desc = mappings.helpTags.description;})
+            (mkKeymap "n" keys.open "<cmd>Telescope<CR>" {desc = mappings.open.description;})
+            (mkKeymap "n" keys.resume "<cmd>Telescope resume<CR>" {desc = mappings.resume.description;})
 
-            (mkSetLznBinding "n" mappings.gitCommits "<cmd>Telescope git_commits<CR>")
-            (mkSetLznBinding "n" mappings.gitBufferCommits "<cmd>Telescope git_bcommits<CR>")
-            (mkSetLznBinding "n" mappings.gitBranches "<cmd>Telescope git_branches<CR>")
-            (mkSetLznBinding "n" mappings.gitStatus "<cmd>Telescope git_status<CR>")
-            (mkSetLznBinding "n" mappings.gitStash "<cmd>Telescope git_stash<CR>")
+            (mkKeymap "n" keys.gitCommits "<cmd>Telescope git_commits<CR>" {desc = mappings.gitCommits.description;})
+            (mkKeymap "n" keys.gitBufferCommits "<cmd>Telescope git_bcommits<CR>" {desc = mappings.gitBufferCommits.description;})
+            (mkKeymap "n" keys.gitBranches "<cmd>Telescope git_branches<CR>" {desc = mappings.gitBranches.description;})
+            (mkKeymap "n" keys.gitStatus "<cmd>Telescope git_status<CR>" {desc = mappings.gitStatus.description;})
+            (mkKeymap "n" keys.gitStash "<cmd>Telescope git_stash<CR>" {desc = mappings.gitStash.description;})
           ]
           ++ (optionals config.vim.lsp.enable [
-            (mkSetLznBinding "n" mappings.lspDocumentSymbols "<cmd>Telescope lsp_document_symbols<CR>")
-            (mkSetLznBinding "n" mappings.lspWorkspaceSymbols "<cmd>Telescope lsp_workspace_symbols<CR>")
+            (mkKeymap "n" keys.lspDocumentSymbols "<cmd>Telescope lsp_document_symbols<CR>" {desc = mappings.lspDocumentSymbols.description;})
+            (mkKeymap "n" keys.lspWorkspaceSymbols "<cmd>Telescope lsp_workspace_symbols<CR>" {desc = mappings.lspWorkspaceSymbols.description;})
 
-            (mkSetLznBinding "n" mappings.lspReferences "<cmd>Telescope lsp_references<CR>")
-            (mkSetLznBinding "n" mappings.lspImplementations "<cmd>Telescope lsp_implementations<CR>")
-            (mkSetLznBinding "n" mappings.lspDefinitions "<cmd>Telescope lsp_definitions<CR>")
-            (mkSetLznBinding "n" mappings.lspTypeDefinitions "<cmd>Telescope lsp_type_definitions<CR>")
-            (mkSetLznBinding "n" mappings.diagnostics "<cmd>Telescope diagnostics<CR>")
+            (mkKeymap "n" keys.lspReferences "<cmd>Telescope lsp_references<CR>" {desc = mappings.lspReferences.description;})
+            (mkKeymap "n" keys.lspImplementations "<cmd>Telescope lsp_implementations<CR>" {desc = mappings.lspImplementations.description;})
+            (mkKeymap "n" keys.lspDefinitions "<cmd>Telescope lsp_definitions<CR>" {desc = mappings.lspDefinitions.description;})
+            (mkKeymap "n" keys.lspTypeDefinitions "<cmd>Telescope lsp_type_definitions<CR>" {desc = mappings.lspTypeDefinitions.description;})
+            (mkKeymap "n" keys.diagnostics "<cmd>Telescope diagnostics<CR>" {desc = mappings.diagnostics.description;})
           ])
-          ++ (
-            optionals config.vim.treesitter.enable [
-              (mkSetLznBinding "n" mappings.treesitter "<cmd>Telescope treesitter<CR>")
-            ]
-          )
-          ++ (
-            optionals config.vim.projects.project-nvim.enable [
-              (mkSetLznBinding "n" mappings.findProjects "<cmd>Telescope projects<CR>")
-            ]
-          );
+          ++ optionals config.vim.treesitter.enable [
+            (mkKeymap "n" keys.treesitter "<cmd>Telescope treesitter<CR>" {desc = mappings.treesitter.description;})
+          ]
+          ++ optionals config.vim.projects.project-nvim.enable [
+            (mkKeymap "n" keys.findProjects "<cmd>Telescope projects<CR>" {desc = mappings.findProjects.description;})
+          ];
       };
 
       binds.whichKey.register = pushDownDefault {


### PR DESCRIPTION
note: we don't need to wait for this PR to release v0.7, I'm putting this up to let yall see if you like the new lib.

adds a less abstracted helper function and removes the horrible ones targeting `vim.keymaps`


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [ ] I have updated the [changelog] as per my changes.
- [ ] I have tested, and self-reviewed my code.
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`).
  - [ ] My code conforms to the [editorconfig] configuration of the project.
  - [ ] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [ ] `.#nix` (default package)
  - [ ] `.#maximal`
  - [ ] `.#docs-html`
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
