### PR TITLE
git/git-conflict: avoid shadowing builtin keybinds

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -1,5 +1,10 @@
 # Release 0.8 {#sec-release-0.8}
 
+## Breaking changes
+
+- `git-conflict` keybinds are now prefixed with `<leader>` to avoid conflicting
+  with builtins
+
 [NotAShelf](https://github.com/notashelf):
 
 [typst-preview.nvim]: https://github.com/chomosuke/typst-preview.nvim

--- a/modules/plugins/git/git-conflict/git-conflict.nix
+++ b/modules/plugins/git/git-conflict/git-conflict.nix
@@ -12,10 +12,10 @@ in {
     setupOpts = mkPluginSetupOption "git-conflict" {};
 
     mappings = {
-      ours = mkMappingOption "Choose Ours [Git-Conflict]" "co";
-      theirs = mkMappingOption "Choose Theirs [Git-Conflict]" "ct";
-      both = mkMappingOption "Choose Both [Git-Conflict]" "cb";
-      none = mkMappingOption "Choose None [Git-Conflict]" "c0";
+      ours = mkMappingOption "Choose Ours [Git-Conflict]" "<leader>co";
+      theirs = mkMappingOption "Choose Theirs [Git-Conflict]" "<leader>ct";
+      both = mkMappingOption "Choose Both [Git-Conflict]" "<leader>cb";
+      none = mkMappingOption "Choose None [Git-Conflict]" "<leader>c0";
       prevConflict = mkMappingOption "Go to the previous Conflict [Git-Conflict]" "]x";
       nextConflict = mkMappingOption "Go to the next Conflict [Git-Conflict]" "[x";
     };


### PR DESCRIPTION
The current default git-conflict keybinds _conflicts_ with vim's builtin keybinds. This PR prefixes
them with the `<leader>` key
