### PR TITLE
lazy: create LazyFile user event, load copilot-lua on LazyFile

### DIFF
--- a/docs/manual/configuring/custom-plugins/lazy-method.md
+++ b/docs/manual/configuring/custom-plugins/lazy-method.md
@@ -38,3 +38,22 @@ As of version **0.7**, we exposed an API for configuring lazy-loaded plugins via
   };
 }
 ```
+
+## LazyFile event {#sec-lazyfile-event}
+
+You can use the `LazyFile` user event to load a plugin when a file is opened:
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "aerial.nvim" = {
+      package = pkgs.vimPlugins.aerial-nvim;
+      event = [{event = "User"; pattern = "LazyFile";}];
+      # ...
+    };
+  };
+}
+```
+
+You can consider `LazyFile` as an alias to
+`["BufReadPost" "BufNewFile" "BufWritePre"]`

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -89,6 +89,7 @@
 [blink.cmp]: https://github.com/saghen/blink.cmp
 
 - Add [blink.cmp] support.
+- Add `LazyFile` user event.
 
 [diniamo](https://github.com/diniamo):
 
@@ -244,8 +245,8 @@
   syncing of nvim shell environment with direnv's.
 - Add [blink.cmp] source options and some default-disabled sources.
 - Add [blink.cmp] option to add
-  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets)
-  so blink.cmp can source snippets from it.
+  [friendly-snippets](https://github.com/rafamadriz/friendly-snippets) so
+  blink.cmp can source snippets from it.
 - Fix [blink.cmp] breaking when built-in sources were modified.
 
 [TheColorman](https://github.com/TheColorman):

--- a/modules/plugins/assistant/copilot/config.nix
+++ b/modules/plugins/assistant/copilot/config.nix
@@ -37,6 +37,12 @@ in {
           inherit (cfg) setupOpts;
           after = mkIf cfg.cmp.enable "require('copilot_cmp').setup()";
 
+          event = [
+            {
+              event = "User";
+              pattern = "LazyFile";
+            }
+          ];
           cmd = ["Copilot" "CopilotAuth" "CopilotDetach" "CopilotPanel" "CopilotStop"];
           keys = [
             (mkLuaKeymap ["n"] cfg.mappings.panel.accept (wrapPanelBinding ''require("copilot.panel").accept'' cfg.mappings.panel.accept) "[copilot] Accept suggestion" {})

--- a/modules/wrapper/lazy/config.nix
+++ b/modules/wrapper/lazy/config.nix
@@ -134,6 +134,15 @@ in {
       startPlugins = ["lz-n" "lzn-auto-require"];
 
       optPlugins = pluginPackages;
+      augroups = [{name = "nvf_lazy_file_hooks";}];
+      autocmds = [
+        {
+          event = ["BufReadPost" "BufNewFile" "BufWritePre"];
+          group = "nvf_lazy_file_hooks";
+          command = "doautocmd User LazyFile";
+          once = true;
+        }
+      ];
 
       lazy.builtLazyConfig = ''
         require('lz.n').load(${toLuaObject lznSpecs})

--- a/modules/wrapper/lazy/lazy.nix
+++ b/modules/wrapper/lazy/lazy.nix
@@ -126,7 +126,7 @@
       };
 
       event = mkOption {
-        type = nullOr (oneOf [str (listOf str) lznEvent]);
+        type = nullOr (oneOf [str lznEvent (listOf (either str lznEvent))]);
         default = null;
         description = "Lazy-load on event";
       };


### PR DESCRIPTION
related: #693 

creates a LazyFile user event based on LazyVim's LazyFile

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [x] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
