### PR TITLE
nvim-lint: fix config syntax

### DIFF
--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -13,7 +13,7 @@ in {
     vim = {
       startPlugins = ["nvim-lint"];
       pluginRC.nvim-lint = entryAnywhere ''
-        require("lint").linters_by_ft(${toLuaObject cfg.linters_by_ft})
+        require("lint").linters_by_ft = ${toLuaObject cfg.linters_by_ft}
       '';
     };
   };


### PR DESCRIPTION
fixes #732 #686 

can't tell if nvim-lint actually works, but at least it doesn't crash now
