### PR TITLE
snippets/luasnip: add setupOpts

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -51,3 +51,5 @@
 
 - Remove `vim.notes.obsidian.setupOpts.dir`, which was set by default. Fixes
   issue with setting the workspace directory.
+- Add `vim.snippets.luasnip.setupOpts`, which was previously missing.
+- Add a trigger event for luasnip lazy-loading

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -52,4 +52,3 @@
 - Remove `vim.notes.obsidian.setupOpts.dir`, which was set by default. Fixes
   issue with setting the workspace directory.
 - Add `vim.snippets.luasnip.setupOpts`, which was previously missing.
-- Add a trigger event for luasnip lazy-loading

--- a/modules/plugins/snippets/luasnip/config.nix
+++ b/modules/plugins/snippets/luasnip/config.nix
@@ -11,10 +11,13 @@ in {
     vim = {
       lazy.plugins.luasnip = {
         package = "luasnip";
+        
         lazy = true;
-        after = cfg.loaders;
+        
         setupModule = "luasnip";
         inherit (cfg) setupOpts;
+        
+        after = cfg.loaders;
       };
       startPlugins = cfg.providers;
       autocomplete.nvim-cmp = {

--- a/modules/plugins/snippets/luasnip/config.nix
+++ b/modules/plugins/snippets/luasnip/config.nix
@@ -9,12 +9,12 @@
 in {
   config = mkIf cfg.enable {
     vim = {
-      lazy.plugins = {
-        luasnip = {
-          package = "luasnip";
-          lazy = true;
-          after = cfg.loaders;
-        };
+      lazy.plugins.luasnip = {
+        package = "luasnip";
+        event = "BufEnter";
+        after = cfg.loaders;
+        setupModule = "luasnip";
+        inherit (cfg) setupOpts;
       };
       startPlugins = cfg.providers;
       autocomplete.nvim-cmp = {

--- a/modules/plugins/snippets/luasnip/config.nix
+++ b/modules/plugins/snippets/luasnip/config.nix
@@ -11,12 +11,12 @@ in {
     vim = {
       lazy.plugins.luasnip = {
         package = "luasnip";
-        
+
         lazy = true;
-        
+
         setupModule = "luasnip";
         inherit (cfg) setupOpts;
-        
+
         after = cfg.loaders;
       };
       startPlugins = cfg.providers;

--- a/modules/plugins/snippets/luasnip/config.nix
+++ b/modules/plugins/snippets/luasnip/config.nix
@@ -11,7 +11,7 @@ in {
     vim = {
       lazy.plugins.luasnip = {
         package = "luasnip";
-        event = "BufEnter";
+        lazy = true;
         after = cfg.loaders;
         setupModule = "luasnip";
         inherit (cfg) setupOpts;

--- a/modules/plugins/snippets/luasnip/luasnip.nix
+++ b/modules/plugins/snippets/luasnip/luasnip.nix
@@ -1,7 +1,7 @@
 {lib, ...}: let
   inherit (lib.options) mkEnableOption mkOption literalExpression literalMD;
   inherit (lib.types) listOf lines;
-  inherit (lib.nvim.types) pluginType;
+  inherit (lib.nvim.types) pluginType mkPluginSetupOption;
 in {
   options.vim.snippets.luasnip = {
     enable = mkEnableOption "luasnip";
@@ -32,5 +32,7 @@ in {
         ```
       '';
     };
+
+    setupOpts = mkPluginSetupOption "LuaSnip" {};
   };
 }

--- a/modules/plugins/snippets/luasnip/luasnip.nix
+++ b/modules/plugins/snippets/luasnip/luasnip.nix
@@ -33,6 +33,8 @@ in {
       '';
     };
 
-    setupOpts = mkPluginSetupOption "LuaSnip" {};
+    setupOpts = mkPluginSetupOption "LuaSnip" {
+      enable_autosnippets = mkEnableOption "autosnippets";
+    };
   };
 }


### PR DESCRIPTION
Added setupOpts to `vim.snippets.luasnip`.

Right now, there is a soft dependency on nvim-cmp, because setting `lazy = true`, makes it so that it won't load if nvim-cmp is not present and configured. I will not fix that in this pr, as users can set `vim.lazy.plugins.luasnip.event = "BufEnter"` themselves.