### PR TITLE
utility/yazi-nvim: add missing dependency (snacks.nvim)

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -196,3 +196,7 @@
 [MaxMur](https://github.com/TheMaxMur)
 
 - Add YAML support under `vim.languages.yaml`.
+
+[alfarel](https://github.com/alfarelcynthesis):
+
+- Add missing `yazi.nvim` dependency (`snacks.nvim`).

--- a/modules/plugins/utility/yazi-nvim/config.nix
+++ b/modules/plugins/utility/yazi-nvim/config.nix
@@ -15,6 +15,7 @@
 in {
   config = mkIf cfg.enable {
     vim = {
+      startPlugins = ["snacks-nvim"];
       lazy.plugins."yazi.nvim" = {
         package = pkgs.vimPlugins.yazi-nvim;
         setupModule = "yazi";

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1880,6 +1880,18 @@
       "url": "https://github.com/m4xshen/smartcolumn.nvim/archive/92f3773af80d674f1eb61e112dca79e2fa449fd1.tar.gz",
       "hash": "0k1xnyvblshn4fhbxgl0i34j22n55xlwr09sdmb23l57br5rb07q"
     },
+    "snacks-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "folke",
+        "repo": "snacks.nvim"
+      },
+      "branch": "main",
+      "revision": "bc0630e43be5699bb94dadc302c0d21615421d93",
+      "url": "https://github.com/folke/snacks.nvim/archive/bc0630e43be5699bb94dadc302c0d21615421d93.tar.gz",
+      "hash": "0a5nw7xa33shag1h12gf930g3vcixbwk8dxv0ji4980ycskh238v"
+    },
     "sqls-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Add `yazi.nvim` dependency [`snacks.nvim`](https://github.com/folke/snacks.nvim/). 

`:checkhealth yazi` was warning about a missing dependency, and project `README` recently added it to the requirements.

Should be fine to put in `startPlugins` as far as I'm aware, seems to be intended as a library and therefore have a light startup time, especially with none of its more complicated features enabled.
I can try and move it to be lazy and see if that has any issues, if that would be preferred.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
  - warning disappears
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc