### PR TITLE
notes/obsidian: remove default dir-value

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -39,6 +39,5 @@
 
 [LilleAila](https://github.com/LilleAila):
 
-[obsidian.nvim](https://github.com/epwalsh/obsidian.nvim)
-
-- Remove `vim.notes.obsidian.setupOpts.dir`. Fixes issue with setting the workspace directory.
+- Remove `vim.notes.obsidian.setupOpts.dir`, which was set by default. 
+  Fixes issue with setting the workspace directory.

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -36,3 +36,9 @@
 
 - Add [aerial.nvim]
 - Add [nvim-ufo]
+
+[LilleAila](https://github.com/LilleAila):
+
+[obsidian.nvim](https://github.com/epwalsh/obsidian.nvim)
+
+- Remove `vim.notes.obsidian.setupOpts.dir`. Fixes issue with setting the workspace directory.

--- a/modules/plugins/notes/obsidian/obsidian.nix
+++ b/modules/plugins/notes/obsidian/obsidian.nix
@@ -24,12 +24,6 @@ in {
       enable = mkEnableOption "complementary neovim plugins for Obsidian editor";
 
       setupOpts = mkPluginSetupOption "Obsidian.nvim" {
-        dir = mkOption {
-          type = str;
-          default = "~/my-vault";
-          description = "Obsidian vault directory";
-        };
-
         daily_notes = {
           folder = mkOption {
             type = nullOr str;


### PR DESCRIPTION
As the `obsidian.nvim` readme describes, the `dir` option is provided for backwards compatibility. The problem with this is that because `nvf` defines this value (*with* a default value), means that it overrides the `workspaces` option, making it impossible to use. Removing it would keep the same functionality, just without the default.