### PR TITLE
plugins/git: add git-conflict-nvim

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -162,3 +162,7 @@
 [Mr-Helpful](https://github.com/Mr-Helpful)
 
 - Corrects pin names used for nvim themes
+
+[Libadoxon](https://github.com/Libadoxon)
+
+- Add [git-conflict](https://github.com/akinsho/git-conflict.nvim) plugin for resolving git conflicts

--- a/modules/plugins/git/default.nix
+++ b/modules/plugins/git/default.nix
@@ -4,6 +4,7 @@ in {
   imports = [
     ./gitsigns
     ./vim-fugitive
+    ./git-conflict
   ];
 
   options.vim.git = {
@@ -13,6 +14,7 @@ in {
       Enabling this option will enable the following plugins:
       * gitsigns
       * vim-fugitive
+      * git-conflict
     '';
   };
 }

--- a/modules/plugins/git/git-conflict/config.nix
+++ b/modules/plugins/git/git-conflict/config.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetBinding;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.git.git-conflict;
+
+  self = import ./git-conflict.nix {inherit lib config;};
+  gcMappingDefinitions = self.options.vim.git.git-conflict.mappings;
+
+  gcMappings = addDescriptionsToMappings cfg.mappings gcMappingDefinitions;
+in {
+  config = mkIf cfg.enable (mkMerge [
+    {
+      vim = {
+        startPlugins = [pkgs.vimPlugins.git-conflict-nvim];
+
+        maps = {
+          normal = mkMerge [
+            (mkSetBinding gcMappings.ours "<Plug>(git-conflict-ours)")
+            (mkSetBinding gcMappings.theirs "<Plug>(git-conflict-theirs)")
+            (mkSetBinding gcMappings.both "<Plug>(git-conflict-both)")
+            (mkSetBinding gcMappings.none "<Plug>(git-conflict-none)")
+            (mkSetBinding gcMappings.prevConflict "<Plug>(git-conflict-prev-conflict)")
+            (mkSetBinding gcMappings.nextConflict "<Plug>(git-conflict-next-conflict)")
+          ];
+        };
+
+        pluginRC.git-conflict = entryAnywhere ''
+          require('git-conflict').setup(${toLuaObject ({default_mappings = false;} // cfg.setupOpts)})
+        '';
+      };
+    }
+  ]);
+}

--- a/modules/plugins/git/git-conflict/config.nix
+++ b/modules/plugins/git/git-conflict/config.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
@@ -19,7 +18,7 @@ in {
   config = mkIf cfg.enable (mkMerge [
     {
       vim = {
-        startPlugins = [pkgs.vimPlugins.git-conflict-nvim];
+        startPlugins = ["git-conflict-nvim"];
 
         maps = {
           normal = mkMerge [

--- a/modules/plugins/git/git-conflict/default.nix
+++ b/modules/plugins/git/git-conflict/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./git-conflict.nix
+  ];
+}

--- a/modules/plugins/git/git-conflict/git-conflict.nix
+++ b/modules/plugins/git/git-conflict/git-conflict.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.git.git-conflict = {
+    enable = mkEnableOption "git-conflict" // {default = config.vim.git.enable;};
+    setupOpts = mkPluginSetupOption "git-conflict" {};
+
+    mappings = {
+      ours = mkMappingOption "Choose Ours [Git-Conflict]" "co";
+      theirs = mkMappingOption "Choose Theirs [Git-Conflict]" "ct";
+      both = mkMappingOption "Choose Both [Git-Conflict]" "cb";
+      none = mkMappingOption "Choose None [Git-Conflict]" "c0";
+      prevConflict = mkMappingOption "Go to the previous Conflict [Git-Conflict]" "]x";
+      nextConflict = mkMappingOption "Go to the next Conflict [Git-Conflict]" "[x";
+    };
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -423,6 +423,18 @@
       "url": "https://github.com/notomo/gesture.nvim/archive/dbd839bda337cb73911aeef06897eb29cb99f76f.tar.gz",
       "hash": "1cqiahc52xh113l8lgpz3k852vvqkv2srj9shdkyya76a2v2sf9d"
     },
+    "git-conflict-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "akinsho",
+        "repo": "git-conflict.nvim"
+      },
+      "branch": "main",
+      "revision": "a1badcd070d176172940eb55d9d59029dad1c5a6",
+      "url": "https://github.com/akinsho/git-conflict.nvim/archive/a1badcd070d176172940eb55d9d59029dad1c5a6.tar.gz",
+      "hash": "05rnwhm1fmg3yb7j2xc9nmw262jc687qxhwabn97qarrk2da0r0a"
+    },
     "gitsigns-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Addition of the [git-conflict](https://github.com/akinsho/git-conflict.nvim) plugin. A plugin for visualizing/managing git conflicts in nvim.
I have made so it gets automatically enabled when `vim.git.enable` is set, like with `gitsignes` and `vim-fugitive`.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc