### PR TITLE
languages/typst: fix callback error with non-english characters

### DIFF
--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -22,7 +22,7 @@
         lspconfig.typst_lsp.setup {
           capabilities = capabilities,
           on_attach = function(client, bufnr)
-            -- Disable semantic tokens if the issue persists
+            -- Disable semantic tokens as a workaround for a semantic token error when using non-english characters
             client.server_capabilities.semanticTokensProvider = nil
           end,
           cmd = ${
@@ -40,7 +40,7 @@
           capabilities = capabilities,
           single_file_support = true,
           on_attach = function(client, bufnr)
-            -- Disable semantic tokens if the issue persists
+            -- Disable semantic tokens as a workaround for a semantic token error when using non-english characters
             client.server_capabilities.semanticTokensProvider = nil
           end,
           cmd = ${

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -21,7 +21,10 @@
       lspConfig = ''
         lspconfig.typst_lsp.setup {
           capabilities = capabilities,
-          on_attach = default_on_attach,
+          on_attach = function(client, bufnr)
+            -- Disable semantic tokens if the issue persists
+            client.server_capabilities.semanticTokensProvider = nil
+          end,
           cmd = ${
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package
@@ -36,7 +39,10 @@
         lspconfig.tinymist.setup {
           capabilities = capabilities,
           single_file_support = true,
-          on_attach = default_on_attach,
+          on_attach = function(client, bufnr)
+            -- Disable semantic tokens if the issue persists
+            client.server_capabilities.semanticTokensProvider = nil
+          end,
           cmd = ${
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package


### PR DESCRIPTION
Applies widespread solution to stop annoying error message in typst whenever using non-english characters.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

nix fmt is temporarlity broken on my system (or I'm sleep deprived and used it wrong. Could be), but I have used the nix formatter within the file and it should pass the formatter checks.
 
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
