### PR TITLE
languages/ruby: add ruby support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -80,6 +80,7 @@ isMaximal: {
       ocaml.enable = false;
       elixir.enable = false;
       haskell.enable = false;
+      ruby.enable = false;
 
       tailwind.enable = false;
       svelte.enable = false;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -57,3 +57,9 @@
 [kaktu5](https://github.com/kaktu5):
 
 - Add WGSL support under `vim.languages.wgsl`.
+
+[tomasguinzburg](https://github.com/tomasguinzburg):
+
+[solargraph]: https://github.com/castwide/solargraph
+
+- Add Ruby support under `vim.languages.ruby` using [solargraph].

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -39,6 +39,7 @@ in {
     ./nu.nix
     ./odin.nix
     ./wgsl.nix
+    ./ruby.nix
   ];
 
   options.vim.languages = {

--- a/modules/plugins/languages/ruby.nix
+++ b/modules/plugins/languages/ruby.nix
@@ -1,0 +1,152 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.types) either listOf package str enum;
+  inherit (lib.nvim.languages) diagnosticsToLua;
+
+  cfg = config.vim.languages.ruby;
+
+  defaultServer = "rubyserver";
+  servers = {
+    rubyserver = {
+      package = pkgs.rubyPackages.solargraph;
+      lspConfig = ''
+        lspconfig.solargraph.setup {
+          capabilities = capabilities,
+          on_attach = attach_keymaps,
+          flags = {
+            debounce_text_changes = 150,
+          },
+          cmd = { "${pkgs.solargraph}/bin/solargraph", "stdio" }
+        }
+      '';
+    };
+  };
+
+  # testing
+
+  defaultFormat = "rubocop";
+  formats = {
+    rubocop = {
+      package = pkgs.rubyPackages.rubocop;
+      nullConfig = ''
+        local conditional = function(fn)
+          local utils = require("null-ls.utils").make_conditional_utils()
+          return fn(utils)
+        end
+
+        table.insert(
+          ls_sources,
+          null_ls.builtins.formatting.rubocop.with({
+            command="${pkgs.bundler}/bin/bundle",
+            args = vim.list_extend(
+              {"exec", "rubocop", "-a" },
+              null_ls.builtins.formatting.rubocop._opts.args
+            ),
+          })
+        )
+      '';
+    };
+  };
+
+  defaultDiagnosticsProvider = ["rubocop"];
+  diagnosticsProviders = {
+    rubocop = {
+      package = pkgs.rubyPackages.rubocop;
+      nullConfig = pkg: ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.diagnostics.rubocop.with({
+            command = "${lib.getExe pkg}",
+          })
+        )
+      '';
+    };
+  };
+in {
+  options.vim.languages.ruby = {
+    enable = mkEnableOption "Ruby language support";
+
+    treesitter = {
+      enable = mkEnableOption "Ruby treesitter" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "ruby";
+    };
+
+    lsp = {
+      enable = mkEnableOption "Ruby LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        type = enum (attrNames servers);
+        default = defaultServer;
+        description = "Ruby LSP server to use";
+      };
+
+      package = mkOption {
+        type = either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+        description = "Ruby LSP server package, or the command to run as a list of strings";
+      };
+    };
+
+    format = {
+      enable = mkEnableOption "Ruby formatter support" // {default = config.vim.languages.enableFormat;};
+
+      type = mkOption {
+        type = enum (attrNames formats);
+        default = defaultFormat;
+        description = "Ruby formatter to use";
+      };
+
+      package = mkOption {
+        type = package;
+        default = formats.${cfg.format.type}.package;
+        description = "Ruby formatter package";
+      };
+    };
+
+    extraDiagnostics = {
+      enable =
+        mkEnableOption "Ruby extra diagnostics support"
+        // {default = config.vim.languages.enableExtraDiagnostics;};
+
+      types = diagnostics {
+        langDesc = "Ruby";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.ruby-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+
+    (mkIf cfg.format.enable {
+      vim.lsp.null-ls.enable = true;
+      vim.lsp.null-ls.sources.ruby-format = formats.${cfg.format.type}.nullConfig;
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.lsp.null-ls.enable = true;
+      vim.lsp.null-ls.sources = diagnosticsToLua {
+        lang = "ruby";
+        config = cfg.extraDiagnostics.types;
+        inherit diagnosticsProviders;
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Ruby is a pain, but I think some basic support is better than nothing and can be improved on.
At the moment, formatters only work if .rubocop.yml contains no extensions, as most of those are not available through nixpkgs yet.

This is my first nix PR so please be thorough.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [X] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [X] `.#nix` (default package)
  - [X] `.#maximal`
  - [X] `.#docs-html` (manual, must build)
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
