### PR TITLE
languages/haskell: specify lsp flag

### DIFF
--- a/modules/plugins/languages/haskell.nix
+++ b/modules/plugins/languages/haskell.nix
@@ -71,7 +71,7 @@ in {
                 cmd = ${
                 if isList cfg.lsp.package
                 then expToLua cfg.lsp.package
-                else ''{"${cfg.lsp.package}/bin/haskell-language-server-wrapper"}''
+                else ''{"${cfg.lsp.package}/bin/haskell-language-server-wrapper", "--lsp"}''
               },
                 on_attach = function(client, bufnr, ht)
                   default_on_attach(client, bufnr, ht)


### PR DESCRIPTION
### What is this?

This specifies the `--lsp` flag when running `haskell-language-server-wrapper`. This allows HLS to run as an LSP instead of checking the file. Another silly one line fix :^).