### PR TITLE
telescope: workaround nixpkgs extensions breaking :Telescope

### DIFF
--- a/modules/plugins/utility/telescope/config.nix
+++ b/modules/plugins/utility/telescope/config.nix
@@ -22,6 +22,12 @@ in {
         package = "telescope";
         setupModule = "telescope";
         inherit (cfg) setupOpts;
+
+        # HACK: workaround until https://github.com/NotAShelf/nvf/issues/535 gets resolved
+        before = ''
+          vim.g.loaded_telescope = nil
+        '';
+
         after = ''
           local telescope = require("telescope")
           ${optionalString config.vim.ui.noice.enable "telescope.load_extension('noice')"}


### PR DESCRIPTION
force a reload when telescope is loaded to workaround #535

doesn't fully address the issue (telescope is still in a loaded-but-not-configured state until
keybind is triggered)


## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` (default package)
  - [ ] `.#maximal`
  - [ ] `.#docs-html` (manual, must build)
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
