### PR TITLE
languages/solidity: init solidity module

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -74,6 +74,7 @@ isMaximal: {
       julia.enable = false;
       vala.enable = false;
       scala.enable = false;
+      solidity.enable = false;
       r.enable = false;
       gleam.enable = false;
       dart.enable = false;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -14,6 +14,7 @@
 [haskell-tools.nvim]: https://github.com/MrcJkb/haskell-tools.nvim
 
 - Add Haskell support under `vim.languages.haskell` using [haskell-tools.nvim].
+- Add Solidity support under `vim.languages.solidity`.
 
 [diniamo](https://github.com/diniamo):
 

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -27,6 +27,7 @@ in {
     ./r.nix
     ./rust.nix
     ./scala.nix
+    ./solidity.nix
     ./sql.nix
     ./svelte.nix
     ./tailwind.nix

--- a/modules/plugins/languages/haskell.nix
+++ b/modules/plugins/languages/haskell.nix
@@ -71,7 +71,7 @@ in {
                 cmd = ${
                 if isList cfg.lsp.package
                 then expToLua cfg.lsp.package
-                else ''{"${cfg.lsp.package}/bin/haskell-language-server-wrapper"}''
+                else ''{"${cfg.lsp.package}/bin/haskell-language-server-wrapper", "--lsp"}''
               },
                 on_attach = function(client, bufnr, ht)
                   default_on_attach(client, bufnr, ht)

--- a/modules/plugins/languages/solidity.nix
+++ b/modules/plugins/languages/solidity.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.vim.languages.solidity;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim) mkGrammarOption;
+in {
+  options.vim.languages.solidity = {
+    enable = mkEnableOption "Solidity support";
+
+    treesitter = {
+      enable = mkEnableOption "Treesitter support for Solidity";
+      package = mkGrammarOption pkgs "solidity";
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (lib.mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
## What have I added?
This adds support for the Solidity language into nvf. LSP support is not on nixpkgs, nor DAP support but the best I could have done (treesitter support) is there.

This also fixes the Haskell LSP command, I have no idea why it didn't use the `--lsp` flag by default.

## Have I tested it?
Yes, treesitter works.