### PR TITLE
theme: Add tinted-vim plugin theming support

### DIFF
--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -3,6 +3,10 @@
 This section lists the release notes for tagged version of **nvf** and the
 current main current main branch
 
+[JamyGolden](https://github.com/JamyGolden):
+
+- Add support for `tinted-vim` (base16, base24) themes
+
 ```{=include=} chapters
 rl-0.1.md
 rl-0.2.md

--- a/modules/plugins/theme/supported-themes.nix
+++ b/modules/plugins/theme/supported-themes.nix
@@ -211,4 +211,9 @@ in {
     '';
     styles = ["dark" "light" "dark_dimmed" "dark_default" "light_default" "dark_high_contrast" "light_high_contrast" "dark_colorblind" "light_colorblind" "dark_tritanopia" "light_tritanopia"];
   };
+  tinted-theming = {
+    setup = {style ? "base24-ayu-dark", ...}: ''
+      vim.cmd.colorscheme("${style}")
+    '';
+  };
 }

--- a/modules/plugins/theme/theme.nix
+++ b/modules/plugins/theme/theme.nix
@@ -43,6 +43,7 @@ in {
         Supported themes can be found in {file}`supportedThemes.nix`.
         Setting the theme to "base16" enables base16 theming and
         requires all of the colors in {option}`vim.theme.base16-colors` to be set.
+        Setting the theme to "tinted-theming" adds all of the "tinted-vim" colorschemes.
       '';
     };
     base16-colors = base16Options;

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2208,6 +2208,19 @@
       "url": "https://github.com/nvim-telescope/telescope.nvim/archive/814f102cd1da3dc78c7d2f20f2ef3ed3cdf0e6e4.tar.gz",
       "hash": "0lbsq6x5bf7l54x7rkdkh7pa63afsgf0jnm0zf9ig7fw2lh18b8f"
     },
+    "tinted-vim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "tinted-theming",
+        "repo": "tinted-vim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "3bca166be9ad02e28934fd6e5c38c31f59cd28fe",
+      "url": "https://github.com/tinted-theming/tinted-vim/archive/3bca166be9ad02e28934fd6e5c38c31f59cd28fe.tar.gz",
+      "hash": "1x6krr0fxip566g7f4j0dh8vrapph0r4vfil3x2mv3zwpqpyvbx5"
+    },
     "tiny-devicons-auto-colors-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
[Tinted Theming](https://github.com/tinted-theming) is the community successor to Base16 and now supports multiple scheme systems, including Base24. This adds [tinted-vim](https://github.com/tinted-theming/tinted-vim) which is simply a bunch of vim colorschemes which can switches to through `vim.cmd.colorscheme("base16-ayu-dark")` for example.

This is my first PR so I'm sure I've done things wrong, but I have read `CONTRIBUTING.md`. A few things of note here:

- I ran `nix run .#maximal -Lv` but it didn't load with the plugin so I wasn't able to test my changes. How can I test the plugin which functions similarly to `base16-nvim`?
- I manually added the values to `npin.sources.json`, is this correct?