### PR TITLE
terminal/slides: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -203,6 +203,7 @@ isMaximal: {
       toggleterm = {
         enable = true;
         lazygit.enable = true;
+        slides.enable = true;
       };
     };
 

--- a/modules/plugins/terminal/toggleterm/config.nix
+++ b/modules/plugins/terminal/toggleterm/config.nix
@@ -12,39 +12,83 @@
 
   cfg = config.vim.terminal.toggleterm;
   lazygitMapDesc = "Open lazygit [toggleterm]";
+  slidesMapDesc = "Open slides [toggleterm]";
 in {
   config = mkIf cfg.enable {
     vim = {
       lazy.plugins.toggleterm-nvim = {
         package = "toggleterm-nvim";
-        cmd = ["ToggleTerm" "ToggleTermSendCurrentLine" "ToggleTermSendVisualLines" "ToggleTermSendVisualSelection" "ToggleTermSetName" "ToggleTermToggleAll"];
+        cmd = [
+          "ToggleTerm"
+          "ToggleTermSendCurrentLine"
+          "ToggleTermSendVisualLines"
+          "ToggleTermSendVisualSelection"
+          "ToggleTermSetName"
+          "ToggleTermToggleAll"
+        ];
         keys =
-          [(mkKeymap "n" cfg.mappings.open "<Cmd>execute v:count . \"ToggleTerm\"<CR>" {desc = "Toggle terminal";})]
+          [
+            (mkKeymap "n" cfg.mappings.open "<Cmd>execute v:count . \"ToggleTerm\"<CR>" {
+              desc = "Toggle terminal";
+            })
+          ]
           ++ optional cfg.lazygit.enable {
             key = cfg.lazygit.mappings.open;
             mode = "n";
             desc = lazygitMapDesc;
+          }
+          ++ optional cfg.slides.enable {
+            key = cfg.slides.mappings.open;
+            mode = "n";
+            desc = slidesMapDesc;
           };
 
         setupModule = "toggleterm";
         inherit (cfg) setupOpts;
-        after = optionalString cfg.lazygit.enable ''
-          local terminal = require 'toggleterm.terminal'
-          local lazygit = terminal.Terminal:new({
-            cmd = '${
-            if (cfg.lazygit.package != null)
-            then getExe cfg.lazygit.package
-            else "lazygit"
-          }',
-            direction = '${cfg.lazygit.direction}',
-            hidden = true,
-            on_open = function(term)
-              vim.cmd("startinsert!")
-            end
-          })
+        after =
+          optionalString cfg.lazygit.enable ''
+            local terminal = require 'toggleterm.terminal'
+            local lazygit = terminal.Terminal:new({
+              cmd = '${
+              if (cfg.lazygit.package != null)
+              then getExe cfg.lazygit.package
+              else "lazygit"
+            }',
+              direction = '${cfg.lazygit.direction}',
+              hidden = true,
+              on_open = function(term)
+                vim.cmd("startinsert!")
+              end
+            })
 
-          vim.keymap.set('n', ${toLuaObject cfg.lazygit.mappings.open}, function() lazygit:toggle() end, {silent = true, noremap = true, desc = '${lazygitMapDesc}'})
-        '';
+            vim.keymap.set('n', ${toLuaObject cfg.lazygit.mappings.open}, function() lazygit:toggle() end, {silent = true, noremap = true, desc = '${lazygitMapDesc}'})
+          ''
+          + optionalString cfg.slides.enable ''
+            local terminal = require 'toggleterm.terminal'
+
+            local file_path = vim.fn.expand("%:p")
+
+            if file_path == "" then
+              print("No file open")
+              return
+            end
+
+            local slides = terminal.Terminal:new({
+              cmd = '${
+              if (cfg.slides.package != null)
+              then getExe cfg.slides.package
+              else "slides"
+            } ' .. file_path,
+              direction = 'float',
+              hidden = true,
+              close_on_exit = true,
+              on_open = function(term)
+                vim.cmd("startinsert!")
+              end
+            })
+
+            vim.keymap.set('n', ${toLuaObject cfg.slides.mappings.open}, function() slides:toggle() end, {silent = true, noremap = true, desc = '${slidesMapDesc}'})
+          '';
       };
     };
   };

--- a/modules/plugins/terminal/toggleterm/toggleterm.nix
+++ b/modules/plugins/terminal/toggleterm/toggleterm.nix
@@ -5,14 +5,31 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.nvim.binds) mkMappingOption;
-  inherit (lib.types) nullOr str enum bool package either int;
+  inherit
+    (lib.types)
+    nullOr
+    str
+    enum
+    bool
+    package
+    either
+    int
+    ;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   inherit (lib.generators) mkLuaInline;
 in {
   imports = [
-    (mkRenamedOptionModule ["vim" "terminal" "toggleterm" "direction"] ["vim" "terminal" "toggleterm" "setupOpts" "direction"])
-    (mkRenamedOptionModule ["vim" "terminal" "toggleterm" "enable_winbar"] ["vim" "terminal" "toggleterm" "setupOpts" "enable_winbar"])
+    (
+      mkRenamedOptionModule
+      ["vim" "terminal" "toggleterm" "direction"]
+      ["vim" "terminal" "toggleterm" "setupOpts" "direction"]
+    )
+    (
+      mkRenamedOptionModule
+      ["vim" "terminal" "toggleterm" "enable_winbar"]
+      ["vim" "terminal" "toggleterm" "setupOpts" "enable_winbar"]
+    )
   ];
 
   options.vim.terminal.toggleterm = {
@@ -27,7 +44,12 @@ in {
 
     setupOpts = mkPluginSetupOption "ToggleTerm" {
       direction = mkOption {
-        type = enum ["horizontal" "vertical" "tab" "float"];
+        type = enum [
+          "horizontal"
+          "vertical"
+          "tab"
+          "float"
+        ];
         default = "horizontal";
         description = "Direction of the terminal";
       };
@@ -52,7 +74,11 @@ in {
         '';
       };
       winbar = {
-        enabled = mkEnableOption "winbar in terminal" // {default = true;};
+        enabled =
+          mkEnableOption "winbar in terminal"
+          // {
+            default = true;
+          };
         name_formatter = mkOption {
           type = luaInline;
           description = "Winbar formatter function.";
@@ -68,7 +94,12 @@ in {
     lazygit = {
       enable = mkEnableOption "LazyGit integration";
       direction = mkOption {
-        type = enum ["horizontal" "vertical" "tab" "float"];
+        type = enum [
+          "horizontal"
+          "vertical"
+          "tab"
+          "float"
+        ];
         default = "float";
         description = "Direction of the lazygit window";
       };
@@ -81,6 +112,20 @@ in {
 
       mappings = {
         open = mkMappingOption "Open lazygit [toggleterm]" "<leader>gg";
+      };
+    };
+
+    slides = {
+      enable = mkEnableOption "Slides integration";
+
+      package = mkOption {
+        type = nullOr package;
+        default = pkgs.slides;
+        description = "The package that should be used for slides. Setting it to null will attempt to use slides from your PATH";
+      };
+
+      mappings = {
+        open = mkMappingOption "Open slides [toggleterm]" "<leader>ss";
       };
     };
   };


### PR DESCRIPTION
I ported [slides](https://github.com/maaslalani/slides) functionality.

Add the ability to open up a floating terminal to view a slideshow presentation for the markdown file in the current buffer.

This is my first contribution outside of documentation—so I'm looking forward to thoughts and feedback!

## Demo

> open a slideshow with `<leader>ss`, use `j` and `k` to navigate slides and press `q` to close.

![Kapture 2025-03-29 at 14 28 01](https://github.com/user-attachments/assets/b708a579-d99a-4ec2-9450-e043144e0400)