### PR TITLE
languages/helm: Initial Helm chart language support

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -243,3 +243,7 @@
 [BANanaD3V](https://github.com/BANanaD3V):
 
 - `alpha` is now configured with nix.
+
+[Butzist](https://github.com/butzist)
+
+- Add Helm chart support under `vim.languages.helm`.

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -13,6 +13,7 @@ in {
     ./gleam.nix
     ./go.nix
     ./hcl.nix
+    ./helm.nix
     ./kotlin.nix
     ./html.nix
     ./haskell.nix

--- a/modules/plugins/languages/helm.nix
+++ b/modules/plugins/languages/helm.nix
@@ -1,0 +1,89 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.lists) isList;
+  inherit (lib.types) enum either listOf package str;
+  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.nvim.lua) expToLua;
+
+  cfg = config.vim.languages.helm;
+  yamlCfg = config.vim.languages.yaml;
+
+  helmCmd =
+    if isList cfg.lsp.package
+    then cfg.lsp.package
+    else ["${cfg.lsp.package}/bin/helm_ls" "serve"];
+  yamlCmd =
+    if isList yamlCfg.lsp.package
+    then builtins.elemAt yamlCfg.lsp.package 0
+    else "${yamlCfg.lsp.package}/bin/yaml-language-server";
+
+  defaultServer = "helm-ls";
+  servers = {
+    helm-ls = {
+      package = pkgs.helm-ls;
+      lspConfig = ''
+        lspconfig.helm_ls.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = ${expToLua helmCmd},
+          settings = {
+            ['helm-ls'] = {
+              yamlls = {
+                  path = "${yamlCmd}"
+              }
+            }
+          }
+        }
+      '';
+    };
+  };
+in {
+  options.vim.languages.helm = {
+    enable = mkEnableOption "Helm language support";
+
+    treesitter = {
+      enable = mkEnableOption "Helm treesitter" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "helm";
+    };
+
+    lsp = {
+      enable = mkEnableOption "Helm LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        description = "Helm LSP server to use";
+        type = enum (attrNames servers);
+        default = defaultServer;
+      };
+
+      package = mkOption {
+        description = "Helm LSP server package";
+        type = either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.helm-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+
+    {
+      # Enables filetype detection
+      vim.startPlugins = [pkgs.vimPlugins.vim-helm];
+    }
+  ]);
+}

--- a/modules/plugins/languages/yaml.nix
+++ b/modules/plugins/languages/yaml.nix
@@ -14,14 +14,27 @@
 
   cfg = config.vim.languages.yaml;
 
+  onAttach =
+    if config.vim.languages.helm.lsp.enable
+    then ''
+      on_attach = function(client, bufnr)
+        local filetype = vim.bo[bufnr].filetype
+        if filetype == "helm" then
+          client.stop()
+        end
+      end''
+    else "on_attach = default_on_attach";
+
   defaultServer = "yaml-language-server";
   servers = {
     yaml-language-server = {
       package = pkgs.nodePackages.yaml-language-server;
       lspConfig = ''
+
+
         lspconfig.yamlls.setup {
-          capabilities = capabilities;
-          on_attach = default_on_attach;
+          capabilities = capabilities,
+          ${onAttach},
           cmd = ${
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package


### PR DESCRIPTION
Depends on #676 and #680

Adds language support for Helm charts via `helm-ls` and `vim-helm`