### PR TITLE
lsp/lspsaga: update source; lazyload; remove keybinds

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -2,10 +2,17 @@
 
 ## Breaking changes
 
+[Lspsaga documentation]: https://nvimdev.github.io/lspsaga/
+
 - `git-conflict` keybinds are now prefixed with `<leader>` to avoid conflicting
   with builtins.
 
 - `alpha` is now configured with nix, default config removed.
+
+- Lspsaga module no longer ships default keybindings. The keybind format has
+  been changed by upstream, and old keybindings do not have equivalents under
+  the new API they provide. Please manually set your keybinds according to
+  [Lspsaga documentation] following the new API.
 
 [NotAShelf](https://github.com/notashelf):
 
@@ -68,6 +75,8 @@
 
 - Move LSPSaga to `setupOpts` format, allowing freeform configuration in
   `vim.lsp.lspsaga.setupOpts`.
+
+- Lazyload Lspsaga and remove default keybindings for it.
 
 [amadaluzia](https://github.com/amadaluzia):
 

--- a/modules/plugins/lsp/lspsaga/config.nix
+++ b/modules/plugins/lsp/lspsaga/config.nix
@@ -3,47 +3,24 @@
   lib,
   ...
 }: let
-  inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetLuaBinding;
-  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.modules) mkIf mkDefault;
 
   cfg = config.vim.lsp;
-  self = import ./lspsaga.nix {inherit config lib;};
-
-  mappingDefinitions = self.options.vim.lsp.lspsaga.mappings;
-  mappings = addDescriptionsToMappings cfg.lspsaga.mappings mappingDefinitions;
 in {
   config = mkIf (cfg.enable && cfg.lspsaga.enable) {
     vim = {
-      startPlugins = ["lspsaga-nvim"];
+      lazy.plugins.lspsaga-nvim = {
+        package = "lspsaga-nvim";
+        setupModule = "lspsaga";
+        inherit (cfg.lspsaga) setupOpts;
 
-      pluginRC.lspsaga = entryAnywhere ''
-        require('lspsaga').init_lsp_saga(${toLuaObject cfg.lspsaga.setupOpts})
-      '';
-
-      maps = {
-        visual = mkSetLuaBinding mappings.codeAction "require('lspsaga.codeaction').range_code_action";
-        normal = mkMerge [
-          (mkSetLuaBinding mappings.lspFinder "require('lspsaga.provider').lsp_finder")
-          (mkSetLuaBinding mappings.renderHoveredDoc "require('lspsaga.hover').render_hover_doc")
-
-          (mkSetLuaBinding mappings.smartScrollUp "function() require('lspsaga.action').smart_scroll_with_saga(-1) end")
-          (mkSetLuaBinding mappings.smartScrollDown "function() require('lspsaga.action').smart_scroll_with_saga(1) end")
-
-          (mkSetLuaBinding mappings.rename "require('lspsaga.rename').rename")
-          (mkSetLuaBinding mappings.previewDefinition "require('lspsaga.provider').preview_definition")
-
-          (mkSetLuaBinding mappings.showLineDiagnostics "require('lspsaga.diagnostic').show_line_diagnostics")
-          (mkSetLuaBinding mappings.showCursorDiagnostics "require('lspsaga.diagnostic').show_cursor_diagnostics")
-
-          (mkSetLuaBinding mappings.nextDiagnostic "require('lspsaga.diagnostic').navigate('next')")
-          (mkSetLuaBinding mappings.previousDiagnostic "require('lspsaga.diagnostic').navigate('prev')")
-
-          (mkSetLuaBinding mappings.codeAction "require('lspsaga.codeaction').code_action")
-          (mkIf (!cfg.lspSignature.enable) (mkSetLuaBinding mappings.signatureHelp "require('lspsaga.signaturehelp').signature_help"))
-        ];
+        event = ["LspAttach"];
       };
+
+      # Optional dependencies, pretty useful to enhance default functionality of
+      # Lspsaga.
+      treesitter.enable = mkDefault true;
+      visuals.nvim-web-devicons.enable = mkDefault true;
     };
   };
 }

--- a/modules/plugins/lsp/lspsaga/lspsaga.nix
+++ b/modules/plugins/lsp/lspsaga/lspsaga.nix
@@ -3,10 +3,21 @@
   lib,
   ...
 }: let
