### PR TITLE
languages/haskell: fix DAP command definition

### DIFF
--- a/modules/plugins/languages/haskell.nix
+++ b/modules/plugins/languages/haskell.nix
@@ -92,7 +92,7 @@ in {
                 cmd = ${
                 if isList cfg.dap.package
                 then expToLua cfg.dap.package
-                else ''${cfg.dap.package}/bin/haskell-debug-adapter''
+                else ''{"${cfg.dap.package}/bin/haskell-debug-adapter"}''
               },
               },
             ''}


### PR DESCRIPTION
# What has changed?
#499 had introduced some breakage involving the Haskell DAP option. Turns out it was because I forgot to encapsulate the command with `{""}`. This PR fixes that error so now the DAP doesn't cause issues.

I have fully tested the module, including DAP support and just about any extras I could think of.