### PR TITLE
Make conform respect config.vim.lsp.formatOnSave and config.vim.lsp.mappings.toggleFormatOnSave

### DIFF
--- a/modules/plugins/formatter/conform-nvim/conform-nvim.nix
+++ b/modules/plugins/formatter/conform-nvim/conform-nvim.nix
@@ -1,12 +1,9 @@
-{
-  pkgs,
-  lib,
-  ...
-}: let
-  inherit (lib.options) mkOption mkEnableOption literalExpression;
-  inherit (lib.types) attrs enum nullOr;
-  inherit (lib.nvim.types) mkPluginSetupOption;
-  inherit (lib.nvim.lua) mkLuaInline;
+{lib, ...}: let
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) attrs either nullOr;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.types) luaInline mkPluginSetupOption;
 in {
   options.vim.formatter.conform-nvim = {
     enable = mkEnableOption "lightweight yet powerful formatter plugin for Neovim [conform-nvim]";
@@ -30,27 +27,48 @@ in {
         description = "Default values when calling `conform.format()`";
       };
 
-      format_on_save = mkOption {
-        type = nullOr attrs;
-        default = {
+      format_on_save = let
+        defaultFormatOnSaveOpts = {
           lsp_format = "fallback";
           timeout_ms = 500;
         };
-        description = ''
-          Table that will be passed to `conform.format()`. If this
-          is set, Conform will run the formatter on save.
-        '';
-      };
+      in
+        mkOption {
+          type = nullOr (either attrs luaInline);
+          default = mkLuaInline ''
+            function()
+              if not vim.g.formatsave or vim.b.disableFormatSave then
+                return
+              else
+                return ${toLuaObject defaultFormatOnSaveOpts}
+              end
+            end
+          '';
+          description = ''
+            Table or function(lualinline) that will be passed to `conform.format()`. If this
+            is set, Conform will run the formatter on save.
+          '';
+        };
 
-      format_after_save = mkOption {
-        type = nullOr attrs;
-        default = {lsp_format = "fallback";};
-        description = ''
-          Table that will be passed to `conform.format()`. If this
-          is set, Conform will run the formatter asynchronously after
-          save.
-        '';
-      };
+      format_after_save = let
+        defaultFormatAfterSaveOpts = {lsp_format = "fallback";};
+      in
+        mkOption {
+          type = nullOr (either attrs luaInline);
+          default = mkLuaInline ''
+            function()
+              if not vim.g.formatsave or vim.b.disableFormatSave then
+                return
+              else
+                return ${toLuaObject defaultFormatAfterSaveOpts}
+              end
+            end
+          '';
+          description = ''
+            Table or function(luainline) that will be passed to `conform.format()`. If this
+            is set, Conform will run the formatter asynchronously after save.
+          '';
+        };
     };
   };
 }


### PR DESCRIPTION
Update of PR https://github.com/NotAShelf/nvf/pull/764

The current defaults([link1](https://github.com/alfarelcynthesis/nvf/blob/main/modules/plugins/formatter/conform-nvim/conform-nvim.nix#L35-L38), [link2](https://github.com/alfarelcynthesis/nvf/blob/main/modules/plugins/formatter/conform-nvim/conform-nvim.nix#L47))from conform config is not respecting the top level config we have for `formatOnSave` - [vim.lsp.formatOnSave](https://notashelf.github.io/nvf/options.html#opt-vim.lsp.formatOnSave). Also, `config.vim.lsp.mappings.toggleFormatOnSave` has no impact.

From [conform docs](https://github.com/stevearc/conform.nvim?tab=readme-ov-file#options)

```
-- If this is set, Conform will run the formatter on save.
-- It will pass the table to conform.format().
-- This can also be a function that returns the table
```

```
-- If this is set, Conform will run the formatter asynchronously after save.
-- It will pass the table to conform.format().
-- This can also be a function that returns the table.
```

these need to be set to `null` (or `nil` in `lua`) when `config.vim.lsp.formatOnSave` is `false`

This PR fixes conform config to respect `config.vim.lsp.formatOnSave`

## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/conform-format-on-save-fix";
```

with `config.vim.lsp.formatOnSave = false;` conform is not auto formatting the file

with `config.vim.lsp.formatOnSave = true;`

![formatOnSaveTrue](https://github.com/user-attachments/assets/d5868549-44ef-425b-ad70-28db1d932f3b)

with `config.vim.lsp.formatOnSave = true;` and using the mapping for `config.vim.lsp.mappings.toggleFormatOnSave`

![toggleFormatOnSave](https://github.com/user-attachments/assets/258e700a-2959-4759-952b-bbc5dae8a311)

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc