### PR TITLE
blink-cmp: apply Nix patch; use new fetcher

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -228,8 +228,9 @@
   syncing of nvim shell environment with direnv's.
 - Add [blink.cmp] source options and some default-disabled sources.
 - Add [blink.cmp] option to add
-  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets) so
-  blink.cmp can source snippets from it.
+  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets)
+  so blink.cmp can source snippets from it.
+- Fix [blink.cmp] breaking when built-in sources were modified.
 
 [TheColorman](https://github.com/TheColorman):
 

--- a/flake/legacyPackages/blink-cmp.nix
+++ b/flake/legacyPackages/blink-cmp.nix
@@ -5,6 +5,7 @@
   git,
   src,
   version,
+  fetchpatch,
 }: let
   blink-fuzzy-lib = rustPlatform.buildRustPackage {
     pname = "blink-fuzzy-lib";
@@ -13,11 +14,10 @@
     # TODO: remove this if plugin stops using nightly rust
     env.RUSTC_BOOTSTRAP = true;
 
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-F1wh/TjYoiIbDY3J/prVF367MKk3vwM7LqOpRobOs7I=";
+
     nativeBuildInputs = [git];
-    cargoLock = {
-      lockFile = "${src}/Cargo.lock";
-      allowBuiltinFetchGit = true;
-    };
   };
 
   libExt =
@@ -34,5 +34,19 @@ in
     preInstall = ''
       mkdir -p target/release
       ln -s ${blink-fuzzy-lib}/lib/libblink_cmp_fuzzy.${libExt} target/release/libblink_cmp_fuzzy.${libExt}
+      echo -n "nix" > target/release/version
     '';
+
+    # Borrowed from nixpkgs
+    # TODO: Remove this patch when updating to next version
+    patches = [
+      (fetchpatch {
+        name = "blink-add-bypass-for-nix.patch";
+        url = "https://github.com/Saghen/blink.cmp/commit/6c83ef1ae34abd7ef9a32bfcd9595ac77b61037c.diff?full_index=1";
+        hash = "sha256-304F1gDDKVI1nXRvvQ0T1xBN+kHr3jdmwMMp8CNl+GU=";
+      })
+    ];
+
+    # Module for reproducing issues
+    nvimSkipModule = ["repro"];
   }

--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -21,8 +21,9 @@
     freeformType = anything;
     options = {
       module = mkOption {
-        type = str;
-        description = "module of the provider";
+        type = nullOr str;
+        default = null;
+        description = "Provider module.";
       };
     };
   };
@@ -40,7 +41,7 @@ in {
         providers = mkOption {
           type = attrsOf providerType;
           default = {};
-          description = "Settings for completion providers";
+          description = "Settings for completion providers.";
         };
 
         transform_items = mkOption {


### PR DESCRIPTION
Clean up build derivation for blink-cmp, based on nixpkgs variant. This pulls in
a patch that we probably should've vendored, but it will no longer be necessary
with the next update.

Also uses the new fetcher.

Possibly fixes #713
