### PR TITLE
lazy: add assertions against common problems

### DIFF
--- a/modules/wrapper/lazy/config.nix
+++ b/modules/wrapper/lazy/config.nix
@@ -88,7 +88,7 @@
         if spec.load != null
         then
           mkLuaInline ''
-            funcion()
+            function(name)
               ${spec.load}
             end
           ''

--- a/modules/wrapper/lazy/config.nix
+++ b/modules/wrapper/lazy/config.nix
@@ -76,7 +76,7 @@
     };
   lznSpecs = mapAttrsToList toLuaLznSpec cfg.plugins;
 
-  pluginPackages = mapAttrsToList (_: plugin: plugin.package) cfg.plugins;
+  pluginPackages = filter (x: x != null) (mapAttrsToList (_: plugin: plugin.package) cfg.plugins);
 
   specToNotLazyConfig = _: spec: ''
     do

--- a/modules/wrapper/lazy/config.nix
+++ b/modules/wrapper/lazy/config.nix
@@ -3,7 +3,7 @@
   config,
   ...
 }: let
-  inherit (builtins) toJSON typeOf head length filter concatLists concatStringsSep;
+  inherit (builtins) toJSON typeOf head length filter concatLists concatStringsSep tryEval;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.generators) mkLuaInline;
@@ -21,10 +21,36 @@
         else keySpec.action;
     };
 
-  toLuaLznSpec = name: spec:
+  toLuaLznSpec = name: spec: let
+    packageName =
+      if typeOf spec.package == "string"
+      then spec.package
+      else if (spec.package ? pname && (tryEval spec.package.pname).success)
+      then spec.package.pname
+      else spec.package.name;
+  in
     (removeAttrs spec ["package" "setupModule" "setupOpts" "keys"])
     // {
-      "@1" = name;
+      "@1" =
+        if spec.package != null && packageName != name && spec.load == null
+        then
+          abort ''
+            vim.lazy.plugins.${name} does not match the package name ${packageName}.
+
+            Please either:
+            - rename it to vim.lazy.plugins.${packageName}, or
+            - if you intend to use a custom loader, specify a
+              vim.lazy.plugins.${name}.load function.
+          ''
+        else if spec.package == null && spec.load == null
+        then
+          abort ''
+            vim.lazy.plugins.${name} has null package but no load function given.
+
+            Please either specify a package, or (if you know what you're doing) provide a
+            custom load function.
+          ''
+        else name;
       beforeAll =
         if spec.beforeAll != null
         then

--- a/modules/wrapper/lazy/lazy.nix
+++ b/modules/wrapper/lazy/lazy.nix
@@ -173,7 +173,7 @@
         description = ''
           Lua code to override the `vim.g.lz_n.load()` function for a single plugin.
 
-          This will be wrapped in a function.
+          This will be wrapped in a `function(name) ... end`.
         '';
       };
     };

--- a/modules/wrapper/lazy/lazy.nix
+++ b/modules/wrapper/lazy/lazy.nix
@@ -67,7 +67,11 @@
     options = {
       package = mkOption {
         type = nullOr pluginType;
-        description = "Plugin package. If null, a custom load function must be provided";
+        description = ''
+          Plugin package.
+
+          If null, a custom load function must be provided
+        '';
       };
 
       setupModule = mkOption {

--- a/modules/wrapper/lazy/lazy.nix
+++ b/modules/wrapper/lazy/lazy.nix
@@ -66,8 +66,8 @@
   lznPluginType = submodule {
     options = {
       package = mkOption {
-        type = pluginType;
-        description = "Plugin package";
+        type = nullOr pluginType;
+        description = "Plugin package. If null, a custom load function must be provided";
       };
 
       setupModule = mkOption {


### PR DESCRIPTION
- checks that the provided name (`vim.lazy.plugins.<name>`) is same as package.pname
  - if a custom load function is given this check is bypassed because they probably know what they're doing
- allow null package for more advanced uses (like auto-loading nvim's optional plugins)

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [ ] I have updated the [changelog] as per my changes.
- [x] I have tested, and self-reviewed my code.
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`).
  - [x] My code conforms to the [editorconfig] configuration of the project.
  - [x] My changes are consistent with the rest of the codebase.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual.
  - [ ] _(For breaking changes)_ I have included a migration guide.
- Package(s) built:
  - [x] `.#nix` (default package)
  - [ ] `.#maximal`
  - [ ] `.#docs-html`
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
