### PR TITLE
fix: don't reference snacks in oil config

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -300,3 +300,7 @@
   `setupOpts.pickers.find_files`
 - Update default `telescope.setupOpts.pickers.find_files.find_command` to only
   include files (and therefore exclude directories from results)
+
+  [ckoehler](https://github.com/ckoehler):
+
+  - Fix oil config referencing snacks

--- a/modules/plugins/utility/oil-nvim/config.nix
+++ b/modules/plugins/utility/oil-nvim/config.nix
@@ -12,7 +12,7 @@ in {
   config = mkIf cfg.enable {
     vim = {
       startPlugins = ["oil-nvim"];
-      pluginRC.snacks-nvim = entryAnywhere ''
+      pluginRC.oil-nvim = entryAnywhere ''
         require("oil").setup(${toLuaObject cfg.setupOpts});
       '';
     };


### PR DESCRIPTION
I think that's a bug...