### PR TITLE
completion/blink: don't break when modifying built-in sources.providers

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -226,8 +226,9 @@
   syncing of nvim shell environment with direnv's.
 - Add [blink.cmp] source options and some default-disabled sources.
 - Add [blink.cmp] option to add
-  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets) so
-  blink.cmp can source snippets from it.
+  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets)
+  so blink.cmp can source snippets from it.
+- Fix [blink.cmp] breaking when built-in sources were modified.
 
 [TheColorman](https://github.com/TheColorman):
 

--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -21,8 +21,9 @@
     freeformType = anything;
     options = {
       module = mkOption {
-        type = str;
-        description = "module of the provider";
+        type = nullOr str;
+        default = null;
+        description = "Provider module.";
       };
     };
   };
@@ -40,7 +41,7 @@ in {
         providers = mkOption {
           type = attrsOf providerType;
           default = {};
-          description = "Settings for completion providers";
+          description = "Settings for completion providers.";
         };
 
         transform_items = mkOption {


### PR DESCRIPTION
It seems like this has been around since before #667, but I only just tried doing this.

Before this pr, doing the following breaks because it complains about `setupOpts.sources.providers.<built-in-source>.module` not being set.

```nix
config.vim.autocomplete.blink-cmp.setupOpts.sources.providers.<built-in-source>.attribute = value;
```

Likely caused by `providerType` option `module` not having a default.
I'm honestly not sure why this causes issues, but it refuses to eval unless it is set, so set it to the correct values.

The implementation does assume that the built-in source modules will not change, which seems relatively safe to me.
If they do, changing them is easy.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc