### PR TITLE
languages/nix: remove hardcoded indentation options

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -26,6 +26,11 @@
 
 - Deprecate rnix-lsp as it has been abandoned and archived upstream.
 
+- Hardcoded indentation values for the Nix language module have been removed. To
+  replicate previous behaviour, you must either consolidate Nix indentation in
+  your Editorconfig configuration, or use an autocommand to set indentation
+  values for buffers with the Nix filetype.
+
 [amadaluzia](https://github.com/amadaluzia):
 
 [haskell-tools.nvim]: https://github.com/MrcJkb/haskell-tools.nvim

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -187,17 +187,6 @@ in {
           '';
         }
       ];
-      vim.pluginRC.nix = ''
-        vim.api.nvim_create_autocmd("FileType", {
-          pattern = "nix",
-          callback = function(opts)
-            local bo = vim.bo[opts.buf]
-            bo.tabstop = 2
-            bo.shiftwidth = 2
-            bo.softtabstop = 2
-          end
-        })
-      '';
     }
 
     (mkIf cfg.treesitter.enable {


### PR DESCRIPTION
Removes the hardcoded 2-wide indentation from Nix filetype. To replicate previous behaviour, user must consolidate indentation behaviour to the Editorconfig configuration, or use autocommands in raw lua configuration.

Example:

```lua
vim.api.nvim_create_autocmd("FileType", {
  pattern = "nix",
  callback = function(opts)
  	local bo = vim.bo[opts.buf]
  	bo.tabstop = 2
  	bo.shiftwidth = 2
  end
 })
```

While feedback for this "sane" default has been mostly positive, nvf has no place setting opinionated defaults that are difficult to override. Fixes #564 