### PR TITLE
languages/graphql: add graphql support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -65,6 +65,7 @@ isMaximal: {
         enable = isMaximal;
         crates.enable = isMaximal;
       };
+      graphql.enable = isMaximal;
 
       # Language modules that are not as common.
       assembly.enable = false;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -320,3 +320,7 @@
 [rrvsh](https://github.com/rrvsh):
 
 - Fix namespace of python-lsp-server by changing it to python3Packages
+
+[dmitriiStepanidenko](https://github.com/dmitriiStepanidenko):
+
+- Add graphql LSP and formatter suport via prettier.

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -44,6 +44,7 @@ in {
     ./wgsl.nix
     ./yaml.nix
     ./ruby.nix
+    ./graphql.nix
   ];
 
   options.vim.languages = {

--- a/modules/plugins/languages/graphql.nix
+++ b/modules/plugins/languages/graphql.nix
@@ -1,0 +1,109 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.lists) isList;
+  inherit (lib.meta) getExe;
+  inherit (lib.types) enum either listOf package str;
+  inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.graphql;
+
+  defaultServer = "graphql";
+  servers = {
+    graphql = {
+      package = pkgs.nodePackages.graphql-language-service-cli;
+      lspConfig = ''
+        lspconfig.graphql.setup {
+          capabilities = capabilities;
+          on_attach = attach_keymaps,
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/graphql-lsp", "server", "-m", "stream"}''
+        }
+        }
+      '';
+    };
+  };
+
+  defaultFormat = "prettier";
+  formats = {
+    prettier = {
+      package = pkgs.nodePackages.prettier;
+    };
+
+    biome = {
+      package = pkgs.biome;
+    };
+  };
+in {
+  options.vim.languages.graphql = {
+    enable = mkEnableOption "Graphql language support";
+
+    treesitter = {
+      enable = mkEnableOption "Graphql treesitter" // {default = config.vim.languages.enableTreesitter;};
+
+      graphqlPackage = mkGrammarOption pkgs "graphql";
+    };
+
+    lsp = {
+      enable = mkEnableOption "Graphql LSP support" // {default = config.vim.languages.enableLSP;};
+
+      server = mkOption {
+        description = "Graphql LSP server to use";
+        type = enum (attrNames servers);
+        default = defaultServer;
+      };
+
+      package = mkOption {
+        description = "Graphql LSP server package, or the command to run as a list of strings";
+        example = ''[lib.getExe pkgs.jdt-language-server "-data" "~/.cache/jdtls/workspace"]'';
+        type = either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
+    };
+    format = {
+      enable = mkEnableOption "Graphql formatting" // {default = config.vim.languages.enableFormat;};
+
+      type = mkOption {
+        description = "Graphql formatter to use";
+        type = enum (attrNames formats);
+        default = defaultFormat;
+      };
+
+      package = mkOption {
+        description = "Graphql formatter package";
+        type = package;
+        default = formats.${cfg.format.type}.package;
+      };
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.graphqlPackage];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.graphql-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.graphql = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Adds a lsp for graphql, adds prettier formatters and treesitter grammar

# Sanity Checking

- [x]  I have updated the [changelog](https://github.com/NotAShelf/nvf/tree/main/docs/release-notes) as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf](https://notashelf.github.io/nvf/index.xhtml#sec-guidelines)

- Style and consistency
    - [x] I ran Alejandra to format my code (nix fmt)
    - [x] My code conforms to the [editorconfig](https://editorconfig.org/) configuration of the project
    - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
    - [ ] My code includes comments in particularly complex areas
    - [ ] I have added a section in the manual
    - [ ] *(For breaking changes)* I have included a migration guide
- Package(s) built:
    - [x] .#nix (default package)
    - [x] .#maximal
    - [ ] .#docs-html (manual, must build)
    - [ ] .#docs-linkcheck (optional, please build if adding links)
- Tested on platform(s)
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin