### PR TITLE
mkdir.nvim, nix-develop.nvim, direnv.vim: init, blink-cmp: add source options, friendly-snippets source

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -200,6 +200,8 @@
 [alfarel](https://github.com/alfarelcynthesis):
 
 - Add missing `yazi.nvim` dependency (`snacks.nvim`).
+- Add [mkdir.nvim](https://github.com/jghauser/mkdir.nvim) plugin
+  for automatic creation of parent directories when editing a nested file.
 
 [TheColorman](https://github.com/TheColorman)
 

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -206,6 +206,7 @@
   for in-neovim `nix develop`, `nix shell` and more.
 - Add [direnv.vim](https://github.com/direnv/direnv.vim) plugin
   for automatic syncing of nvim shell environment with direnv's.
+- Add [blink.cmp] source options and some default-disabled sources.
 
 [TheColorman](https://github.com/TheColorman)
 

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -204,6 +204,8 @@
   for automatic creation of parent directories when editing a nested file.
 - Add [nix-develop.nvim](https://github.com/figsoda/nix-develop.nvim) plugin
   for in-neovim `nix develop`, `nix shell` and more.
+- Add [direnv.vim](https://github.com/direnv/direnv.vim) plugin
+  for automatic syncing of nvim shell environment with direnv's.
 
 [TheColorman](https://github.com/TheColorman)
 

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -3,7 +3,7 @@
 ## Breaking changes
 
 - `git-conflict` keybinds are now prefixed with `<leader>` to avoid conflicting
-  with builtins
+  with builtins.
 
 [NotAShelf](https://github.com/notashelf):
 
@@ -18,7 +18,7 @@
 - Add a search widget to the options page in the nvf manual.
 
 - Add [render-markdown.nvim] under
-  `languages.markdown.extensions.render-markdown-nvim`
+  `languages.markdown.extensions.render-markdown-nvim`.
 
 - Implement [](#opt-vim.git.gitsigns.setupOpts) for user-specified setup table
   in gitsigns configuration.
@@ -62,7 +62,7 @@
 
 [blink.cmp]: https://github.com/saghen/blink.cmp
 
-- Add [blink.cmp] support
+- Add [blink.cmp] support.
 
 [diniamo](https://github.com/diniamo):
 
@@ -76,8 +76,8 @@
 [aerial.nvim]: (https://github.com/stevearc/aerial.nvim)
 [nvim-ufo]: (https://github.com/kevinhwang91/nvim-ufo)
 
-- Add [aerial.nvim]
-- Add [nvim-ufo]
+- Add [aerial.nvim].
+- Add [nvim-ufo].
 
 [LilleAila](https://github.com/LilleAila):
 
@@ -160,7 +160,7 @@
   Inspiration from `vim.languages.clang.dap` implementation.
 - Add [leetcode.nvim] plugin under `vim.utility.leetcode-nvim`.
 
-[nezia1](https://github.com/nezia1)
+[nezia1](https://github.com/nezia1):
 
 - Add support for [nixd](https://github.com/nix-community/nixd) language server.
 
@@ -170,30 +170,31 @@
   available plugins, under `vim.utility.multicursors`.
 - Add [hydra.nvim](https://github.com/nvimtools/hydra.nvim) as dependency for
   `multicursors.nvim` and lazy loads by default.
-  [folospior](https://github.com/folospior)
+
+[folospior](https://github.com/folospior):
 
 - Fix plugin name for lsp/lspkind.
 
 - Move `vim-illuminate` to `setupOpts format`
 
-[iynaix](https://github.com/iynaix)
+[iynaix](https://github.com/iynaix):
 
 - Add lsp options support for [nixd](https://github.com/nix-community/nixd)
   language server.
 
-[Mr-Helpful](https://github.com/Mr-Helpful)
+[Mr-Helpful](https://github.com/Mr-Helpful):
 
-- Corrects pin names used for nvim themes
+- Corrects pin names used for nvim themes.
 
-[Libadoxon](https://github.com/Libadoxon)
+[Libadoxon](https://github.com/Libadoxon):
 
 - Add [git-conflict](https://github.com/akinsho/git-conflict.nvim) plugin for
-  resolving git conflicts
+  resolving git conflicts.
 - Add formatters for go: [gofmt](https://go.dev/blog/gofmt),
   [golines](https://github.com/segmentio/golines) and
-  [gofumpt](https://github.com/mvdan/gofumpt)
+  [gofumpt](https://github.com/mvdan/gofumpt).
 
-[MaxMur](https://github.com/TheMaxMur)
+[MaxMur](https://github.com/TheMaxMur):
 
 - Add YAML support under `vim.languages.yaml`.
 
@@ -211,7 +212,7 @@
   [friendly-snippets](https://github.com/rafamadriz/friendly-snippets)
   so blink.cmp can source snippets from it.
 
-[TheColorman](https://github.com/TheColorman)
+[TheColorman](https://github.com/TheColorman):
 
 - Fix plugin `setupOpts` for `neovim-session-manager` having an invalid value
   for `autoload_mode`.

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -207,6 +207,9 @@
 - Add [direnv.vim](https://github.com/direnv/direnv.vim) plugin
   for automatic syncing of nvim shell environment with direnv's.
 - Add [blink.cmp] source options and some default-disabled sources.
+- Add [blink.cmp] option to add
+  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets)
+  so blink.cmp can source snippets from it.
 
 [TheColorman](https://github.com/TheColorman)
 

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -202,6 +202,8 @@
 - Add missing `yazi.nvim` dependency (`snacks.nvim`).
 - Add [mkdir.nvim](https://github.com/jghauser/mkdir.nvim) plugin
   for automatic creation of parent directories when editing a nested file.
+- Add [nix-develop.nvim](https://github.com/figsoda/nix-develop.nvim) plugin
+  for in-neovim `nix develop`, `nix shell` and more.
 
 [TheColorman](https://github.com/TheColorman)
 

--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -2,7 +2,7 @@
   inherit (lib.options) mkEnableOption mkOption literalMD;
   inherit (lib.types) listOf str either attrsOf submodule enum anything int nullOr;
   inherit (lib.generators) mkLuaInline;
-  inherit (lib.nvim.types) mkPluginSetupOption luaInline;
+  inherit (lib.nvim.types) mkPluginSetupOption luaInline pluginType;
   inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.config) mkBool;
 
@@ -118,5 +118,64 @@ in {
       scrollDocsUp = mkMappingOption "Scroll docs up [blink.cmp]" "<C-d>";
       scrollDocsDown = mkMappingOption "Scroll docs down [blink.cmp]" "<C-f>";
     };
+
+    sourcePlugins = let
+      sourcePluginType = submodule {
+        options = {
+          package = mkOption {
+            type = pluginType;
+            description = ''
+              `blink-cmp` source plugin package.
+            '';
+          };
+          module = mkOption {
+            type = str;
+            description = ''
+              Value of {option}`vim.autocomplete.blink-cmp.setupOpts.sources.providers.<name>.module`.
+
+              Should be present in the source's documentation.
+            '';
+          };
+          enable = mkEnableOption "this source";
+        };
+      };
+    in
+      mkOption {
+        type = submodule {
+          freeformType = attrsOf sourcePluginType;
+          options = let
+            defaultSourcePluginOption = name: package: module: {
+              package = mkOption {
+                type = pluginType;
+                default = package;
+                description = ''
+                  `blink-cmp` ${name} source plugin package.
+                '';
+              };
+              module = mkOption {
+                type = str;
+                default = module;
+                description = ''
+                  Value of {option}`vim.autocomplete.blink-cmp.setupOpts.sources.providers.${name}.module`.
+                '';
+              };
+              enable = mkEnableOption "${name} source";
+            };
+          in {
+            # emoji completion after :
+            emoji = defaultSourcePluginOption "emoji" "blink-emoji-nvim" "blink-emoji";
+            # spelling suggestions as completions
+            spell = defaultSourcePluginOption "spell" "blink-cmp-spell" "blink-cmp-spell";
+            # words from nearby files
+            ripgrep = defaultSourcePluginOption "ripgrep" "blink-ripgrep-nvim" "blink-ripgrep";
+          };
+        };
+        default = {};
+        description = ''
+          `blink.cmp` sources.
+
+          Attribute names must be source names used in {option}`vim.autocomplete.blink-cmp.setupOpts.sources.default`.
+        '';
+      };
   };
 }

--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -177,5 +177,7 @@ in {
           Attribute names must be source names used in {option}`vim.autocomplete.blink-cmp.setupOpts.sources.default`.
         '';
       };
+
+    friendly-snippets.enable = mkEnableOption "friendly-snippets for blink to source from automatically";
   };
 }

--- a/modules/plugins/completion/blink-cmp/config.nix
+++ b/modules/plugins/completion/blink-cmp/config.nix
@@ -6,6 +6,8 @@
   inherit (lib.modules) mkIf;
   inherit (lib.strings) optionalString;
   inherit (lib.generators) mkLuaInline;
+  inherit (lib.attrsets) attrValues filterAttrs;
+  inherit (lib.lists) map;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (builtins) concatStringsSep typeOf tryEval attrNames mapAttrs;
 
@@ -19,9 +21,12 @@
     else if (plugin ? pname && (tryEval plugin.pname).success)
     then plugin.pname
     else plugin.name;
+
+  enabledBlinkSources = filterAttrs (_source: definition: definition.enable) cfg.sourcePlugins;
+  blinkSourcePlugins = map (definition: definition.package) (attrValues enabledBlinkSources);
 in {
   vim = mkIf cfg.enable {
-    startPlugins = ["blink-compat"];
+    startPlugins = ["blink-compat"] ++ blinkSourcePlugins;
     lazy.plugins = {
       blink-cmp = {
         package = "blink-cmp";
@@ -32,12 +37,14 @@ in {
         #
         # event = ["InsertEnter" "CmdlineEnter"];
 
-        after = ''
-          ${optionalString config.vim.lazy.enable
-            (concatStringsSep "\n" (map
-              (package: "require('lz.n').trigger_load(${toLuaObject (getPluginName package)})")
-              cmpCfg.sourcePlugins))}
-        '';
+        after =
+          # lua
+          ''
+            ${optionalString config.vim.lazy.enable
+              (concatStringsSep "\n" (map
+                (package: "require('lz.n').trigger_load(${toLuaObject (getPluginName package)})")
+                cmpCfg.sourcePlugins))}
+          '';
       };
     };
 
@@ -45,13 +52,26 @@ in {
       enableSharedCmpSources = true;
       blink-cmp.setupOpts = {
         sources = {
-          default = ["lsp" "path" "snippets" "buffer"] ++ (attrNames cmpCfg.sources);
+          default =
+            [
+              "lsp"
+              "path"
+              "snippets"
+              "buffer"
+            ]
+            ++ (attrNames cmpCfg.sources)
+            ++ (attrNames enabledBlinkSources);
           providers =
             mapAttrs (name: _: {
               inherit name;
               module = "blink.compat.source";
             })
-            cmpCfg.sources;
+            cmpCfg.sources
+            // (mapAttrs (name: definition: {
+                inherit name;
+                inherit (definition) module;
+              })
+              enabledBlinkSources);
         };
         snippets = mkIf config.vim.snippets.luasnip.enable {
           preset = "luasnip";
@@ -67,16 +87,18 @@ in {
           ${mappings.next} = [
             "select_next"
             "snippet_forward"
-            (mkLuaInline ''
-              function(cmp)
-                local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-                has_words_before = col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
+            (mkLuaInline
+              # lua
+              ''
+                function(cmp)
+                  local line, col = unpack(vim.api.nvim_win_get_cursor(0))
+                  has_words_before = col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
 
-                if has_words_before then
-                  return cmp.show()
+                  if has_words_before then
+                    return cmp.show()
+                  end
                 end
-              end
-            '')
+              '')
             "fallback"
           ];
           ${mappings.previous} = [

--- a/modules/plugins/completion/blink-cmp/config.nix
+++ b/modules/plugins/completion/blink-cmp/config.nix
@@ -7,7 +7,7 @@
   inherit (lib.strings) optionalString;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.attrsets) attrValues filterAttrs;
-  inherit (lib.lists) map;
+  inherit (lib.lists) map optional;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (builtins) concatStringsSep typeOf tryEval attrNames mapAttrs;
 
@@ -26,7 +26,7 @@
   blinkSourcePlugins = map (definition: definition.package) (attrValues enabledBlinkSources);
 in {
   vim = mkIf cfg.enable {
-    startPlugins = ["blink-compat"] ++ blinkSourcePlugins;
+    startPlugins = ["blink-compat"] ++ blinkSourcePlugins ++ (optional cfg.friendly-snippets.enable "friendly-snippets");
     lazy.plugins = {
       blink-cmp = {
         package = "blink-cmp";

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -8,6 +8,7 @@
     ./icon-picker
     ./images
     ./leetcode-nvim
+    ./mkdir
     ./motion
     ./multicursors
     ./new-file-template

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -3,6 +3,7 @@
     ./binds
     ./ccc
     ./diffview
+    ./direnv
     ./fzf-lua
     ./gestures
     ./icon-picker

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -12,6 +12,7 @@
     ./motion
     ./multicursors
     ./new-file-template
+    ./nix-develop
     ./outline
     ./preview
     ./surround

--- a/modules/plugins/utility/direnv/config.nix
+++ b/modules/plugins/utility/direnv/config.nix
@@ -1,0 +1,13 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+
+  cfg = config.vim.utility.direnv;
+in {
+  vim = mkIf cfg.enable {
+    startPlugins = ["direnv-vim"];
+  };
+}

--- a/modules/plugins/utility/direnv/default.nix
+++ b/modules/plugins/utility/direnv/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./direnv.nix
+  ];
+}

--- a/modules/plugins/utility/direnv/direnv.nix
+++ b/modules/plugins/utility/direnv/direnv.nix
@@ -1,0 +1,5 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+in {
+  options.vim.utility.direnv.enable = mkEnableOption "syncing nvim shell environment with direnv's using `direnv.vim`";
+}

--- a/modules/plugins/utility/mkdir/config.nix
+++ b/modules/plugins/utility/mkdir/config.nix
@@ -1,0 +1,12 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  cfg = config.vim.utility.mkdir;
+in {
+  vim = mkIf cfg.enable {
+    startPlugins = ["mkdir-nvim"];
+  };
+}

--- a/modules/plugins/utility/mkdir/default.nix
+++ b/modules/plugins/utility/mkdir/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./mkdir.nix
+  ];
+}

--- a/modules/plugins/utility/mkdir/mkdir.nix
+++ b/modules/plugins/utility/mkdir/mkdir.nix
@@ -1,0 +1,7 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+in {
+  options.vim.utility.mkdir.enable = mkEnableOption ''
+    parent directory creation when editing a nested path that does not exist using `mkdir.nvim`
+  '';
+}

--- a/modules/plugins/utility/nix-develop/config.nix
+++ b/modules/plugins/utility/nix-develop/config.nix
@@ -1,0 +1,12 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  cfg = config.vim.utility.nix-develop;
+in {
+  vim = mkIf cfg.enable {
+    startPlugins = ["nix-develop-nvim"];
+  };
+}

--- a/modules/plugins/utility/nix-develop/default.nix
+++ b/modules/plugins/utility/nix-develop/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./nix-develop.nix
+  ];
+}

--- a/modules/plugins/utility/nix-develop/nix-develop.nix
+++ b/modules/plugins/utility/nix-develop/nix-develop.nix
@@ -1,0 +1,5 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+in {
+  options.vim.utility.nix-develop.enable = mkEnableOption "in-neovim `nix develop`, `nix shell`, and more using `nix-develop.nvim`";
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -315,6 +315,18 @@
       "url": "https://github.com/sindrets/diffview.nvim/archive/4516612fe98ff56ae0415a259ff6361a89419b0a.tar.gz",
       "hash": "0brabpd02596hg98bml118bx6z2sly98kf1cr2p0xzybiinb4zs9"
     },
+    "direnv-vim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "direnv",
+        "repo": "direnv.vim"
+      },
+      "branch": "master",
+      "revision": "ab2a7e08dd630060cd81d7946739ac7442a4f269",
+      "url": "https://github.com/direnv/direnv.vim/archive/ab2a7e08dd630060cd81d7946739ac7442a4f269.tar.gz",
+      "hash": "1hhwfnaj9ibz17ggxvhzrkinghfy51fqfa0bs482z484jpvjc31g"
+    },
     "dracula": {
       "type": "Git",
       "repository": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1316,6 +1316,18 @@
       "url": "https://github.com/otavioschwanck/new-file-template.nvim/archive/6ac66669dbf2dc5cdee184a4fe76d22465ca67e8.tar.gz",
       "hash": "0c7378c3w6bniclp666rq15c28akb0sjy58ayva0wpyin4k26hl3"
     },
+    "nix-develop-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "figsoda",
+        "repo": "nix-develop.nvim"
+      },
+      "branch": "main",
+      "revision": "afea026f5c478c000a8af8de87f7b711676387ab",
+      "url": "https://github.com/figsoda/nix-develop.nvim/archive/afea026f5c478c000a8af8de87f7b711676387ab.tar.gz",
+      "hash": "0nwjgr19pzdxd7yygz380b388qcfbzp9svs916kh0zayzi9yxc2k"
+    },
     "noice-nvim": {
       "type": "Git",
       "repository": {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -51,6 +51,18 @@
       "url": "https://api.github.com/repos/saghen/blink.cmp/tarball/v0.12.4",
       "hash": "0jdifjifxjqa8r80wlqgkn5rm48wziap92340xz228nrgd0c9g69"
     },
+    "blink-cmp-spell": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "ribru17",
+        "repo": "blink-cmp-spell"
+      },
+      "branch": "master",
+      "revision": "38d6797dea6f72baa6e8b3bfca6da96d8fcac64d",
+      "url": "https://github.com/ribru17/blink-cmp-spell/archive/38d6797dea6f72baa6e8b3bfca6da96d8fcac64d.tar.gz",
+      "hash": "19pnasa446iiapgsr3z2fpk0nnrzh8g5wrzrq8n0y4q0z6spc9f6"
+    },
     "blink-compat": {
       "type": "Git",
       "repository": {
@@ -62,6 +74,30 @@
       "revision": "4104671562c663d059d91a99da3780bead5bc467",
       "url": "https://github.com/saghen/blink.compat/archive/4104671562c663d059d91a99da3780bead5bc467.tar.gz",
       "hash": "0bsf8kg5s3m1xk9d4n0yl0h5xyk484hip3z8va547f6ibim9ccv4"
+    },
+    "blink-emoji-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "moyiz",
+        "repo": "blink-emoji.nvim"
+      },
+      "branch": "master",
+      "revision": "a77aebc092ebece1eed108f301452ae774d6b67a",
+      "url": "https://github.com/moyiz/blink-emoji.nvim/archive/a77aebc092ebece1eed108f301452ae774d6b67a.tar.gz",
+      "hash": "0n4qv2mk7zx910gnwf9ri2w5qxwx8szx99nqqzik4yyvl4axm41d"
+    },
+    "blink-ripgrep-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "mikavilpas",
+        "repo": "blink-ripgrep.nvim"
+      },
+      "branch": "main",
+      "revision": "305e1ae5363f527abdfd71915a3fe1f42af52824",
+      "url": "https://github.com/mikavilpas/blink-ripgrep.nvim/archive/305e1ae5363f527abdfd71915a3fe1f42af52824.tar.gz",
+      "hash": "1hcfyicgf33dlr2hhgnhhzdcxxqw1v8v1yjfbnwvlcsgw0rhjl8w"
     },
     "bufdelete-nvim": {
       "type": "Git",

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1205,6 +1205,18 @@
       "url": "https://github.com/wfxr/minimap.vim/archive/57287e2dd28fa3e63276a32d11c729df14741d54.tar.gz",
       "hash": "05k4cgcrz0gj92xy685bd4p6nh2jmaywc2f5sw1lap0v685h7n79"
     },
+    "mkdir-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "jghauser",
+        "repo": "mkdir.nvim"
+      },
+      "branch": "main",
+      "revision": "c55d1dee4f099528a1853b28bb28caa802eba217",
+      "url": "https://github.com/jghauser/mkdir.nvim/archive/c55d1dee4f099528a1853b28bb28caa802eba217.tar.gz",
+      "hash": "0zpyvkbw7wfqdxfgidr7zfxqb5ldci4pflx50rsm1hbwai0ybv23"
+    },
     "modes-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Adds a few very simple plugins I use, as well as options for blink-cmp that I find useful.

I can split this into a couple PRs if that would be preferred.

- [mkdir.nvim](https://github.com/jghauser/mkdir.nvim)
- [nix-develop.nvim](https://github.com/figsoda/nix-develop.nvim)
- [direnv.vim](https://github.com/direnv/direnv.vim)

Two blink-cmp options:

- `blink-cmp.sourcePlugins`, for arbitrary blink-cmp completion sources
  - there is a three provided sources that I've tested, that are disabled by default.
    I'm not sure how to indicate in the docs that they are present without making them
    disappear as soon as any other sources are added.
- `blink-cmp.friendly-snippets.enable`, for an alternate snippet source
  - friendly-snippets is automatically detected by blink-cmp, so it doesn't need the same
    handling as other options

I also snuck in some typo fixing in the release notes (in a separate commit).
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc