### PR TITLE
lsp/null-ls: convert to new setupOpts format; get rid of prelude DAG

### DIFF
--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -5,6 +5,7 @@
 }: let
   inherit (builtins) toJSON;
   inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.binds) addDescriptionsToMappings mkSetExprBinding mkSetLuaBinding pushDownDefault;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.lua) toLuaObject;
@@ -32,6 +33,7 @@ in {
                 return '<Ignore>'
               end
             '')
+
             (mkSetExprBinding gsMappings.previousHunk ''
               function()
                 if vim.wo.diff then return ${toJSON gsMappings.previousHunk.value} end
@@ -77,13 +79,12 @@ in {
     }
 
     (mkIf cfg.codeActions.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.gitsigns-ca = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.code_actions.gitsigns
-        )
-      '';
+      vim.lsp.null-ls = {
+        enable = true;
+        setupOpts.sources.gitsigns-ca = mkLuaInline ''
+          require("null-ls").builtins.code_actions.gitsigns
+        '';
+      };
     })
   ]);
 }

--- a/modules/plugins/lsp/null-ls/config.nix
+++ b/modules/plugins/lsp/null-ls/config.nix
@@ -4,13 +4,12 @@
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.attrsets) mapAttrs;
-  inherit (lib.trivial) boolToString;
-  inherit (lib.nvim.dag) entryAnywhere entryAfter entryBetween;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAfter;
 
-  cfg = config.vim.lsp;
+  cfg = config.vim.lsp.null-ls;
 in {
-  config = mkIf cfg.null-ls.enable (mkMerge [
+  config = mkIf cfg.enable (mkMerge [
     {
       vim = {
         startPlugins = [
@@ -18,35 +17,14 @@ in {
           "plenary-nvim"
         ];
 
-        # null-ls implies LSP already being set up
-        # since it will hook into LSPs to receive information
+        # null-ls implies that LSP is already being set up
+        # as it will hook into LSPs to receive information.
         lsp.enable = true;
 
-        pluginRC = {
-          # early setup for null-ls
-          null_ls-setup = entryAnywhere ''
-            local null_ls = require("null-ls")
-            local null_helpers = require("null-ls.helpers")
-            local null_methods = require("null-ls.methods")
-            local ls_sources = {}
-          '';
-
-          # null-ls setup
-          null_ls = entryAfter ["null_ls-setup" "lsp-setup"] ''
-            require('null-ls').setup({
-              debug = ${boolToString cfg.null-ls.debug},
-              diagnostics_format = "${cfg.null-ls.diagnostics_format}",
-              debounce = ${toString cfg.null-ls.debounce},
-              default_timeout = ${toString cfg.null-ls.default_timeout},
-              sources = ls_sources,
-              on_attach = default_on_attach
-            })
-          '';
-        };
+        pluginRC.null_ls = entryAfter ["lsp-setup"] ''
+          require('null-ls').setup(${toLuaObject cfg.setupOpts})
+        '';
       };
-    }
-    {
-      vim.pluginRC = mapAttrs (_: v: (entryBetween ["null_ls"] ["null_ls-setup"] v)) cfg.null-ls.sources;
     }
   ]);
 }

--- a/modules/plugins/lsp/null-ls/null-ls.nix
+++ b/modules/plugins/lsp/null-ls/null-ls.nix
@@ -1,34 +1,87 @@
 {lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) attrsOf str int;
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) attrsOf str int nullOr;
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.nvim.types) luaInline mkPluginSetupOption;
+  inherit (lib.nvim.config) batchRenameOptions;
+
+  migrationTable = {
+    debug = "debug";
+    diagnostics_format = "diagnostics_format";
+    debounce = "debounce";
+    default_timeout = "default_timeout";
+    sources = "sources";
+  };
+
+  renamedSetupOpts =
+    batchRenameOptions
+    ["vim" "lsp" "null-ls"]
+    ["vim" "lsp" "null-ls" "setupOpts"]
+    migrationTable;
 in {
+  imports = renamedSetupOpts;
+
   options.vim.lsp.null-ls = {
-    enable = mkEnableOption "null-ls, also enabled automatically";
+    enable = mkEnableOption ''
+      null-ls, plugin to use Neovim as a language server to inject LSP diagnostics,
+      code actions, and more via Lua.
+    '';
 
-    debug = mkEnableOption "debugging information for `null-ls";
+    setupOpts = mkPluginSetupOption "null-ls" {
+      debug = mkEnableOption ''
+        debugging information for null-ls.
 
-    diagnostics_format = mkOption {
-      type = str;
-      default = "[#{m}] #{s} (#{c})";
-      description = "Diagnostic output format for null-ls";
-    };
+        Displays all possible log messages and writes them to the null-ls log,
+        which you can view with the command `:NullLsLog`
+      '';
 
-    debounce = mkOption {
-      type = int;
-      default = 250;
-      description = "Default debounce";
-    };
+      diagnostics_format = mkOption {
+        type = str;
+        default = "[#{m}] #{s} (#{c})";
+        description = ''
+          Sets the default format used for diagnostics. null-ls will replace th
+          e following special components with the relevant diagnostic information:
 
-    default_timeout = mkOption {
-      type = int;
-      default = 5000;
-      description = "Default timeout value, in milliseconds";
-    };
+          * `#{m}`: message
+          * `#{s}`: source name (defaults to null-ls if not specified)
+          * `#{c}`: code (if available)
+        '';
+      };
 
-    sources = mkOption {
-      description = "null-ls sources";
-      type = attrsOf str;
-      default = {};
+      debounce = mkOption {
+        type = int;
+        default = 250;
+        description = ''
+          Amount of time between the last change to a buffer and the next `textDocument/didChange` notification.
+        '';
+      };
+
+      default_timeout = mkOption {
+        type = int;
+        default = 5000;
+        description = ''
+          Amount of time (in milliseconds) after which built-in sources will time out.
+
+          :::{.note}
+          Built-in sources can define their own timeout period and users can override
+          the timeout period on a per-source basis
+          :::
+        '';
+      };
+
+      sources = mkOption {
+        type = nullOr (attrsOf luaInline);
+        default = null;
+        description = "Sources for null-ls to register";
+      };
+
+      on_attach = mkOption {
+        type = nullOr luaInline;
+        default = mkLuaInline "on_attach";
+        description = ''
+          Defines an on_attach callback to run whenever null-ls attaches to a buffer.
+        '';
+      };
     };
   };
 }


### PR DESCRIPTION
Converts null-ls to the new setupOpts format now that the plugin has been updated and internal dependency is removed. Few breaking changes, but nothing that should concern the users as far as I'm aware.