### PR TITLE
session/nvim-session-manager: fix autoload_mode type

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -200,3 +200,8 @@
 [alfarel](https://github.com/alfarelcynthesis):
 
 - Add missing `yazi.nvim` dependency (`snacks.nvim`).
+
+[TheColorman](https://github.com/TheColorman)
+
+- Fix plugin `setupOpts` for `neovim-session-manager` having an invalid value
+  for `autoload_mode`.

--- a/modules/plugins/session/nvim-session-manager/nvim-session-manager.nix
+++ b/modules/plugins/session/nvim-session-manager/nvim-session-manager.nix
@@ -1,5 +1,6 @@
 {lib, ...}: let
   inherit (lib.types) nullOr str bool;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib) mkEnableOption mkOption types mkRenamedOptionModule;
 in {
   imports = let
@@ -68,6 +69,8 @@ in {
 
       autoload_mode = mkOption {
         type = types.enum ["Disabled" "CurrentDir" "LastSession"];
+        # variable `sm` referenced from ./config.nix
+        apply = value: mkLuaInline "sm.AutoloadMode.${value}";
         default = "LastSession";
         description = "Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession";
       };


### PR DESCRIPTION
Fixes `Error detected while processing VimEnter Autocommands for "*"` by
using an enum type for "autoload_mode" instead of a string.

See https://github.com/Shatur/neovim-session-manager/issues/135.

~~I've implemented this by just overwriting the `autoload_mode` attribute in `setupOpts` with the `//` operator. It looks a bit messy, but I couldn't think of a cleaner way to achieve it while still making good use of `toLuaObject`.~~

Not done using the `apply` parameter of `mkOption`.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

You can check the change with the following commands, that run an instance of `nvf` from my fork without and with the fix commit respectively:

```bash
# Does not include the fix
nix run "git+https://gist.github.com/TheColorman/022acefec3137a404a898731e3b211f3"
# Includes the fix
nix run "git+https://gist.github.com/TheColorman/f70ac01742c886ed475afff6d4f5e2bd"
```

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

CC @NotAShelf (main contributor to nvim-session-manager)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
