### PR TITLE
languages/cue: initial CUE language support

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -159,8 +159,10 @@
 [thamenato](https://github.com/thamenato):
 
 [ruff]: (https://github.com/astral-sh/ruff)
+[cue]: (https://cuelang.org/)
 
 - Add [ruff] as a formatter option in `vim.languages.python.format.type`.
+- Add [cue] support under `vim.languages.cue`.
 
 [ARCIII](https://github.com/ArmandoCIII):
 

--- a/modules/plugins/languages/cue.nix
+++ b/modules/plugins/languages/cue.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) package;
+  inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.cue;
+in {
+  options.vim.languages.cue = {
+    enable = mkEnableOption "CUE language support";
+
+    treesitter = {
+      enable = mkEnableOption "CUE treesitter" // {default = config.vim.languages.enableTreesitter;};
+
+      package = mkGrammarOption pkgs "cue";
+    };
+
+    lsp = {
+      enable = mkEnableOption "CUE LSP support" // {default = config.vim.languages.enableLSP;};
+
+      package = mkOption {
+        type = package;
+        default = pkgs.cue;
+        description = "cue lsp implementation";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.cue-lsp = ''
+        lspconfig.cue.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = {"${cfg.lsp.package}/bin/cue", "lsp"},
+        }
+      '';
+    })
+  ]);
+}

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -5,6 +5,7 @@ in {
     ./asm.nix
     ./astro.nix
     ./bash.nix
+    ./cue.nix
     ./dart.nix
     ./clang.nix
     ./css.nix


### PR DESCRIPTION
Add supports to `cue` language.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc