### PR TITLE
plugins/nvim-docs-view: fix default mappings (#675)

### DIFF
--- a/modules/plugins/lsp/nvim-docs-view/nvim-docs-view.nix
+++ b/modules/plugins/lsp/nvim-docs-view/nvim-docs-view.nix
@@ -57,8 +57,8 @@ in {
     };
 
     mappings = {
-      viewToggle = mkMappingOption "Open or close the docs view panel" "lvt";
-      viewUpdate = mkMappingOption "Manually update the docs view panel" "lvu";
+      viewToggle = mkMappingOption "Open or close the docs view panel" "<leader>lvt";
+      viewUpdate = mkMappingOption "Manually update the docs view panel" "<leader>lvu";
     };
   };
 }


### PR DESCRIPTION
Default mappings of plugin nvim-docs-view conflict with directional navigation in normal mode. This PR prefixes the keybindings with the leader key.