### PR TITLE
highlight: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -102,6 +102,7 @@
   - `mini.trailspace`
   - `mini.visits`
 - Add [fzf-lua](https://github.com/ibhagwan/fzf-lua) in `vim.fzf-lua`
+- Add options to define highlights under `vim.highlight`
 
 [kaktu5](https://github.com/kaktu5):
 

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -102,7 +102,7 @@
   - `mini.trailspace`
   - `mini.visits`
 - Add [fzf-lua](https://github.com/ibhagwan/fzf-lua) in `vim.fzf-lua`
-- Add options to define highlights under `vim.highlight`
+- Add options to define highlights under [](#opt-vim.highlight)
 
 [kaktu5](https://github.com/kaktu5):
 

--- a/modules/neovim/init/default.nix
+++ b/modules/neovim/init/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./basic.nix
     ./debug.nix
+    ./highlight.nix
     ./spellcheck.nix
   ];
 }

--- a/modules/neovim/init/highlight.nix
+++ b/modules/neovim/init/highlight.nix
@@ -3,11 +3,11 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkOption literalExpression;
+  inherit (lib.options) mkOption;
   inherit (lib.types) nullOr attrsOf listOf submodule bool ints str enum;
-  inherit (lib.strings) hasPrefix concatStringsSep;
+  inherit (lib.strings) hasPrefix concatLines;
   inherit (lib.attrsets) mapAttrsToList;
-  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.dag) entryBetween;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.nvim.types) hexColor;
 
@@ -15,18 +15,18 @@
     mkOption {
       type = nullOr hexColor;
       default = null;
+      example = "#ebdbb2";
       description = ''
         The ${target} color to use. Written as color name or hex "#RRGGBB".
       '';
-      example = "#ebdbb2";
     };
 
   mkBoolOption = name:
     mkOption {
       type = nullOr bool;
       default = null;
-      description = ''Whether to enable ${name}'';
       example = false;
+      description = "Whether to enable ${name}";
     };
 
   cfg = config.vim.highlight;
@@ -98,14 +98,14 @@ in {
       };
     });
     default = {};
-    description = "Custom highlight to apply";
-    example = literalExpression ''
+    example = ''
       {
         SignColumn = {
           bg = "#282828";
         };
       }
     '';
+    description = "Custom highlights to apply";
   };
 
   config = {
@@ -116,6 +116,6 @@ in {
         )
         cfg;
     in
-      entryAnywhere (concatStringsSep "\n" highlights);
+      entryBetween ["lazyConfigs" "pluginConfigs" "extraPluginConfigs"] ["theme"] (concatLines highlights);
   };
 }

--- a/modules/neovim/init/highlight.nix
+++ b/modules/neovim/init/highlight.nix
@@ -92,7 +92,7 @@ in {
             "NONE"
           ]));
           default = null;
-          description = "The cterm arguments to use. See :h highlight-args";
+          description = "The cterm arguments to use. See ':h highlight-args'";
         };
         force = mkBoolOption "force update";
       };

--- a/modules/neovim/init/highlight.nix
+++ b/modules/neovim/init/highlight.nix
@@ -4,7 +4,7 @@
   ...
 }: let
   inherit (lib.options) mkOption literalExpression;
-  inherit (lib.types) nullOr attrsOf listOf submodule bool ints str;
+  inherit (lib.types) nullOr attrsOf listOf submodule bool ints str enum;
   inherit (lib.strings) hasPrefix concatStringsSep;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.nvim.dag) entryAnywhere;
@@ -75,7 +75,22 @@ in {
           description = "The cterm background color to use";
         };
         cterm = mkOption {
-          type = nullOr (listOf str);
+          type = nullOr (listOf (enum [
+            "bold"
+            "underline"
+            "undercurl"
+            "underdouble"
+            "underdotted"
+            "underdashed"
+            "strikethrough"
+            "reverse"
+            "inverse"
+            "italic"
+            "standout"
+            "altfont"
+            "nocombine"
+            "NONE"
+          ]));
           default = null;
           description = "The cterm arguments to use. See :h highlight-args";
         };

--- a/modules/neovim/init/highlight.nix
+++ b/modules/neovim/init/highlight.nix
@@ -1,0 +1,106 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkOption literalExpression;
+  inherit (lib.types) nullOr attrsOf listOf submodule bool ints str;
+  inherit (lib.strings) hasPrefix concatStringsSep;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.types) hexColor;
+
+  mkColorOption = target:
+    mkOption {
+      type = nullOr hexColor;
+      default = null;
+      description = ''
+        The ${target} color to use. Written as color name or hex "#RRGGBB".
+      '';
+      example = "#ebdbb2";
+    };
+
+  mkBoolOption = name:
+    mkOption {
+      type = nullOr bool;
+      default = null;
+      description = ''Whether to enable ${name}'';
+      example = false;
+    };
+
+  cfg = config.vim.highlight;
+in {
+  options.vim.highlight = mkOption {
+    type = attrsOf (submodule {
+      # See :h nvim_set_hl
+      options = {
+        bg = mkColorOption "background";
+        fg = mkColorOption "foreground";
+        sp = mkColorOption "special";
+        blend = mkOption {
+          type = nullOr (ints.between 0 100);
+          default = null;
+          description = "Blend as an integer between 0 and 100";
+        };
+        bold = mkBoolOption "bold";
+        standout = mkBoolOption "standout";
+        underline = mkBoolOption "underline";
+        undercurl = mkBoolOption "undercurl";
+        underdouble = mkBoolOption "underdouble";
+        underdotted = mkBoolOption "underdotted";
+        underdashed = mkBoolOption "underdashed";
+        strikethrough = mkBoolOption "strikethrough";
+        italic = mkBoolOption "italic";
+        reverse = mkBoolOption "reverse";
+        nocombine = mkBoolOption "nocombine";
+        link = mkOption {
+          type = nullOr str;
+          default = null;
+          description = "The name of another highlight group to link to";
+        };
+        default = mkOption {
+          type = nullOr bool;
+          default = null;
+          description = "Don't override existing definition";
+        };
+        ctermfg = mkOption {
+          type = nullOr str;
+          default = null;
+          description = "The cterm foreground color to use";
+        };
+        ctermbg = mkOption {
+          type = nullOr str;
+          default = null;
+          description = "The cterm background color to use";
+        };
+        cterm = mkOption {
+          type = nullOr (listOf str);
+          default = null;
+          description = "The cterm arguments to use. See :h highlight-args";
+        };
+        force = mkBoolOption "force update";
+      };
+    });
+    default = {};
+    description = "Custom highlight to apply";
+    example = literalExpression ''
+      {
+        SignColumn = {
+          bg = "#282828";
+        };
+      }
+    '';
+  };
+
+  config = {
+    vim.luaConfigRC.highlight = let
+      highlights =
+        mapAttrsToList (
+          name: value: ''vim.api.nvim_set_hl(0, ${toLuaObject name}, ${toLuaObject value})''
+        )
+        cfg;
+    in
+      entryAnywhere (concatStringsSep "\n" highlights);
+  };
+}

--- a/modules/neovim/init/highlight.nix
+++ b/modules/neovim/init/highlight.nix
@@ -98,13 +98,11 @@ in {
       };
     });
     default = {};
-    example = ''
-      {
-        SignColumn = {
-          bg = "#282828";
-        };
-      }
-    '';
+    example = {
+      SignColumn = {
+        bg = "#282828";
+      };
+    };
     description = "Custom highlights to apply";
   };
 


### PR DESCRIPTION
Creates options for configuring highlight groups, mirroring the options available in `nvim_set_hl`.