### PR TITLE
languages: migrate to conform/nvim-lint

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -88,8 +88,11 @@
 
 [blink.cmp]: https://github.com/saghen/blink.cmp
 
+- Add [aerial.nvim].
+- Add [nvim-ufo].
 - Add [blink.cmp] support.
 - Add `LazyFile` user event.
+- Migrate language modules from none-ls to conform/nvim-lint
 
 [diniamo](https://github.com/diniamo):
 
@@ -97,14 +100,6 @@
 
 - Disable the built-in format-on-save feature of zls. Use `vim.lsp.formatOnSave`
   instead.
-
-[horriblename](https://github.com/horriblename):
-
-[aerial.nvim]: (https://github.com/stevearc/aerial.nvim)
-[nvim-ufo]: (https://github.com/kevinhwang91/nvim-ufo)
-
-- Add [aerial.nvim].
-- Add [nvim-ufo].
 
 [LilleAila](https://github.com/LilleAila):
 

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -3,18 +3,36 @@
   lib,
   ...
 }: let
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.diagnostics.nvim-lint;
 in {
-  config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["nvim-lint"];
-      pluginRC.nvim-lint = entryAnywhere ''
-        require("lint").linters_by_ft = ${toLuaObject cfg.linters_by_ft}
-      '';
-    };
-  };
+  config = mkMerge [
+    (mkIf cfg.enable {
+      vim = {
+        startPlugins = ["nvim-lint"];
+        pluginRC.nvim-lint = entryAnywhere ''
+          require("lint").linters_by_ft = ${toLuaObject cfg.linters_by_ft}
+        '';
+      };
+    })
+    (mkIf cfg.lint_after_save {
+      vim = {
+        augroups = [{name = "nvf_nvim_lint";}];
+        autocmds = [
+          {
+            event = ["BufWritePost"];
+            callback = mkLuaInline ''
+              function()
+                require("lint").try_lint()
+              end
+            '';
+          }
+        ];
+      };
+    })
+  ];
 }

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -16,6 +16,18 @@ in {
         startPlugins = ["nvim-lint"];
         pluginRC.nvim-lint = entryAnywhere ''
           require("lint").linters_by_ft = ${toLuaObject cfg.linters_by_ft}
+
+          local linters = require("lint").linters
+          local nvf_linters = ${toLuaObject cfg.linters}
+          for linter, config in pairs(nvf_linters) do
+            if linters[linter] == nil then
+              linters[linter] = config
+            else
+              for key, val in pairs(config) do
+                linters[linter][key] = val
+              end
+            end
+          end
         '';
       };
     })

--- a/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
+++ b/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
@@ -21,5 +21,7 @@ in {
         accept.
       '';
     };
+
+    lint_after_save = mkEnableOption "autocmd to lint after each save" // {default = true;};
   };
 }

--- a/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
+++ b/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
@@ -1,6 +1,76 @@
 {lib, ...}: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.types) attrsOf listOf str;
+  inherit (lib.types) nullOr attrsOf listOf str either submodule bool enum;
+  inherit (lib.nvim.types) luaInline;
+
+  linterType = submodule {
+    options = {
+      name = mkOption {
+        type = nullOr str;
+        default = null;
+        description = "Name of the linter";
+      };
+
+      cmd = mkOption {
+        type = nullOr str;
+        default = null;
+        description = "Command of the linter";
+      };
+
+      args = mkOption {
+        type = nullOr (listOf (either str luaInline));
+        default = null;
+        description = "Arguments to pass";
+      };
+
+      stdin = mkOption {
+        type = nullOr bool;
+        default = null;
+        description = "Send content via stdin.";
+      };
+
+      append_fname = mkOption {
+        type = nullOr bool;
+        default = null;
+        description = ''
+          Automatically add the current file name to the commands arguments. Only
+          has an effect if stdin is false
+        '';
+      };
+
+      stream = mkOption {
+        type = nullOr (enum ["stdout" "stderr" "both"]);
+        default = null;
+        description = "Result stream";
+      };
+
+      ignore_exitcode = mkOption {
+        type = nullOr bool;
+        default = null;
+        description = ''
+          Declares if exit code != 1 should be ignored or result in a warning.
+        '';
+      };
+
+      env = mkOption {
+        type = nullOr (attrsOf str);
+        default = null;
+        description = "Environment variables to use";
+      };
+
+      cwd = mkOption {
+        type = nullOr str;
+        default = null;
+        description = "Working directory of the linter";
+      };
+
+      parser = mkOption {
+        type = nullOr luaInline;
+        default = null;
+        description = "Parser function";
+      };
+    };
+  };
 in {
   options.vim.diagnostics.nvim-lint = {
     enable = mkEnableOption "asynchronous linter plugin for Neovim [nvim-lint]";
@@ -19,6 +89,30 @@ in {
         through `toLuaObject. You are responsible for passing the correct Nix
         data types to generate a correct Lua value that conform is able to
         accept.
+      '';
+    };
+
+    linters = mkOption {
+      type = attrsOf linterType;
+      default = {};
+      example = ''
+        {
+          phpcs = {
+            args = ["-q" "--report-json" "-"];
+
+            # this will replace the builtin's env table if it exists
+            env = {
+              ENV_VAR = "something";
+            };
+          };
+        }
+      '';
+
+      description = ''
+        Linter configurations. Builtin linters will be updated and not
+        replaced, but note that this is not a deep extend operation, i.e. if
+        you define an `env` option, it will replace the entire `env` table
+        provided by the builtin (if it exists).
       '';
     };
 

--- a/modules/plugins/languages/astro.nix
+++ b/modules/plugins/languages/astro.nix
@@ -10,8 +10,8 @@
   inherit (lib.lists) isList;
   inherit (lib.meta) getExe;
   inherit (lib.types) enum either listOf package str;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.lua) expToLua;
-  inherit (lib.nvim.languages) diagnosticsToLua;
   inherit (lib.nvim.types) mkGrammarOption diagnostics;
 
   cfg = config.vim.languages.astro;
@@ -39,26 +39,10 @@
   formats = {
     prettier = {
       package = pkgs.nodePackages.prettier;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.prettier.with({
-            command = "${cfg.format.package}/bin/prettier",
-          })
-        )
-      '';
     };
 
     biome = {
       package = pkgs.biome;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.biome.with({
-            command = "${cfg.format.package}/bin/biome",
-          })
-        )
-      '';
     };
   };
 
@@ -67,24 +51,23 @@
   diagnosticsProviders = {
     eslint_d = {
       package = pkgs.eslint_d;
-      nullConfig = pkg: ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.diagnostics.eslint_d.with({
-            command = "${getExe pkg}",
-            condition = function(utils)
-              return utils.root_has_file({
-                "eslint.config.js",
-                "eslint.config.mjs",
-                ".eslintrc",
-                ".eslintrc.json",
-                ".eslintrc.js",
-                ".eslintrc.yml",
-              })
-            end,
-          })
-        )
-      '';
+      config = {
+        # HACK: change if nvim-lint gets a dynamic enable thing
+        parser = mkLuaInline ''
+          function(output, bufnr, cwd)
+            local markers = { "eslint.config.js", "eslint.config.mjs",
+              ".eslintrc", ".eslintrc.json", ".eslintrc.js", ".eslintrc.yml", }
+            for _, filename in ipairs(markers) do
+              local path = vim.fs.join(cwd, filename)
+              if vim.loop.fs_stat(path) then
+                return require("lint.linters.eslint_d").parser(output, bufnr, cwd)
+              end
+            end
+
+            return {}
+          end
+        '';
+      };
     };
   };
 in {
@@ -153,16 +136,29 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.astro-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.astro = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources = diagnosticsToLua {
-        lang = "astro";
-        config = cfg.extraDiagnostics.types;
-        inherit diagnosticsProviders;
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.astro = cfg.extraDiagnostics.types;
+        linters = mkMerge (map (
+            name: {
+              ${name} =
+                diagnosticsProviders.${name}.config
+                // {
+                  cmd = getExe diagnosticsProviders.${name}.package;
+                };
+            }
+          )
+          cfg.extraDiagnostics.types);
       };
     })
   ]);

--- a/modules/plugins/languages/css.nix
+++ b/modules/plugins/languages/css.nix
@@ -6,6 +6,7 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.types) enum either listOf package str;
@@ -42,14 +43,6 @@
   formats = {
     prettier = {
       package = pkgs.nodePackages.prettier;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.prettier.with({
-            command = "${cfg.format.package}/bin/prettier",
-          })
-        )
-      '';
     };
 
     prettierd = {
@@ -132,8 +125,13 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.css-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.css = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/elixir.nix
+++ b/modules/plugins/languages/elixir.nix
@@ -38,14 +38,9 @@
   formats = {
     mix = {
       package = pkgs.elixir;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.mix.with({
-            command = "${cfg.format.package}/bin/mix",
-          })
-        )
-      '';
+      config = {
+        command = "${cfg.format.package}/bin/mix";
+      };
     };
   };
 in {
@@ -107,8 +102,12 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.elixir-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.elixir = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} =
+          formats.${cfg.format.type}.config;
+      };
     })
 
     (mkIf cfg.elixir-tools.enable {

--- a/modules/plugins/languages/fsharp.nix
+++ b/modules/plugins/languages/fsharp.nix
@@ -7,6 +7,7 @@
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.types) either listOf package str enum;
+  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.nvim.types) mkGrammarOption;
@@ -35,14 +36,6 @@
   formats = {
     fantomas = {
       package = pkgs.fantomas;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.fantomas.with({
-            command = "${cfg.format.package}/bin/fantomas",
-          })
-        )
-      '';
     };
   };
 
@@ -102,8 +95,13 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.fsharp-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.fsharp = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/go.nix
+++ b/modules/plugins/languages/go.nix
@@ -38,36 +38,15 @@
   formats = {
     gofmt = {
       package = pkgs.go;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.gofmt.with({
-            command = "${cfg.format.package}/bin/gofmt",
-          })
-        )
-      '';
+      config.command = "${cfg.format.package}/bin/gofmt";
     };
     gofumpt = {
       package = pkgs.gofumpt;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.gofumpt.with({
-            command = "${cfg.format.package}/bin/gofumpt",
-          })
-        )
-      '';
+      config.command = getExe cfg.format.package;
     };
     golines = {
       package = pkgs.golines;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.golines.with({
-            command = "${cfg.format.package}/bin/golines",
-          })
-        )
-      '';
+      config.command = "${cfg.format.package}/bin/golines";
     };
   };
 
@@ -153,8 +132,11 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.go-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.go = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = formats.${cfg.format.type}.config;
+      };
     })
 
     (mkIf cfg.dap.enable {

--- a/modules/plugins/languages/hcl.nix
+++ b/modules/plugins/languages/hcl.nix
@@ -6,6 +6,7 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) package bool enum;
   inherit (lib.nvim.types) mkGrammarOption;
@@ -30,14 +31,6 @@
   formats = {
     hclfmt = {
       package = pkgs.hclfmt;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.hclfmt.with({
-            command = "${lib.getExe cfg.format.package}",
-          })
-        )
-      '';
     };
   };
 in {
@@ -110,8 +103,13 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.hcl-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.hcl = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/nim.nix
+++ b/modules/plugins/languages/nim.nix
@@ -6,6 +6,7 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.types) enum either listOf package str;
@@ -38,14 +39,9 @@
   formats = {
     nimpretty = {
       package = pkgs.nim;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.nimpretty.with({
-            command = "${pkgs.nim}/bin/nimpretty",
-          })
-        )
-      '';
+      config = {
+        command = "${cfg.format.package}/bin/nimpretty";
+      };
     };
   };
 in {
@@ -110,8 +106,11 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.nim-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.nim = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = formats.${cfg.format.type}.config;
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/ocaml.nix
+++ b/modules/plugins/languages/ocaml.nix
@@ -37,14 +37,6 @@
   formats = {
     ocamlformat = {
       package = pkgs.ocamlPackages.ocamlformat;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.ocamlformat.with({
-            command = "${cfg.format.package}/bin/ocamlformat",
-          })
-        )
-      '';
     };
   };
 in {
@@ -97,9 +89,13 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.ocamlformat = formats.${cfg.format.type}.nullConfig;
-      vim.extraPackages = [formats.${cfg.format.type}.package];
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.ocaml = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
   ]);
 }

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -66,26 +66,10 @@
   formats = {
     black = {
       package = pkgs.black;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.black.with({
-            command = "${cfg.format.package}/bin/black",
-          })
-        )
-      '';
     };
 
     isort = {
       package = pkgs.isort;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.isort.with({
-            command = "${cfg.format.package}/bin/isort",
-          })
-        )
-      '';
     };
 
     black-and-isort = {
@@ -96,15 +80,6 @@
           black --quiet - "$@" | isort --profile black -
         '';
       };
-
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.black.with({
-            command = "${cfg.format.package}/bin/black",
-          })
-        )
-      '';
     };
 
     ruff = {
@@ -115,14 +90,6 @@
           ruff format -
         '';
       };
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.ruff.with({
-            command = "${cfg.format.package}/bin/ruff",
-          })
-        )
-      '';
     };
   };
 
@@ -272,8 +239,22 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.python-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        # HACK: I'm planning to remove these soon so I just took the easiest way out
+        setupOpts.formatters_by_ft.python =
+          if cfg.format.type == "black-and-isort"
+          then ["black"]
+          else [cfg.format.type];
+        setupOpts.formatters =
+          if (cfg.format.type == "black-and-isort")
+          then {
+            black.command = "${cfg.format.package}/bin/black";
+          }
+          else {
+            ${cfg.format.type}.command = getExe cfg.format.package;
+          };
+      };
     })
 
     (mkIf cfg.dap.enable {

--- a/modules/plugins/languages/r.nix
+++ b/modules/plugins/languages/r.nix
@@ -24,28 +24,29 @@
       package = pkgs.rWrapper.override {
         packages = [pkgs.rPackages.styler];
       };
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.styler.with({
-            command = "${cfg.format.package}/bin/R",
-          })
-        )
-      '';
+      config = {
+        command = "${cfg.format.package}/bin/R";
+      };
     };
 
     format_r = {
       package = pkgs.rWrapper.override {
         packages = [pkgs.rPackages.formatR];
       };
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.format_r.with({
-            command = "${cfg.format.package}/bin/R",
-          })
-        )
-      '';
+      config = {
+        command = "${cfg.format.package}/bin/R";
+        stdin = true;
+        args = [
+          "--slave"
+          "--no-restore"
+          "--no-save"
+          "-s"
+          "-e"
+          ''formatR::tidy_source(source="stdin")''
+        ];
+        # TODO: range_args seem to be possible
+        # https://github.com/nvimtools/none-ls.nvim/blob/main/lua/null-ls/builtins/formatting/format_r.lua
+      };
     };
   };
 
@@ -118,8 +119,11 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.r-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.r = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = formats.${cfg.format.type}.config;
+      };
     })
 
     (mkIf cfg.lsp.enable {

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -5,6 +5,7 @@
   ...
 }: let
   inherit (builtins) attrNames;
+  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.strings) optionalString;
@@ -21,14 +22,6 @@
   formats = {
     rustfmt = {
       package = pkgs.rustfmt;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.rustfmt.with({
-            command = "${cfg.format.package}/bin/rustfmt",
-          })
-        )
-      '';
     };
   };
 in {
@@ -128,8 +121,13 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.rust-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.rust = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
 
     (mkIf (cfg.lsp.enable || cfg.dap.enable) {

--- a/modules/plugins/languages/svelte.nix
+++ b/modules/plugins/languages/svelte.nix
@@ -9,9 +9,9 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.meta) getExe;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.types) enum either listOf package str;
   inherit (lib.nvim.lua) expToLua;
-  inherit (lib.nvim.languages) diagnosticsToLua;
   inherit (lib.nvim.types) mkGrammarOption diagnostics;
 
   cfg = config.vim.languages.svelte;
@@ -39,52 +39,38 @@
   formats = {
     prettier = {
       package = pkgs.nodePackages.prettier;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.prettier.with({
-            command = "${cfg.format.package}/bin/prettier",
-          })
-        )
-      '';
     };
 
     biome = {
       package = pkgs.biome;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.biome.with({
-            command = "${cfg.format.package}/bin/biome",
-          })
-        )
-      '';
     };
   };
 
   # TODO: specify packages
   defaultDiagnosticsProvider = ["eslint_d"];
   diagnosticsProviders = {
-    eslint_d = {
-      package = pkgs.eslint_d;
-      nullConfig = pkg: ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.diagnostics.eslint_d.with({
-            command = "${getExe pkg}",
-            condition = function(utils)
-              return utils.root_has_file({
-                "eslint.config.js",
-                "eslint.config.mjs",
-                ".eslintrc",
-                ".eslintrc.json",
-                ".eslintrc.js",
-                ".eslintrc.yml",
-              })
-            end,
-          })
-        )
-      '';
+    eslint_d = let
+      pkg = pkgs.eslint_d;
+    in {
+      package = pkg;
+      config = {
+        cmd = getExe pkg;
+        # HACK: change if nvim-lint gets a dynamic enable thing
+        parser = mkLuaInline ''
+          function(output, bufnr, cwd)
+            local markers = { "eslint.config.js", "eslint.config.mjs",
+              ".eslintrc", ".eslintrc.json", ".eslintrc.js", ".eslintrc.yml", }
+            for _, filename in ipairs(markers) do
+              local path = vim.fs.join(cwd, filename)
+              if vim.loop.fs_stat(path) then
+                return require("lint.linters.eslint_d").parser(output, bufnr, cwd)
+              end
+            end
+
+            return {}
+          end
+        '';
+      };
     };
   };
 in {
@@ -153,16 +139,22 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.svelte-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.svelte = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources = diagnosticsToLua {
-        lang = "svelte";
-        config = cfg.extraDiagnostics.types;
-        inherit diagnosticsProviders;
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.svelte = cfg.extraDiagnostics.types;
+        linters =
+          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
+            cfg.extraDiagnostics.types);
       };
     })
   ]);

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -9,7 +9,6 @@
   inherit (lib.lists) isList;
   inherit (lib.types) nullOr enum either attrsOf listOf package str;
   inherit (lib.attrsets) attrNames;
-  inherit (lib.generators) mkLuaInline;
   inherit (lib.meta) getExe;
   inherit (lib.nvim.lua) expToLua toLuaObject;
   inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption;
@@ -61,26 +60,10 @@
   formats = {
     typstfmt = {
       package = pkgs.typstfmt;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.typstfmt.with({
-            command = "${cfg.format.package}/bin/typstfmt",
-          })
-        )
-      '';
     };
     # https://github.com/Enter-tainer/typstyle
     typstyle = {
       package = pkgs.typstyle;
-      nullConfig = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.formatting.typstfmt.with({
-            command = "${cfg.format.package}/bin/typstyle",
-          })
-        )
-      '';
     };
   };
 in {
@@ -176,8 +159,13 @@ in {
     })
 
     (mkIf cfg.format.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.typst-format = formats.${cfg.format.type}.nullConfig;
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.typst = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
     })
 
     (mkIf cfg.lsp.enable {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1551,9 +1551,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "bb680d752cec37949faca7a1f509e2fe67ab418a",
-      "url": "https://github.com/nvimtools/none-ls.nvim/archive/bb680d752cec37949faca7a1f509e2fe67ab418a.tar.gz",
-      "hash": "11zgc86cjkv1vi183mplx3bsqa2x7ardk7ybyrp702xx5hmd882l"
+      "revision": "a117163db44c256d53c3be8717f3e1a2a28e6299",
+      "url": "https://github.com/nvimtools/none-ls.nvim/archive/a117163db44c256d53c3be8717f3e1a2a28e6299.tar.gz",
+      "hash": "1qxi1wq3snhns49sl6rli5hsgjn7zzc43brnwv0b6mfzl55ydzr8"
     },
     "nord": {
       "type": "Git",


### PR DESCRIPTION
migrate from null-ls to conform/nvim-lint

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

This PR is free of breaking change, but I do want to do a refactor later to remove redundant options to "centralize" options to the conform/nvim-lint modules.

planned refactors:
- remove `<lang>.format.package` - should be set in conform
- change `<lang>.format.type` to accept a list, some languages need multiple formatters

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
