### PR TITLE
treewide: update plugin references by name after npins migration

### DIFF
--- a/modules/plugins/assistant/chatgpt/config.nix
+++ b/modules/plugins/assistant/chatgpt/config.nix
@@ -30,17 +30,19 @@
 in {
   config = mkIf cfg.enable {
     vim = {
-      startPlugins = [
-        "chatgpt"
-      ];
+      startPlugins = ["chatgpt-nvim"];
+
       pluginRC.chagpt = entryAnywhere ''
         require("chatgpt").setup(${toLuaObject cfg.setupOpts})
       '';
-      maps.normal = mkMerge [
-        (mkSetBinding mappings.chatGpt "<cmd>ChatGPT<CR>")
-        maps
-      ];
-      maps.visual = maps;
+
+      maps = {
+        visual = maps;
+        normal = mkMerge [
+          (mkSetBinding mappings.chatGpt "<cmd>ChatGPT<CR>")
+          maps
+        ];
+      };
     };
   };
 }

--- a/modules/plugins/languages/csharp.nix
+++ b/modules/plugins/languages/csharp.nix
@@ -75,8 +75,8 @@
   };
 
   extraServerPlugins = {
-    omnisharp = ["omnisharp-extended"];
-    csharp_ls = ["csharpls-extended"];
+    omnisharp = ["omnisharp-extended-lsp-nvim"];
+    csharp_ls = ["csharpls-extended-lsp-nvim"];
   };
 
   cfg = config.vim.languages.csharp;

--- a/modules/plugins/languages/elixir.nix
+++ b/modules/plugins/languages/elixir.nix
@@ -112,7 +112,7 @@ in {
     })
 
     (mkIf cfg.elixir-tools.enable {
-      vim.startPlugins = ["elixir-tools"];
+      vim.startPlugins = ["elixir-tools-nvim"];
       vim.pluginRC.elixir-tools = entryAnywhere ''
         local elixir = require("elixir")
         local elixirls = require("elixir.elixirls")

--- a/modules/plugins/languages/ts.nix
+++ b/modules/plugins/languages/ts.nix
@@ -230,7 +230,7 @@ in {
 
     # Extensions
     (mkIf cfg.extensions."ts-error-translator".enable {
-      vim.startPlugins = ["ts-error-translator"];
+      vim.startPlugins = ["ts-error-translator-nvim"];
       vim.pluginRC.ts-error-translator = entryAnywhere ''
         require("ts-error-translator").setup(${toLuaObject cfg.extensions.ts-error-translator.setupOpts})
       '';

--- a/modules/plugins/notes/orgmode/config.nix
+++ b/modules/plugins/notes/orgmode/config.nix
@@ -13,9 +13,7 @@ in {
   config = mkIf cfg.enable (mkMerge [
     {
       vim = {
-        startPlugins = [
-          "orgmode-nvim"
-        ];
+        startPlugins = ["orgmode"];
 
         binds.whichKey.register = pushDownDefault {
           "<leader>o" = "+Notes";

--- a/modules/plugins/session/nvim-session-manager/config.nix
+++ b/modules/plugins/session/nvim-session-manager/config.nix
@@ -15,7 +15,7 @@ in {
     vim = {
       startPlugins =
         [
-          "nvim-session-manager"
+          "neovim-session-manager"
           "plenary-nvim"
         ]
         ++ optionals cfg.usePicker ["dressing-nvim"];

--- a/modules/plugins/visuals/cellular-automaton/config.nix
+++ b/modules/plugins/visuals/cellular-automaton/config.nix
@@ -13,7 +13,7 @@
 in {
   config = mkIf cfg.enable {
     vim = {
-      startPlugins = ["cellular-automaton"];
+      startPlugins = ["cellular-automaton-nvim"];
 
       maps.normal = mkBinding cfg.mappings.makeItRain "<cmd>CellularAutomaton make_it_rain<CR>" "Make it rain";
 

--- a/modules/plugins/visuals/tiny-devicons-auto-colors/config.nix
+++ b/modules/plugins/visuals/tiny-devicons-auto-colors/config.nix
@@ -11,7 +11,7 @@
 in {
   config = mkIf cfg.enable {
     vim = {
-      startPlugins = ["tiny-devicons-auto-colors" "nvim-web-devicons"];
+      startPlugins = ["tiny-devicons-auto-colors-nvim" "nvim-web-devicons"];
 
       pluginRC.tiny-devicons-auto-colors = entryAnywhere ''
         require("tiny-devicons-auto-colors").setup(${toLuaObject cfg.setupOpts})


### PR DESCRIPTION
Relevant: #628 

I've updated all plugins which were not updated in the plugins-by-input-name format. As we did not previously enforce a naming convention, some plugins already contain the -nvim or -lua suffix that they were missing. Those have been left out.