### PR TITLE
language/php: add initial support for intelephense php lsp

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -241,3 +241,7 @@
 [BANanaD3V](https://github.com/BANanaD3V):
 
 - `alpha` is now configured with nix.
+
+[viicslen](https://github.com/viicslen):
+
+- Add `intelephense` language server suppor under `vim.languages.php.lsp.server`

--- a/modules/plugins/languages/php.nix
+++ b/modules/plugins/languages/php.nix
@@ -64,6 +64,26 @@
         }
       '';
     };
+    
+    intelephense = {
+      package = pkgs.intelephense;
+      lspConfig = ''
+        lspconfig.intelephense.setup{
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = ${
+            if isList cfg.lsp.package
+            then expToLua cfg.lsp.package
+            else ''
+              {
+                "${getExe cfg.lsp.package}",
+                "--stdio"
+              },
+            ''
+          }
+        }
+      '';
+    };
   };
 in {
   options.vim.languages.php = {


### PR DESCRIPTION
This pull request includes an update to the `modules/plugins/languages/php.nix` file to add `intelephense` language server configuration for PHP. 