### PR TITLE
Make conform respect config.vim.lsp.formatOnSave

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -283,3 +283,11 @@
 [Sc3l3t0n](https://github.com/Sc3l3t0n):
 
 - Add F# support under `vim.languages.fsharp`.
+
+[tebuevd](https://github.com/tebuevd):
+
+- Fix `pickers` configuration for `telescope` by nesting it under `setupOpts`
+- Fix `find_command` configuration for `telescope` by nesting it under
+  `setupOpts.pickers.find_files`
+- Update default `telescope.setupOpts.pickers.find_files.find_command` to only
+  include files (and therefore exclude directories from results)

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -284,6 +284,10 @@
 
 - Add F# support under `vim.languages.fsharp`.
 
+[venkyr77](https://github.com/venkyr77):
+
+- Add lint (luacheck) and formatting (stylua) support for Lua.
+
 [tebuevd](https://github.com/tebuevd):
 
 - Fix `pickers` configuration for `telescope` by nesting it under `setupOpts`

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -235,8 +235,9 @@
 
 [alfarel](https://github.com/alfarelcynthesis):
 
-- Add missing `yazi.nvim` dependency (`snacks.nvim`).
+[conform.nvim]: https://github.com/stevearc/conform.nvim
 
+- Add missing `yazi.nvim` dependency (`snacks.nvim`).
 - Add [mkdir.nvim](https://github.com/jghauser/mkdir.nvim) plugin for automatic
   creation of parent directories when editing a nested file.
 - Add [nix-develop.nvim](https://github.com/figsoda/nix-develop.nvim) plugin for
@@ -248,6 +249,8 @@
   [friendly-snippets](https://github.com/rafamadriz/friendly-snippets) so
   blink.cmp can source snippets from it.
 - Fix [blink.cmp] breaking when built-in sources were modified.
+- Fix [conform.nvim] not allowing disabling formatting on and after save.
+  Use `null` value to disable them if conform is enabled.
 
 [TheColorman](https://github.com/TheColorman):
 

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -31,7 +31,7 @@ in {
         '';
       };
     })
-    (mkIf cfg.lint_after_save {
+    (mkIf (cfg.enable && cfg.lint_after_save) {
       vim = {
         augroups = [{name = "nvf_nvim_lint";}];
         autocmds = [

--- a/modules/plugins/formatter/conform-nvim/conform-nvim.nix
+++ b/modules/plugins/formatter/conform-nvim/conform-nvim.nix
@@ -1,12 +1,11 @@
 {
-  pkgs,
+  config,
   lib,
   ...
 }: let
-  inherit (lib.options) mkOption mkEnableOption literalExpression;
-  inherit (lib.types) attrs enum;
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) attrs nullOr;
   inherit (lib.nvim.types) mkPluginSetupOption;
-  inherit (lib.nvim.lua) mkLuaInline;
 in {
   options.vim.formatter.conform-nvim = {
     enable = mkEnableOption "lightweight yet powerful formatter plugin for Neovim [conform-nvim]";
@@ -31,11 +30,14 @@ in {
       };
 
       format_on_save = mkOption {
-        type = attrs;
-        default = {
-          lsp_format = "fallback";
-          timeout_ms = 500;
-        };
+        type = nullOr attrs;
+        default =
+          if config.vim.lsp.formatOnSave
+          then {
+            lsp_format = "fallback";
+            timeout_ms = 500;
+          }
+          else null;
         description = ''
           Table that will be passed to `conform.format()`. If this
           is set, Conform will run the formatter on save.
@@ -43,8 +45,11 @@ in {
       };
 
       format_after_save = mkOption {
-        type = attrs;
-        default = {lsp_format = "fallback";};
+        type = nullOr attrs;
+        default =
+          if config.vim.lsp.formatOnSave
+          then {lsp_format = "fallback";}
+          else null;
         description = ''
           Table that will be passed to `conform.format()`. If this
           is set, Conform will run the formatter asynchronously after

--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -5,6 +5,7 @@
 }: let
   inherit (builtins) toJSON;
   inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.binds) addDescriptionsToMappings mkSetExprBinding mkSetLuaBinding pushDownDefault;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.lua) toLuaObject;
@@ -32,6 +33,7 @@ in {
                 return '<Ignore>'
               end
             '')
+
             (mkSetExprBinding gsMappings.previousHunk ''
               function()
                 if vim.wo.diff then return ${toJSON gsMappings.previousHunk.value} end
@@ -77,13 +79,12 @@ in {
     }
 
     (mkIf cfg.codeActions.enable {
-      vim.lsp.null-ls.enable = true;
-      vim.lsp.null-ls.sources.gitsigns-ca = ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.code_actions.gitsigns
-        )
-      '';
+      vim.lsp.null-ls = {
+        enable = true;
+        setupOpts.sources.gitsigns-ca = mkLuaInline ''
+          require("null-ls").builtins.code_actions.gitsigns
+        '';
+      };
     })
   ]);
 }

--- a/modules/plugins/lsp/config.nix
+++ b/modules/plugins/lsp/config.nix
@@ -93,11 +93,7 @@ in {
                 })
             end
           ''
-          else "
-              vim.lsp.buf.format({
-                bufnr = bufnr,
-              })
-        "
+          else ""
         }
               end,
             })

--- a/modules/plugins/lsp/null-ls/config.nix
+++ b/modules/plugins/lsp/null-ls/config.nix
@@ -4,13 +4,12 @@
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.attrsets) mapAttrs;
-  inherit (lib.trivial) boolToString;
-  inherit (lib.nvim.dag) entryAnywhere entryAfter entryBetween;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAfter;
 
-  cfg = config.vim.lsp;
+  cfg = config.vim.lsp.null-ls;
 in {
-  config = mkIf cfg.null-ls.enable (mkMerge [
+  config = mkIf cfg.enable (mkMerge [
     {
       vim = {
         startPlugins = [
@@ -18,35 +17,14 @@ in {
           "plenary-nvim"
         ];
 
-        # null-ls implies LSP already being set up
-        # since it will hook into LSPs to receive information
+        # null-ls implies that LSP is already being set up
+        # as it will hook into LSPs to receive information.
         lsp.enable = true;
 
-        pluginRC = {
-          # early setup for null-ls
-          null_ls-setup = entryAnywhere ''
-            local null_ls = require("null-ls")
-            local null_helpers = require("null-ls.helpers")
-            local null_methods = require("null-ls.methods")
-            local ls_sources = {}
-          '';
-
-          # null-ls setup
-          null_ls = entryAfter ["null_ls-setup" "lsp-setup"] ''
-            require('null-ls').setup({
-              debug = ${boolToString cfg.null-ls.debug},
-              diagnostics_format = "${cfg.null-ls.diagnostics_format}",
-              debounce = ${toString cfg.null-ls.debounce},
-              default_timeout = ${toString cfg.null-ls.default_timeout},
-              sources = ls_sources,
-              on_attach = default_on_attach
-            })
-          '';
-        };
+        pluginRC.null_ls = entryAfter ["lsp-setup"] ''
+          require('null-ls').setup(${toLuaObject cfg.setupOpts})
+        '';
       };
-    }
-    {
-      vim.pluginRC = mapAttrs (_: v: (entryBetween ["null_ls"] ["null_ls-setup"] v)) cfg.null-ls.sources;
     }
   ]);
 }

--- a/modules/plugins/lsp/null-ls/null-ls.nix
+++ b/modules/plugins/lsp/null-ls/null-ls.nix
@@ -1,34 +1,87 @@
 {lib, ...}: let
-  inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) attrsOf str int;
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) attrsOf str int nullOr;
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.nvim.types) luaInline mkPluginSetupOption;
+  inherit (lib.nvim.config) batchRenameOptions;
+
+  migrationTable = {
+    debug = "debug";
+    diagnostics_format = "diagnostics_format";
+    debounce = "debounce";
+    default_timeout = "default_timeout";
+    sources = "sources";
+  };
+
+  renamedSetupOpts =
+    batchRenameOptions
+    ["vim" "lsp" "null-ls"]
+    ["vim" "lsp" "null-ls" "setupOpts"]
+    migrationTable;
 in {
+  imports = renamedSetupOpts;
+
   options.vim.lsp.null-ls = {
-    enable = mkEnableOption "null-ls, also enabled automatically";
+    enable = mkEnableOption ''
+      null-ls, plugin to use Neovim as a language server to inject LSP diagnostics,
+      code actions, and more via Lua.
+    '';
 
-    debug = mkEnableOption "debugging information for `null-ls";
+    setupOpts = mkPluginSetupOption "null-ls" {
+      debug = mkEnableOption ''
+        debugging information for null-ls.
 
-    diagnostics_format = mkOption {
-      type = str;
-      default = "[#{m}] #{s} (#{c})";
-      description = "Diagnostic output format for null-ls";
-    };
+        Displays all possible log messages and writes them to the null-ls log,
+        which you can view with the command `:NullLsLog`
+      '';
 
-    debounce = mkOption {
-      type = int;
-      default = 250;
-      description = "Default debounce";
-    };
+      diagnostics_format = mkOption {
+        type = str;
+        default = "[#{m}] #{s} (#{c})";
+        description = ''
+          Sets the default format used for diagnostics. null-ls will replace th
+          e following special components with the relevant diagnostic information:
 
-    default_timeout = mkOption {
-      type = int;
-      default = 5000;
-      description = "Default timeout value, in milliseconds";
-    };
+          * `#{m}`: message
+          * `#{s}`: source name (defaults to null-ls if not specified)
+          * `#{c}`: code (if available)
+        '';
+      };
 
-    sources = mkOption {
-      description = "null-ls sources";
-      type = attrsOf str;
-      default = {};
+      debounce = mkOption {
+        type = int;
+        default = 250;
+        description = ''
+          Amount of time between the last change to a buffer and the next `textDocument/didChange` notification.
+        '';
+      };
+
+      default_timeout = mkOption {
+        type = int;
+        default = 5000;
+        description = ''
+          Amount of time (in milliseconds) after which built-in sources will time out.
+
+          :::{.note}
+          Built-in sources can define their own timeout period and users can override
+          the timeout period on a per-source basis
+          :::
+        '';
+      };
+
+      sources = mkOption {
+        type = nullOr (attrsOf luaInline);
+        default = null;
+        description = "Sources for null-ls to register";
+      };
+
+      on_attach = mkOption {
+        type = nullOr luaInline;
+        default = mkLuaInline "on_attach";
+        description = ''
+          Defines an on_attach callback to run whenever null-ls attaches to a buffer.
+        '';
+      };
     };
   };
 }

--- a/modules/plugins/utility/telescope/telescope.nix
+++ b/modules/plugins/utility/telescope/telescope.nix
@@ -8,6 +8,12 @@
   inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   setupOptions = {
+    pickers.find_files.find_command = mkOption {
+      description = "cmd to use for finding files";
+      type = either (listOf str) luaInline;
+      default = ["${pkgs.fd}/bin/fd" "--type=file"];
+    };
+
     defaults = {
       vimgrep_arguments = mkOption {
         description = ''
@@ -26,11 +32,6 @@
           "--hidden"
           "--no-ignore"
         ];
-      };
-      pickers.find_command = mkOption {
-        description = "cmd to use for finding files";
-        type = either (listOf str) luaInline;
-        default = ["${pkgs.fd}/bin/fd"];
       };
       prompt_prefix = mkOption {
         description = "Shown in front of Telescope's prompt";

--- a/modules/plugins/visuals/nvim-scrollbar/config.nix
+++ b/modules/plugins/visuals/nvim-scrollbar/config.nix
@@ -12,8 +12,7 @@ in {
   config = mkIf cfg.enable {
     vim = {
       startPlugins = ["nvim-scrollbar"];
-
-      pluginRC.cursorline = entryAnywhere ''
+      pluginRC.nvim-scrollbar = entryAnywhere ''
         require("scrollbar").setup(${toLuaObject cfg.setupOpts})
       '';
     };

--- a/modules/plugins/visuals/nvim-scrollbar/scrollbar-nvim.nix
+++ b/modules/plugins/visuals/nvim-scrollbar/scrollbar-nvim.nix
@@ -13,7 +13,7 @@ in {
     setupOpts = mkPluginSetupOption "scrollbar-nvim" {
       excluded_filetypes = mkOption {
         type = listOf str;
-        default = ["prompt" "TelescopePrompt" "noice" "noice" "NvimTree" "neo-tree" "alpha" "notify" "Navbuddy"];
+        default = ["prompt" "TelescopePrompt" "noice" "NvimTree" "neo-tree" "alpha" "notify" "Navbuddy" "fastaction_popup"];
         description = "Filetypes to hide the scrollbar on";
       };
     };


### PR DESCRIPTION
The current defaults([link1](https://github.com/alfarelcynthesis/nvf/blob/main/modules/plugins/formatter/conform-nvim/conform-nvim.nix#L35-L38), [link2](https://github.com/alfarelcynthesis/nvf/blob/main/modules/plugins/formatter/conform-nvim/conform-nvim.nix#L47))from conform config is not respecting the top level config we have for `formatOnSave` - [vim.lsp.formatOnSave](https://notashelf.github.io/nvf/options.html#opt-vim.lsp.formatOnSave).

From [conform docs](https://github.com/stevearc/conform.nvim?tab=readme-ov-file#options)

```
-- If this is set, Conform will run the formatter on save.
-- It will pass the table to conform.format().
-- This can also be a function that returns the table
```

```
-- If this is set, Conform will run the formatter asynchronously after save.
-- It will pass the table to conform.format().
-- This can also be a function that returns the table.
```

these need to be set to `null` (or `nil` in `lua`) when `config.vim.lsp.formatOnSave` is `false`

This PR fixes conform config to respect `config.vim.lsp.formatOnSave`

## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/format-on-save-fix";
```

with `config.vim.lsp.formatOnSave = false;` conform is not auto formatting the file

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc