### PR TITLE
languages/markdown: add `render-markdown.nvim` as an extension

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -3,11 +3,15 @@
 [NotAShelf](https://github.com/notashelf):
 
 [typst-preview.nvim]: https://github.com/chomosuke/typst-preview.nvim
+[render-markdown.nvim]: https://github.com/MeanderingProgrammer/render-markdown.nvim
 
 - Add [typst-preview.nvim] under
   `languages.typst.extensions.typst-preview-nvim`.
 
 - Add a search widget to the options page in the nvf manual.
+
+- Add [render-markdown.nvim] under
+  `languages.markdown.extensions.render-markdown-nvim`
 
 [amadaluzia](https://github.com/amadaluzia):
 

--- a/flake.lock
+++ b/flake.lock
@@ -1694,6 +1694,22 @@
         "type": "github"
       }
     },
+    "plugin-render-markdown-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1735525479,
+        "narHash": "sha256-ncFqBv0JITX3pTsLON+HctLUaKXhLRMBUrRWmI8KOSA=",
+        "owner": "MeanderingProgrammer",
+        "repo": "render-markdown.nvim",
+        "rev": "6fbd1491abc104409f119685de5353c35c97c005",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MeanderingProgrammer",
+        "repo": "render-markdown.nvim",
+        "type": "github"
+      }
+    },
     "plugin-rose-pine": {
       "flake": false,
       "locked": {
@@ -2170,6 +2186,7 @@
         "plugin-precognition-nvim": "plugin-precognition-nvim",
         "plugin-project-nvim": "plugin-project-nvim",
         "plugin-registers": "plugin-registers",
+        "plugin-render-markdown-nvim": "plugin-render-markdown-nvim",
         "plugin-rose-pine": "plugin-rose-pine",
         "plugin-rtp-nvim": "plugin-rtp-nvim",
         "plugin-run-nvim": "plugin-run-nvim",

--- a/flake.nix
+++ b/flake.nix
@@ -488,6 +488,11 @@
       flake = false;
     };
 
+    plugin-render-markdown-nvim = {
+      url = "github:MeanderingProgrammer/render-markdown.nvim";
+      flake = false;
+    };
+
     # Minimap
     plugin-minimap-vim = {
       url = "github:wfxr/minimap.vim";


### PR DESCRIPTION
As requested by @deviantsemicolon. Adds render-markdown.nvim to the markdown module as an extension. Ideally the last time we change the language module to avoid making the upcoming language refactor more difficult.