### PR TITLE
fix(formatter/conform-nvim): allow disabling format on/after save

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -235,8 +235,9 @@
 
 [alfarel](https://github.com/alfarelcynthesis):
 
-- Add missing `yazi.nvim` dependency (`snacks.nvim`).
+[conform.nvim]: https://github.com/stevearc/conform.nvim
 
+- Add missing `yazi.nvim` dependency (`snacks.nvim`).
 - Add [mkdir.nvim](https://github.com/jghauser/mkdir.nvim) plugin for automatic
   creation of parent directories when editing a nested file.
 - Add [nix-develop.nvim](https://github.com/figsoda/nix-develop.nvim) plugin for
@@ -248,6 +249,8 @@
   [friendly-snippets](https://github.com/rafamadriz/friendly-snippets) so
   blink.cmp can source snippets from it.
 - Fix [blink.cmp] breaking when built-in sources were modified.
+- Fix [conform.nvim] not allowing disabling formatting on and after save.
+  Use `null` value to disable them if conform is enabled.
 
 [TheColorman](https://github.com/TheColorman):
 

--- a/modules/plugins/formatter/conform-nvim/conform-nvim.nix
+++ b/modules/plugins/formatter/conform-nvim/conform-nvim.nix
@@ -4,7 +4,7 @@
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption literalExpression;
-  inherit (lib.types) attrs enum;
+  inherit (lib.types) attrs enum nullOr;
   inherit (lib.nvim.types) mkPluginSetupOption;
   inherit (lib.nvim.lua) mkLuaInline;
 in {
@@ -31,7 +31,7 @@ in {
       };
 
       format_on_save = mkOption {
-        type = attrs;
+        type = nullOr attrs;
         default = {
           lsp_format = "fallback";
           timeout_ms = 500;
@@ -43,7 +43,7 @@ in {
       };
 
       format_after_save = mkOption {
-        type = attrs;
+        type = nullOr attrs;
         default = {lsp_format = "fallback";};
         description = ''
           Table that will be passed to `conform.format()`. If this


### PR DESCRIPTION
Allow `null` which disables this functionality, as already described by the options.
This doesn't change the default which format both on and after save.

Also, there are a lot of completely unused inherits in the module, which I didn't clean up, but are probably worth noting.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
  - haven't tested the change directly in nvf, but I have been overriding the setup in my personal config to use `null` for a while
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc