### PR TITLE
assistant/codecompanion-nvim: add mappings

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -276,3 +276,7 @@
 [rice-cracker-dev](https://github.com/rice-cracker-dev):
 
 - `eslint_d` now checks for configuration files to load.
+
+[Sc3l3t0n](https://github.com/Sc3l3t0n):
+
+- Add some mappings to [codecompanion-nvim]

--- a/modules/plugins/assistant/codecompanion/codecompanion-nvim.nix
+++ b/modules/plugins/assistant/codecompanion/codecompanion-nvim.nix
@@ -1,6 +1,7 @@
 {lib, ...}: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) int str enum nullOr attrs;
+  inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
 in {
   options.vim.assistant = {
@@ -272,6 +273,17 @@ in {
             that can be used in the action palette.
           '';
         };
+      };
+
+      mappings = {
+        inlineAssistant.open = mkMappingOption "[CodeCompanion] Open inline Assistant" "<leader>aa";
+        chat = {
+          open = mkMappingOption "[CodeCompanion] Open chat" "<leader>ao";
+          toggle = mkMappingOption "[CodeCompanion] Toggle chat" "<leader>ac";
+          addToChatBuffer = mkMappingOption "[CodeCompanion] Add selection to chat" "<leader>ab";
+        };
+        actions.open = mkMappingOption "[CodeCompanion] Open actions" "<C-a>";
+        command.open = mkMappingOption "[CodeCompanion] Open cli command generation prompt" "<leader>ag";
       };
     };
   };

--- a/modules/plugins/assistant/codecompanion/config.nix
+++ b/modules/plugins/assistant/codecompanion/config.nix
@@ -3,9 +3,21 @@
   lib,
   ...
 }: let
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.nvim.binds) addDescriptionsToMappings mkSetBinding mkSetLuaBinding;
 
+  self = import ./codecompanion-nvim.nix {inherit lib;};
   cfg = config.vim.assistant.codecompanion-nvim;
+
+  mappingDefinitions = self.options.vim.assistant.codecompanion-nvim.mappings;
+  mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
+  maps = mkMerge [
+    (mkSetBinding mappings.inlineAssistant.open "<cmd>CodeCompanion<CR>")
+    (mkSetBinding mappings.chat.open "<cmd>CodeCompanionChat<CR>")
+    (mkSetBinding mappings.chat.toggle "<cmd>CodeCompanionChat Toggle<CR>")
+    (mkSetBinding mappings.actions.open "<cmd>CodeCompanionActions<CR>")
+    (mkSetLuaBinding mappings.command.open "function() vim.fn.feedkeys(\":CodeCompanionCmd \") end")
+  ];
 in {
   config = mkIf cfg.enable {
     vim = {
@@ -19,6 +31,14 @@ in {
           setupModule = "codecompanion";
           inherit (cfg) setupOpts;
         };
+      };
+
+      maps = {
+        visual = mkMerge [
+          (mkSetBinding mappings.chat.addToChatBuffer "<cmd>CodeCompanionChat Add<CR>")
+          maps
+        ];
+        normal = maps;
       };
 
       treesitter.enable = true;


### PR DESCRIPTION
I tried out the `codecompanion-nvim` plugin and noticed, there were no mappings available, so I mapped some common commands of the plugin.

Maybe @ArmandoCIII could take a look too.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes (I'm not sure if I should, because the plugin is new in this release)
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc