### PR TITLE
languages/flutter: update package name to match pin

### DIFF
--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -137,7 +137,7 @@ in {
       vim.startPlugins =
         if ftcfg.enableNoResolvePatch
         then ["flutter-tools-patched"]
-        else ["flutter-tools"];
+        else ["flutter-tools-nvim"];
 
       vim.pluginRC.flutter-tools = entryAnywhere ''
         require('flutter-tools').setup {


### PR DESCRIPTION
Small fix that changes `flutter-tools` to `flutter-tools-nvim`