### PR TITLE
completion/nvim-cmp: document default sources; allow override

### DIFF
--- a/modules/plugins/completion/nvim-cmp/config.nix
+++ b/modules/plugins/completion/nvim-cmp/config.nix
@@ -60,12 +60,6 @@ in {
         enableSharedCmpSources = true;
 
         nvim-cmp = {
-          sources = {
-            nvim-cmp = null;
-            buffer = "[Buffer]";
-            path = "[Path]";
-          };
-
           sourcePlugins = ["cmp-buffer" "cmp-path"];
 
           setupOpts = {

--- a/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
+++ b/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
@@ -98,14 +98,16 @@ in {
 
     sources = mkOption {
       type = attrsOf (nullOr str);
-      default = {};
+      default = {
+        nvim-cmp = null;
+        buffer = "[Buffer]";
+        path = "[Path]";
+      };
+      example = {
+        nvim-cmp = null;
+        buffer = "[Buffer]";
+      };
       description = "The list of sources used by nvim-cmp";
-      example = literalExpression ''
-        {
-          nvim-cmp = null;
-          buffer = "[Buffer]";
-        }
-      '';
     };
 
     sourcePlugins = mkOption {


### PR DESCRIPTION
Moves nvim-cmp's default sources to the option default, which makes them appear
on the documentation properly. This should also make it so that overriding the
default no longer requires `mkForce`.

Closes #701 
