### PR TITLE
languages/python: add ruff formatter

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -41,8 +41,8 @@
 
 [horriblename](https://github.com/horriblename):
 
-[aerial.nvim](https://github.com/stevearc/aerial.nvim)
-[nvim-ufo](https://github.com/kevinhwang91/nvim-ufo)
+[aerial.nvim]: (https://github.com/stevearc/aerial.nvim)
+[nvim-ufo]: (https://github.com/kevinhwang91/nvim-ufo)
 
 - Add [aerial.nvim]
 - Add [nvim-ufo]
@@ -52,7 +52,8 @@
 - Remove `vim.notes.obsidian.setupOpts.dir`, which was set by default. Fixes
   issue with setting the workspace directory.
 - Add `vim.snippets.luasnip.setupOpts`, which was previously missing.
-- Add `"prettierd"` as a formatter option in `vim.languages.markdown.format.type`.
+- Add `"prettierd"` as a formatter option in
+  `vim.languages.markdown.format.type`.
 
 [kaktu5](https://github.com/kaktu5):
 
@@ -63,3 +64,9 @@
 [solargraph]: https://github.com/castwide/solargraph
 
 - Add Ruby support under `vim.languages.ruby` using [solargraph].
+
+[thamenato](https://github.com/thamenato):
+
+[ruff]: (https://github.com/astral-sh/ruff)
+
+- Add [ruff] as a formatter option in `vim.languages.python.format.type`.

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -108,7 +108,13 @@
     };
 
     ruff = {
-      package = pkgs.ruff;
+      package = pkgs.writeShellApplication {
+        name =  "ruff";
+        runtimeInputs = [pkgs.ruff];
+        text = ''
+          ruff format -
+        '';
+      };
       nullConfig = ''
         table.insert(
           ls_sources,

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -106,6 +106,18 @@
         )
       '';
     };
+
+    ruff = {
+      package = pkgs.ruff;
+      nullConfig = ''
+        table.insert(
+          ls_sources,
+          null_ls.builtins.formatting.ruff.with({
+            command = "${cfg.format.package}/bin/ruff",
+          })
+        )
+      '';
+    };
   };
 
   defaultDebugger = "debugpy";

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -109,7 +109,7 @@
 
     ruff = {
       package = pkgs.writeShellApplication {
-        name =  "ruff";
+        name = "ruff";
         runtimeInputs = [pkgs.ruff];
         text = ''
           ruff format -


### PR DESCRIPTION
This PR adds support to using `ruff` as a formatter for Python.