### PR TITLE
git/gitsigns: migrate to `setupOpts`

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -13,6 +13,9 @@
 - Add [render-markdown.nvim] under
   `languages.markdown.extensions.render-markdown-nvim`
 
+- Implement [](#opt-vim.git.gitsigns.setupOpts) for user-specified setup table
+  in gitsigns configuration.
+
 [amadaluzia](https://github.com/amadaluzia):
 
 [haskell-tools.nvim]: https://github.com/MrcJkb/haskell-tools.nvim

--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -7,6 +7,7 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.nvim.binds) addDescriptionsToMappings mkSetExprBinding mkSetLuaBinding pushDownDefault;
   inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.git.gitsigns;
 
@@ -70,7 +71,7 @@ in {
         };
 
         pluginRC.gitsigns = entryAnywhere ''
-          require('gitsigns').setup{}
+          require('gitsigns').setup(${toLuaObject cfg.setupOpts})
         '';
       };
     }

--- a/modules/plugins/git/gitsigns/gitsigns.nix
+++ b/modules/plugins/git/gitsigns/gitsigns.nix
@@ -6,6 +6,7 @@
   inherit (lib.options) mkEnableOption;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.nvim.binds) mkMappingOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
 in {
   imports = [
     (mkRenamedOptionModule ["vim" "git" "gitsigns" "codeActions" "vim" "gitsigns" "codeActions"] ["vim" "git" "gitsigns" "codeActions" "enable"])
@@ -13,6 +14,7 @@ in {
 
   options.vim.git.gitsigns = {
     enable = mkEnableOption "gitsigns" // {default = config.vim.git.enable;};
+    setupOpts = mkPluginSetupOption "gitsigns" {};
 
     codeActions.enable = mkEnableOption "gitsigns codeactions through null-ls";
 


### PR DESCRIPTION
Adds `vim.git.gitsigns.setupOpts` for user-specified setup table. We do not provide any defaults, as we did not do so previously and users may add their own options easily.