### PR TITLE
languages/zig: Added dap support

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -122,3 +122,8 @@
 [ruff]: (https://github.com/astral-sh/ruff)
 
 - Add [ruff] as a formatter option in `vim.languages.python.format.type`.
+
+[ARCIII](https://github.com/ArmandoCIII):
+
+- Add `vim.languages.zig.dap` support through pkgs.lldb dap adapter.
+  Code Inspiration from `vim.languages.clang.dap` implementation.

--- a/modules/plugins/languages/zig.nix
+++ b/modules/plugins/languages/zig.nix
@@ -89,19 +89,21 @@ in {
 
     dap = {
       enable = mkOption {
-        description = "Enable Zig Debug Adapter";
         type = bool;
         default = config.vim.languages.enableDAP;
+        description = "Enable Zig Debug Adapter";
       };
+
       debugger = mkOption {
-        description = "Zig debugger to use";
         type = enum (attrNames debuggers);
         default = defaultDebugger;
+        description = "Zig debugger to use";
       };
+
       package = mkOption {
-        description = "Zig debugger package.";
         type = package;
         default = debuggers.${cfg.dap.debugger}.package;
+        description = "Zig debugger package.";
       };
     };
   };

--- a/modules/plugins/languages/zig.nix
+++ b/modules/plugins/languages/zig.nix
@@ -8,9 +8,11 @@
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge mkDefault;
   inherit (lib.lists) isList;
-  inherit (lib.types) either listOf package str enum;
+  inherit (lib.types) bool either listOf package str enum;
   inherit (lib.nvim.lua) expToLua;
   inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.zig;
 
   defaultServer = "zls";
   servers = {
@@ -31,7 +33,35 @@
     };
   };
 
-  cfg = config.vim.languages.zig;
+  # TODO: dap.adapter.lldb is duplicated when enabling the
+  # vim.languages.clang.dap module. This does not cause
+  # breakage... but could be cleaner.
+  defaultDebugger = "lldb-vscode";
+  debuggers = {
+    lldb-vscode = {
+      package = pkgs.lldb;
+      dapConfig = ''
+        dap.adapters.lldb = {
+          type = 'executable',
+          command = '${cfg.dap.package}/bin/lldb-dap',
+          name = 'lldb'
+        }
+        dap.configurations.zig = {
+          {
+            name = 'Launch',
+            type = 'lldb',
+            request = 'launch',
+            program = function()
+              return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+            end,
+            cwd = "''${workspaceFolder}",
+            stopOnEntry = false,
+            args = {},
+          },
+        }
+      '';
+    };
+  };
 in {
   options.vim.languages.zig = {
     enable = mkEnableOption "Zig language support";
@@ -56,6 +86,24 @@ in {
         default = pkgs.zls;
       };
     };
+
+    dap = {
+      enable = mkOption {
+        description = "Enable Zig Debug Adapter";
+        type = bool;
+        default = config.vim.languages.enableDAP;
+      };
+      debugger = mkOption {
+        description = "Zig debugger to use";
+        type = enum (attrNames debuggers);
+        default = defaultDebugger;
+      };
+      package = mkOption {
+        description = "Zig debugger package.";
+        type = package;
+        default = debuggers.${cfg.dap.debugger}.package;
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -75,6 +123,13 @@ in {
 
         # nvf handles autosaving already
         globals.zig_fmt_autosave = mkDefault 0;
+      };
+    })
+
+    (mkIf cfg.dap.enable {
+      vim = {
+        debugger.nvim-dap.enable = true;
+        debugger.nvim-dap.sources.zig-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
       };
     })
   ]);


### PR DESCRIPTION
Implemented DAP support for zig. Included comment regarding redundant `dap.adapters.lldb` code when both clang and zig dap modules are enabled. Redundant code does NOT break when both clang and zig dap are enabled during tests.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer review by performing self-reviews here
before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [x] I have added a section in the manual
  - [x] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` (default package)
  - [x] `.#maximal`
  - [x] `.#docs-html` (manual, must build)
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc