### PR TITLE
eslint_d: added conditions for launching eslint_d

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -271,3 +271,7 @@
 [Butzist](https://github.com/butzist):
 
 - Add Helm chart support under `vim.languages.helm`.
+
+[rice-cracker-dev](https://github.com/rice-cracker-dev)
+
+- `eslint_d` now checks for configuration files to load.

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -272,6 +272,6 @@
 
 - Add Helm chart support under `vim.languages.helm`.
 
-[rice-cracker-dev](https://github.com/rice-cracker-dev)
+[rice-cracker-dev](https://github.com/rice-cracker-dev):
 
 - `eslint_d` now checks for configuration files to load.

--- a/modules/plugins/languages/astro.nix
+++ b/modules/plugins/languages/astro.nix
@@ -72,6 +72,16 @@
           ls_sources,
           null_ls.builtins.diagnostics.eslint_d.with({
             command = "${getExe pkg}",
+            condition = function(utils)
+              return utils.root_has_file({
+                "eslint.config.js",
+                "eslint.config.mjs",
+                ".eslintrc",
+                ".eslintrc.json",
+                ".eslintrc.js",
+                ".eslintrc.yml",
+              })
+            end,
           })
         )
       '';

--- a/modules/plugins/languages/svelte.nix
+++ b/modules/plugins/languages/svelte.nix
@@ -72,6 +72,16 @@
           ls_sources,
           null_ls.builtins.diagnostics.eslint_d.with({
             command = "${getExe pkg}",
+            condition = function(utils)
+              return utils.root_has_file({
+                "eslint.config.js",
+                "eslint.config.mjs",
+                ".eslintrc",
+                ".eslintrc.json",
+                ".eslintrc.js",
+                ".eslintrc.yml",
+              })
+            end,
           })
         )
       '';

--- a/modules/plugins/languages/ts.nix
+++ b/modules/plugins/languages/ts.nix
@@ -123,6 +123,16 @@
           ls_sources,
           null_ls.builtins.diagnostics.eslint_d.with({
             command = "${getExe pkg}",
+            condition = function(utils)
+              return utils.root_has_file({
+                "eslint.config.js",
+                "eslint.config.mjs",
+                ".eslintrc",
+                ".eslintrc.json",
+                ".eslintrc.js",
+                ".eslintrc.yml",
+              })
+            end,
           })
         )
       '';


### PR DESCRIPTION
i added conditions to launch eslint_d when root has one of these files:
- eslint.config.mjs
- eslint.config.js
- .eslintrc
- .eslintrc.js
- .eslintrc.json
- .eslintrc.yml

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`