### PR TITLE
Add lint(luacheck), format(stylua) support for lua

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -280,3 +280,7 @@
 [Sc3l3t0n](https://github.com/Sc3l3t0n):
 
 - Add F# support under `vim.languages.fsharp`.
+
+[venkyr77](https://github.com/venkyr77):
+
+- Add lint(luacheck), format(stylua) support for lua.

--- a/modules/plugins/languages/lua.nix
+++ b/modules/plugins/languages/lua.nix
@@ -4,16 +4,30 @@
   lib,
   ...
 }: let
+  inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.meta) getExe;
   inherit (lib.lists) isList;
-  inherit (lib.types) either listOf package str;
-  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.types) bool either enum listOf package str;
+  inherit (lib.nvim.types) diagnostics mkGrammarOption;
   inherit (lib.nvim.lua) expToLua;
   inherit (lib.nvim.dag) entryBefore;
 
   cfg = config.vim.languages.lua;
+  defaultFormat = "stylua";
+  formats = {
+    stylua = {
+      package = pkgs.stylua;
+    };
+  };
+
+  defaultDiagnosticsProvider = ["luacheck"];
+  diagnosticsProviders = {
+    luacheck = {
+      package = pkgs.luajitPackages.luacheck;
+    };
+  };
 in {
   imports = [
     (lib.mkRemovedOptionModule ["vim" "languages" "lua" "lsp" "neodev"] ''
@@ -38,6 +52,34 @@ in {
       };
 
       lazydev.enable = mkEnableOption "lazydev.nvim integration, useful for neovim plugin developers";
+    };
+
+    format = {
+      enable = mkOption {
+        description = "Enable Lua formatting";
+        type = bool;
+        default = config.vim.languages.enableFormat;
+      };
+      type = mkOption {
+        description = "Lua formatter to use";
+        type = enum (attrNames formats);
+        default = defaultFormat;
+      };
+
+      package = mkOption {
+        description = "Lua formatter package";
+        type = package;
+        default = formats.${cfg.format.type}.package;
+      };
+    };
+
+    extraDiagnostics = {
+      enable = mkEnableOption "extra Lua diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+      types = diagnostics {
+        langDesc = "Lua";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
     };
   };
 
@@ -73,6 +115,27 @@ in {
             library = { { path = "''${3rd}/luv/library", words = { "vim%.uv" } } },
           })
         '';
+      })
+
+      (mkIf cfg.format.enable {
+        vim.formatter.conform-nvim = {
+          enable = true;
+          setupOpts.formatters_by_ft.lua = [cfg.format.type];
+          setupOpts.formatters.${cfg.format.type} = {
+            command = getExe cfg.format.package;
+          };
+        };
+      })
+
+      (mkIf cfg.extraDiagnostics.enable {
+        vim.diagnostics.nvim-lint = {
+          enable = true;
+          linters_by_ft.lua = cfg.extraDiagnostics.types;
+          linters = mkMerge (map (name: {
+              ${name}.cmd = getExe diagnosticsProviders.${name}.package;
+            })
+            cfg.extraDiagnostics.types);
+        };
       })
     ]))
   ];


### PR DESCRIPTION
After [this commit](https://github.com/NotAShelf/nvf/pull/749) nvf migrated to conform & nvim-lint. This makes adding formatters and linters a bit less convoluted compared to the previous `null-ls` approach. This PR adds lint, format support to `lua`.

Formatter - https://github.com/JohnnyMorganz/StyLua ([nixpkgs link](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/by-name/st/stylua/package.nix#L33))
Linter - https://github.com/mpeterv/luacheck ([nixpkgs link](https://github.com/NixOS/nixpkgs/blob/nixos-24.11/pkgs/development/lua-modules/generated-packages.nix#L1649))

## Testing:

### Formatter

with,

`vim.languages.lua.format.enable = true;`

`:ConformInfo` shows `stylua`

<img width="882" alt="image" src="https://github.com/user-attachments/assets/3aba852d-c140-4d04-b60d-344919762510" />

with

`vim.languages.lua.format.enable = false;`

`:ConformInfo` shows no formatters for buffer

<img width="878" alt="image" src="https://github.com/user-attachments/assets/2467ab92-b32c-42e8-bfe7-10ddfd5c18d9" />

### Linter

with

`vim.languages.lua.extraDiagnostics.enable = true;`, the linter shows diagnostics

<img width="600" alt="image" src="https://github.com/user-attachments/assets/72a6b9b2-0b2c-44dc-9268-ca5d227d72d1" />

with

`vim.languages.lua.extraDiagnostics.enable =false;`, the linter do not show diagnostics

<img width="600" alt="image" src="https://github.com/user-attachments/assets/c9d5534f-66f9-4951-9912-6701afd98851" />

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc