### PR TITLE
utiltiy/snacks-nvim: init module

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -13,6 +13,7 @@
 [render-markdown.nvim]: https://github.com/MeanderingProgrammer/render-markdown.nvim
 [yanky.nvim]: https://github.com/gbprod/yanky.nvim
 [yazi.nvim]: https://github.com/mikavilpas/yazi.nvim
+[snacks.nvim]: https://github.com/folke/snacks.nvim
 
 - Add [typst-preview.nvim] under
   `languages.typst.extensions.typst-preview-nvim`.
@@ -61,6 +62,9 @@
   backend while shada is disabled in Neovim options.
 
 - Add [yazi.nvim] as a companion plugin for Yazi, the terminal file manager.
+
+- Add [snacks.nvim] under `vim.utility.snacks-nvim` as a general-purpose utility
+  plugin.
 
 [amadaluzia](https://github.com/amadaluzia):
 

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -17,6 +17,7 @@
     ./nix-develop
     ./outline
     ./preview
+    ./snacks-nvim
     ./surround
     ./telescope
     ./wakatime

--- a/modules/plugins/utility/snacks-nvim/config.nix
+++ b/modules/plugins/utility/snacks-nvim/config.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAnywhere;
+
+  cfg = config.vim.utility.snacks-nvim;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["snacks-nvim"];
+      pluginRC.snacks-nvim = entryAnywhere ''
+        require("snacks").setup(${toLuaObject cfg.setupOpts});
+      '';
+    };
+  };
+}

--- a/modules/plugins/utility/snacks-nvim/default.nix
+++ b/modules/plugins/utility/snacks-nvim/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./snacks-nvim.nix
+  ];
+}

--- a/modules/plugins/utility/snacks-nvim/snacks-nvim.nix
+++ b/modules/plugins/utility/snacks-nvim/snacks-nvim.nix
@@ -1,0 +1,12 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.utility.snacks-nvim = {
+    enable = mkEnableOption ''
+      collection of QoL plugins for Neovim [snacks-nvim]
+    '';
+
+    setupOpts = mkPluginSetupOption "snacks-nvim" {};
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1989,16 +1989,19 @@
       "hash": "0k1xnyvblshn4fhbxgl0i34j22n55xlwr09sdmb23l57br5rb07q"
     },
     "snacks-nvim": {
-      "type": "Git",
+      "type": "GitRelease",
       "repository": {
         "type": "GitHub",
         "owner": "folke",
         "repo": "snacks.nvim"
       },
-      "branch": "main",
-      "revision": "bc0630e43be5699bb94dadc302c0d21615421d93",
-      "url": "https://github.com/folke/snacks.nvim/archive/bc0630e43be5699bb94dadc302c0d21615421d93.tar.gz",
-      "hash": "0a5nw7xa33shag1h12gf930g3vcixbwk8dxv0ji4980ycskh238v"
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "version": "v2.22.0",
+      "revision": "5eac729fa290248acfe10916d92a5ed5e5c0f9ed",
+      "url": "https://api.github.com/repos/folke/snacks.nvim/tarball/v2.22.0",
+      "hash": "1hbm4fnw51qdp0nz83fcxbvnxjq2k57a37w6dp0wz6wkcx7cwxw9"
     },
     "sqls-nvim": {
       "type": "Git",


### PR DESCRIPTION
Adds a module for [snacks.nvim](https://github.com/folke/snacks.nvim) under `vim.utility.snacks-nvim`. There are no defaults, as we are now trying to avoid default options as much as possible

Note that some of the healthchecks will warn the user about missing tools, e.g., lazygit. This is expected, as nvf wants to avoid bundling tools and increase the closure size. This can be solved by running `:checkhealth snacks` and adding the missing tools as you require them.

Closes #613 