+  inherit (lib.modules) mkRemovedOptionModule;
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) borderType mkPluginSetupOption;
 in {
+  imports = [
+    (mkRemovedOptionModule ["vim" "lsp" "lspsaga" "mappings"] ''
+      Lspsaga mappings have been removed from nvf, as the original author has made
+      very drastic changes to the API after taking back ownership, and the fork we
+      used is now archived. Please refer to Lspsaga documentation to add keybinds
+      for functionality you have used.
+
+      <https://nvimdev.github.io/lspsaga>
+    '')
+  ];
+
   options.vim.lsp.lspsaga = {
     enable = mkEnableOption "LSP Saga";
 
@@ -16,27 +27,6 @@ in {
         default = config.vim.ui.borders.globalStyle;
         description = "Border type, see {command}`:help nvim_open_win`";
       };
-    };
-
-    mappings = {
-      lspFinder = mkMappingOption "LSP Finder [LSPSaga]" "<leader>lf";
-      renderHoveredDoc = mkMappingOption "Rendered hovered docs [LSPSaga]" "<leader>lh";
-
-      smartScrollUp = mkMappingOption "Smart scroll up [LSPSaga]" "<C-f>";
-      smartScrollDown = mkMappingOption "Smart scroll up [LSPSaga]" "<C-b>";
-
-      rename = mkMappingOption "Rename [LSPSaga]" "<leader>lr";
-      previewDefinition = mkMappingOption "Preview definition [LSPSaga]" "<leader>ld";
-
-      showLineDiagnostics = mkMappingOption "Show line diagnostics [LSPSaga]" "<leader>ll";
-      showCursorDiagnostics = mkMappingOption "Show cursor diagnostics [LSPSaga]" "<leader>lc";
-
-      nextDiagnostic = mkMappingOption "Next diagnostic [LSPSaga]" "<leader>ln";
-      previousDiagnostic = mkMappingOption "Previous diagnostic [LSPSaga]" "<leader>lp";
-
-      codeAction = mkMappingOption "Code action [LSPSaga]" "<leader>ca";
-
-      signatureHelp = mkMappingOption "Signature help [LSPSaga]" "<leader>ls";
     };
   };
 }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -717,13 +717,13 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "tami5",
+        "owner": "nvimdev",
         "repo": "lspsaga.nvim"
       },
       "branch": "main",
-      "revision": "5faeec9f2508d2d49a66c0ac0d191096b4e3fa81",
-      "url": "https://github.com/tami5/lspsaga.nvim/archive/5faeec9f2508d2d49a66c0ac0d191096b4e3fa81.tar.gz",
-      "hash": "1bw71db69na2sriv9q167z9bgkir4nwny1bdfv9z606bmng4hhzc"
+      "revision": "6063935cf68de9aa6dd79f8e1caf5df0a9385de3",
+      "url": "https://github.com/nvimdev/lspsaga.nvim/archive/6063935cf68de9aa6dd79f8e1caf5df0a9385de3.tar.gz",
+      "hash": "1pqasjg2f2yd3ci8hyxfqqs7xnkmwdc411dlm6qg1agiv1h8v205"
     },
     "lua-utils-nvim": {
       "type": "Git",


### PR DESCRIPTION
Points lspsaga to the new source, which is the repository by the original author now that he is back. With this update, comes breaking API changes to keybinds- so I removed them entirely. Users are invited to add their own keybinds using nvf's own API. Documentation has been updated.

We also lazyload lspsaga now :)