### PR TITLE
utility/fzf-lua: remove hard dependency on fzf

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -300,6 +300,7 @@
 - Add neo-tree integration for Bufferline.
 - Add more applicable filetypes to illuminate denylist.
 - Disable mini.indentscope for applicable filetypes.
+- Fix fzf-lua having a hard dependency on fzf.
 
 [tebuevd](https://github.com/tebuevd):
 

--- a/modules/plugins/utility/fzf-lua/fzf-lua.nix
+++ b/modules/plugins/utility/fzf-lua/fzf-lua.nix
@@ -1,15 +1,21 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
-  inherit (lib.types) nullOr enum;
+  inherit (lib.types) enum package;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.nvim.types) mkPluginSetupOption borderType;
 in {
   options.vim.fzf-lua = {
     enable = mkEnableOption "fzf-lua";
     setupOpts = mkPluginSetupOption "fzf-lua" {
+      fzf_bin = mkOption {
+        type = package;
+        default = "${lib.getExe pkgs.fzf}";
+        description = "fzf package to use";
+      };
       winopts.border = mkOption {
         type = borderType;
         default = config.vim.ui.borders.globalStyle;


### PR DESCRIPTION
fzf-lua will fail with error message if `fzf` is not installed system-wide

This PR removes this hard dependency by adding `fzf` to packages available for the wrapper


## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/fzf-lua-fix";
```

before,

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/b545ad58-9cd1-4e12-8806-b98da7e5b870" />

after,

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/f3ceccab-6cbc-4b8a-b160-9154bfd0f4b4" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc