### PR TITLE
utility/auto-save: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -301,6 +301,7 @@
 - Add more applicable filetypes to illuminate denylist.
 - Disable mini.indentscope for applicable filetypes.
 - Enable inlay hints support - `config.vim.lsp.inlayHints`.
+- Add [`auto-save-nvim`](https://github.com/pocco81/auto-save.nvim).
 
 [tebuevd](https://github.com/tebuevd):
 

--- a/modules/plugins/utility/auto-save/auto-save.nix
+++ b/modules/plugins/utility/auto-save/auto-save.nix
@@ -1,0 +1,17 @@
+{lib, ...}: let
+  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) int;
+in {
+  options.vim.auto-save = {
+    enable = mkEnableOption "auto-save";
+    setupOpts = mkPluginSetupOption "auto-save" {
+      debounce_delay = mkOption {
+        type = int;
+        # plugin default is 135, adding an option to setupOpts for example
+        default = 100;
+        description = "saves the file at most every `debounce_delay` milliseconds";
+      };
+    };
+  };
+}

--- a/modules/plugins/utility/auto-save/config.nix
+++ b/modules/plugins/utility/auto-save/config.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+
+  cfg = config.vim.auto-save;
+in {
+  vim.lazy.plugins."auto-save.nvim" = mkIf cfg.enable {
+    package = pkgs.vimPlugins.auto-save-nvim;
+    setupModule = "auto-save";
+    inherit (cfg) setupOpts;
+  };
+}

--- a/modules/plugins/utility/auto-save/default.nix
+++ b/modules/plugins/utility/auto-save/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./auto-save.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./auto-save
     ./binds
     ./ccc
     ./diffview


### PR DESCRIPTION
This PR adds [auto-save.nvim](https://github.com/pocco81/auto-save.nvim/)


## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/auto-save-init";
```

with `config.vim.auto-save.enable = false`,

![before](https://github.com/user-attachments/assets/5019f002-34b1-47fb-bded-b041865b4f20)

with `config.vim.auto-save.enable = true`,

![after](https://github.com/user-attachments/assets/de15eda4-b119-4d89-8dd3-e20bf80cb0df)


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc