### PR TITLE
wrapper/lazy: allow luaInline as a type in keys

### DIFF
--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -6,7 +6,7 @@
   inherit (lib.options) mkOption;
   inherit (lib.attrsets) attrNames mapAttrs' filterAttrs nameValuePair;
   inherit (lib.strings) hasPrefix removePrefix;
-  inherit (lib.types) submodule either package enum str lines attrsOf anything listOf nullOr;
+  inherit (lib.types) submodule either package enum str lines anything listOf nullOr;
 
   # Get the names of all flake inputs that start with the given prefix.
   fromInputs = {

--- a/modules/wrapper/lazy/config.nix
+++ b/modules/wrapper/lazy/config.nix
@@ -97,7 +97,7 @@
       keys =
         if typeOf spec.keys == "list" && length spec.keys > 0 && typeOf (head spec.keys) == "set"
         then map toLuaLznKeySpec (filter (keySpec: keySpec.key != null) spec.keys)
-        # empty list or str or (listOf str)
+        # empty list, str, (listOf str), luaInline or (listOf luaInline)
         else spec.keys;
     };
   lznSpecs = mapAttrsToList toLuaLznSpec cfg.plugins;

--- a/modules/wrapper/lazy/lazy.nix
+++ b/modules/wrapper/lazy/lazy.nix
@@ -1,7 +1,7 @@
 {lib, ...}: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) enum listOf submodule nullOr str bool int attrsOf anything either oneOf lines;
-  inherit (lib.nvim.types) pluginType;
+  inherit (lib.nvim.types) pluginType luaInline;
   inherit (lib.nvim.config) mkBool;
 
   lznKeysSpec = submodule {
@@ -135,7 +135,7 @@
       };
 
       keys = mkOption {
-        type = nullOr (oneOf [str (listOf lznKeysSpec) (listOf str)]);
+        type = nullOr (oneOf [(listOf lznKeysSpec) str (listOf str) luaInline (listOf luaInline)]);
         default = null;
         example = ''
           keys = [


### PR DESCRIPTION
One way of using keys is `{ "<C-x>", mode = "n" }`, which isn't possible in nvf without luaInline