### PR TITLE
utility/yazi-nvim: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -10,6 +10,7 @@
 [typst-preview.nvim]: https://github.com/chomosuke/typst-preview.nvim
 [render-markdown.nvim]: https://github.com/MeanderingProgrammer/render-markdown.nvim
 [yanky.nvim]: https://github.com/gbprod/yanky.nvim
+[yazi.nvim]: https://github.com/mikavilpas/yazi.nvim
 
 - Add [typst-preview.nvim] under
   `languages.typst.extensions.typst-preview-nvim`.
@@ -45,6 +46,11 @@
     Pick only one.
 
 - Add [yanky.nvim] to available plugins, under `vim.utility.yanky-nvim`.
+
+- Fix plugin `setupOpts` for yanky.nvim and assert if shada is configured as a
+  backend while shada is disabled in Neovim options.
+
+- Add [yazi.nvim] as a companion plugin for Yazi, the terminal file manager.
 
 [amadaluzia](https://github.com/amadaluzia):
 
@@ -154,7 +160,6 @@
   Inspiration from `vim.languages.clang.dap` implementation.
 - Add [leetcode.nvim] plugin under `vim.utility.leetcode-nvim`.
 
-
 [nezia1](https://github.com/nezia1)
 
 - Add support for [nixd](https://github.com/nix-community/nixd) language server.
@@ -165,7 +170,7 @@
   available plugins, under `vim.utility.multicursors`.
 - Add [hydra.nvim](https://github.com/nvimtools/hydra.nvim) as dependency for
   `multicursors.nvim` and lazy loads by default.
-[folospior](https://github.com/folospior)
+  [folospior](https://github.com/folospior)
 
 - Fix plugin name for lsp/lspkind.
 
@@ -180,5 +185,8 @@
 
 [Libadoxon](https://github.com/Libadoxon)
 
-- Add [git-conflict](https://github.com/akinsho/git-conflict.nvim) plugin for resolving git conflicts
-- Add formatters for go: [gofmt](https://go.dev/blog/gofmt), [golines](https://github.com/segmentio/golines) and [gofumpt](https://github.com/mvdan/gofumpt)
+- Add [git-conflict](https://github.com/akinsho/git-conflict.nvim) plugin for
+  resolving git conflicts
+- Add formatters for go: [gofmt](https://go.dev/blog/gofmt),
+  [golines](https://github.com/segmentio/golines) and
+  [gofumpt](https://github.com/mvdan/gofumpt)

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -7,6 +7,7 @@
     ./gestures
     ./icon-picker
     ./images
+    ./leetcode-nvim
     ./motion
     ./multicursors
     ./new-file-template
@@ -16,6 +17,6 @@
     ./telescope
     ./wakatime
     ./yanky-nvim
-    ./leetcode-nvim
+    ./yazi-nvim
   ];
 }

--- a/modules/plugins/utility/yanky-nvim/config.nix
+++ b/modules/plugins/utility/yanky-nvim/config.nix
@@ -11,6 +11,7 @@
 
   cfg = config.vim.utility.yanky-nvim;
   usingSqlite = cfg.setupOpts.ring.storage == "sqlite";
+  usingShada = cfg.setupOpts.ring.storage == "shada";
 in {
   config = mkIf cfg.enable {
     vim = {
@@ -28,5 +29,15 @@ in {
         require("yanky").setup(${toLuaObject cfg.setupOpts});
       '';
     };
+
+    assertions = [
+      {
+        assertion = usingShada && ((config.vim.options.shada or "") == "");
+        message = ''
+          Yanky.nvim is configured to use 'shada' for the storage backend, but shada is disabled
+          in 'vim.options'. Please re-enable shada, or switch to a different backend.
+        '';
+      }
+    ];
   };
 }

--- a/modules/plugins/utility/yanky-nvim/yanky-nvim.nix
+++ b/modules/plugins/utility/yanky-nvim/yanky-nvim.nix
@@ -1,13 +1,14 @@
 {lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) enum;
+  inherit (lib.nvim.types) mkPluginSetupOption;
 in {
   options.vim.utility.yanky-nvim = {
     enable = mkEnableOption ''
       improved Yank and Put functionalities for Neovim  [yanky-nvim]
     '';
 
-    setupOpts = {
+    setupOpts = mkPluginSetupOption "yanky-nvim" {
       ring.storage = mkOption {
         type = enum ["shada" "sqlite" "memory"];
         default = "shada";
@@ -15,11 +16,11 @@ in {
         description = ''
           storage mode for ring values.
 
-          - shada: this will save pesistantly using Neovim ShaDa feature.
+          - **shada**: this will save pesistantly using Neovim ShaDa feature.
             This means that history will be persisted between each session of Neovim.
-          - memory: each Neovim instance will have his own history and it will be
+          - **memory**: each Neovim instance will have his own history and it will be
             lost between sessions.
-          - sqlite: more reliable than `shada`, requires `sqlite.lua` as a dependency.
+          - **sqlite**: more reliable than `shada`, requires `sqlite.lua` as a dependency.
             nvf will add this dependency to `PATH` automatically.
         '';
       };

--- a/modules/plugins/utility/yazi-nvim/config.nix
+++ b/modules/plugins/utility/yazi-nvim/config.nix
@@ -1,0 +1,32 @@
+{
+  options,
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.binds) mkKeymap;
+
+  cfg = config.vim.utility.yazi-nvim;
+  keys = cfg.mappings;
+
+  inherit (options.vim.utility.yazi-nvim) mappings;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      lazy.plugins."yazi.nvim" = {
+        package = pkgs.vimPlugins.yazi-nvim;
+        setupModule = "yazi";
+        inherit (cfg) setupOpts;
+        event = ["BufAdd" "VimEnter"];
+
+        keys = [
+          (mkKeymap "n" keys.openYazi "<cmd>Yazi<CR>" {desc = mappings.openYazi.description;})
+          (mkKeymap "n" keys.openYaziDir "<cmd>Yazi cwd<CR>" {desc = mappings.openYaziDir.description;})
+          (mkKeymap "n" keys.yaziToggle "<cmd>Yazi toggle<CR>" {desc = mappings.yaziToggle.description;})
+        ];
+      };
+    };
+  };
+}

--- a/modules/plugins/utility/yazi-nvim/default.nix
+++ b/modules/plugins/utility/yazi-nvim/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./yazi-nvim.nix
+  ];
+}

--- a/modules/plugins/utility/yazi-nvim/yazi-nvim.nix
+++ b/modules/plugins/utility/yazi-nvim/yazi-nvim.nix
@@ -1,0 +1,26 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) bool;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (lib.nvim.binds) mkMappingOption;
+in {
+  options.vim.utility.yazi-nvim = {
+    enable = mkEnableOption ''
+      companion plugin for the yazi terminal file manager [yazi-nvim]
+    '';
+
+    mappings = {
+      openYazi = mkMappingOption "Open yazi at the current file [yazi.nvim]" "<leader>-";
+      openYaziDir = mkMappingOption "Open the file manager in nvim's working directory [yazi.nvim]" "<leader>cw";
+      yaziToggle = mkMappingOption "Resume the last yazi session [yazi.nvim]" "<c-up>";
+    };
+
+    setupOpts = mkPluginSetupOption "yazi-nvim" {
+      open_for_directories = mkOption {
+        type = bool;
+        default = false;
+        description = "Whether to open Yazi instead of netrw";
+      };
+    };
+  };
+}


### PR DESCRIPTION
- **utility/yazi-nvim: init**
- **utility/yanky-nvim: fix plugin setupOpts; assert when shada is disabled**

Adds `vim.plugins.utility.yazi-nvim`, and a bunch of default keybinds for it.
Additionally, fixes some minor oversight in Yanky setup that managed to slip by.

Closes #585

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
