### PR TITLE
utility/oil-nvim: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -26,6 +26,7 @@
 [yanky.nvim]: https://github.com/gbprod/yanky.nvim
 [yazi.nvim]: https://github.com/mikavilpas/yazi.nvim
 [snacks.nvim]: https://github.com/folke/snacks.nvim
+[oil.nvim]: https://github.com/stevearc/oil.nvim
 
 - Add [typst-preview.nvim] under
   `languages.typst.extensions.typst-preview-nvim`.
@@ -82,6 +83,9 @@
   `vim.lsp.lspsaga.setupOpts`.
 
 - Lazyload Lspsaga and remove default keybindings for it.
+
+- Add [oil.nvim] as an alternative file explorer. It will be available under
+  `vim.utility.oil-nvim`.
 
 [amadaluzia](https://github.com/amadaluzia):
 

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -15,6 +15,7 @@
     ./multicursors
     ./new-file-template
     ./nix-develop
+    ./oil-nvim
     ./outline
     ./preview
     ./snacks-nvim

--- a/modules/plugins/utility/oil-nvim/config.nix
+++ b/modules/plugins/utility/oil-nvim/config.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAnywhere;
+
+  cfg = config.vim.utility.oil-nvim;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["oil-nvim"];
+      pluginRC.snacks-nvim = entryAnywhere ''
+        require("oil").setup(${toLuaObject cfg.setupOpts});
+      '';
+    };
+  };
+}

--- a/modules/plugins/utility/oil-nvim/default.nix
+++ b/modules/plugins/utility/oil-nvim/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./oil-nvim.nix
+  ];
+}

--- a/modules/plugins/utility/oil-nvim/oil-nvim.nix
+++ b/modules/plugins/utility/oil-nvim/oil-nvim.nix
@@ -1,0 +1,12 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.utility.oil-nvim = {
+    enable = mkEnableOption ''
+      Neovim file explorer: edit your filesystem like a buffer [oil-nvim]
+    '';
+
+    setupOpts = mkPluginSetupOption "oil-nvim" {};
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1919,6 +1919,19 @@
       "url": "https://github.com/epwalsh/obsidian.nvim/archive/14e0427bef6c55da0d63f9a313fd9941be3a2479.tar.gz",
       "hash": "15ycmhn48ryaqzch6w3w6llq2qgmjx8xwkb9dn0075z60dybpflr"
     },
+    "oil-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "stevearc",
+        "repo": "oil.nvim"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "ab887d926c2665a708fbe9e6c4654042cc5f4c60",
+      "url": "https://github.com/stevearc/oil.nvim/archive/ab887d926c2665a708fbe9e6c4654042cc5f4c60.tar.gz",
+      "hash": "13jp8i11yhl9xjki3pcyr1q1gzskskm2fgb3slrwfphn586jb5i6"
+    },
     "omnisharp-extended-lsp-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Add oil.nvim, the alternative file explorer to edit filesystems as a buffer.

Closes #722 