### PR TITLE
mini/indentscope: add autocmd to disable indentscope in applicable filetypes

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -295,6 +295,7 @@
 - Add catppuccin integration for Bufferline, Lspsaga.
 - Add neo-tree integration for Bufferline.
 - Add more applicable filetypes to illuminate denylist.
+- Disable mini.indentscope for applicable filetypes.
 
 [tebuevd](https://github.com/tebuevd):
 

--- a/modules/plugins/mini/indentscope/config.nix
+++ b/modules/plugins/mini/indentscope/config.nix
@@ -3,6 +3,7 @@
   lib,
   ...
 }: let
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.modules) mkIf;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.lua) toLuaObject;
@@ -10,6 +11,21 @@
   cfg = config.vim.mini.indentscope;
 in {
   vim = mkIf cfg.enable {
+    autocmds = [
+      {
+        callback = mkLuaInline ''
+          function()
+            local ignore_filetypes = ${toLuaObject cfg.setupOpts.ignore_filetypes}
+            if vim.tbl_contains(ignore_filetypes, vim.bo.filetype) then
+              vim.b.miniindentscope_disable = true
+            end
+          end
+        '';
+        desc = "Disable indentscope for certain filetypes";
+        event = ["FileType"];
+      }
+    ];
+
     startPlugins = ["mini-indentscope"];
 
     pluginRC.mini-indentscope = entryAnywhere ''

--- a/modules/plugins/mini/indentscope/indentscope.nix
+++ b/modules/plugins/mini/indentscope/indentscope.nix
@@ -1,13 +1,16 @@
-{
-  config,
-  lib,
-  ...
-}: let
-  inherit (lib.options) mkEnableOption;
+{lib, ...}: let
+  inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (lib.types) str listOf;
 in {
   options.vim.mini.indentscope = {
     enable = mkEnableOption "mini.indentscope";
-    setupOpts = mkPluginSetupOption "mini.indentscope" {};
+    setupOpts = mkPluginSetupOption "mini.indentscope" {
+      ignore_filetypes = mkOption {
+        type = listOf str;
+        default = ["help" "neo-tree" "notify" "NvimTree" "TelescopePrompt"];
+        description = "File types to ignore for illuminate";
+      };
+    };
   };
 }


### PR DESCRIPTION
This PR adds autocmd to disable indentscope in applicable filetypes


## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/indentscope-fix";
```

before change

<img width="404" alt="image" src="https://github.com/user-attachments/assets/bcabaa5f-c0f5-4ef7-bedb-23e8f72abc18" />


after change

<img width="404" alt="image" src="https://github.com/user-attachments/assets/a5d024a5-bce4-4944-b929-088f5e947be2" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc