### PR TITLE
languages/markdown: add prettierd formatter

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -51,3 +51,4 @@
 
 - Remove `vim.notes.obsidian.setupOpts.dir`, which was set by default. Fixes
   issue with setting the workspace directory.
+- Add `"prettierd"` as a formatter option in `vim.languages.markdown.format.type`.

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -46,6 +46,18 @@
         )
       '';
     };
+    prettierd = {
+      package = pkgs.prettierd;
+      nullConfig = ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.formatting.prettierd.with({
+            filetypes = ${expToLua (concatLists [cfg.format.extraFiletypes ["markdown"]])},
+            command = "${cfg.format.package}/bin/prettierd",
+          })
+        )
+      '';
+    };
   };
 in {
   options.vim.languages.markdown = {


### PR DESCRIPTION
Adds prettierd as a formatter option.
This would be made a lot easier by #382, but before that is complete, this looks like the best way to do it.