### PR TITLE
nvim-notify: use explicit function for vim.notify

### DIFF
--- a/modules/plugins/ui/notifications/nvim-notify/config.nix
+++ b/modules/plugins/ui/notifications/nvim-notify/config.nix
@@ -16,7 +16,7 @@ in {
       pluginRC.nvim-notify = entryAnywhere ''
         local notify = require("notify")
         notify.setup(${toLuaObject cfg.setupOpts})
-        vim.notify = notify
+        vim.notify = notify.notify
       '';
     };
   };


### PR DESCRIPTION
Avoids [a check](https://github.com/rcarriga/nvim-notify/blob/fbef5d32be8466dd76544a257d3f3dce20082a07/lua/notify/init.lua#L189-L195) that shouldn't exist in the first place. I ran into an issue while developing my plugin where vim.notify would return nil instead of what the other branch would, and it's pretty miraculous I found the problem to be honest. The edge cases the check handles should already be handled by plugins. If nvf some part of nvf relied on this, then that part would break without nvim-notify enabled, and if some part of the user's config relied on this then it would be really annoying if something seemingly unrelated broke when they disabled nvim-notify.