### PR TITLE
blink: fix missing inputs.self in HM and NixOS modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
         };
 
         homeManagerModules = {
-          nvf = import ./flake/modules/home-manager.nix {inherit lib self;};
+          nvf = import ./flake/modules/home-manager.nix {inherit lib inputs;};
           default = self.homeManagerModules.nvf;
           neovim-flake =
             lib.warn ''

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
         };
 
         nixosModules = {
-          nvf = import ./flake/modules/nixos.nix {inherit lib self;};
+          nvf = import ./flake/modules/nixos.nix {inherit lib inputs;};
           default = self.nixosModules.nvf;
           neovim-flake =
             lib.warn ''

--- a/flake/modules/home-manager.nix
+++ b/flake/modules/home-manager.nix
@@ -1,13 +1,13 @@
 # Home Manager module
 {
-  self,
+  inputs,
   lib,
 }: {
   config,
   pkgs,
   ...
 }: let
-  inherit (self) packages inputs;
+  inherit (inputs.self) packages;
   inherit (lib) maintainers;
   inherit (lib.modules) mkIf mkAliasOptionModule;
   inherit (lib.lists) optional;
@@ -19,7 +19,7 @@
   nvfModule = submoduleWith {
     description = "Nvf module";
     class = "nvf";
-    specialArgs = {
+    specialArgs = lib.trace (builtins.attrNames inputs) {
       inherit pkgs lib inputs;
     };
     modules = import ../../modules/modules.nix {inherit pkgs lib;};

--- a/flake/modules/nixos.nix
+++ b/flake/modules/nixos.nix
@@ -1,13 +1,13 @@
 # NixOS module
 {
-  self,
+  inputs,
   lib,
 }: {
   config,
   pkgs,
   ...
 }: let
-  inherit (self) inputs packages;
+  inherit (inputs.self) packages;
   inherit (lib) maintainers;
   inherit (lib.modules) mkIf mkOverride mkAliasOptionModule;
   inherit (lib.lists) optional;


### PR DESCRIPTION
fixes #635 

to illustrate the problem, see this example flake.nix:

```nix
{
	inputs = { /* ... */ };
	outputs = {nixpkgs, ...}@inputs: {
		testing = {
			a = inputs.self             # valid
			b = inputs.self.inputs      # valid
			c = inputs.self.inputs.self # does not exist
		};
	};
}
```

prior to this change, inputs.self.inputs was passed to the hm
module, which lacks the self attr

This change passes in the "top-level" inputs instead.