### PR TITLE
languages: expose low-level API; convert existing modules

### DIFF
--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,11 +1,11 @@
 {lib}: let
   inherit (builtins) isString getAttr;
   inherit (lib.options) mkOption;
-  inherit (lib.types) listOf bool str submodule;
-  inherit (lib.generators) mkLuaInline;
+  inherit (lib.types) listOf bool str submodule attrsOf anything either nullOr;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.nvim.types) luaInline;
 in {
+  # TODO: remove
   diagnosticsToLua = {
     lang,
     config,
@@ -35,6 +35,7 @@ in {
     };
 
   lspOptions = submodule {
+    freeformType = attrsOf anything;
     options = {
       enable = mkOption {
         type = bool;
@@ -43,29 +44,32 @@ in {
       };
 
       capabilities = mkOption {
-        type = luaInline;
-        default = mkLuaInline "capabilities";
+        type = nullOr (either luaInline (attrsOf anything));
+        default = null;
         description = "LSP capabilitiess to pass to lspconfig";
       };
 
       on_attach = mkOption {
-        type = luaInline;
-        default = mkLuaInline "default_on_attach";
+        type = nullOr luaInline;
+        default = null;
         description = "Function to execute when an LSP server attaches to a buffer";
       };
 
       filetypes = mkOption {
-        type = listOf str;
+        type = nullOr (listOf str);
+        default = null;
         description = "Filetypes to auto-attach LSP in";
       };
 
       cmd = mkOption {
-        type = listOf str;
+        type = nullOr (listOf str);
+        default = null;
         description = "Command used to start the LSP server";
       };
 
       root_markers = mkOption {
-        type = listOf str;
+        type = nullOr (listOf str);
+        default = null;
         description = ''
           "root markers" used to determine the root directory of the workspace, and
           the filetypes associated with this LSP server.

--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,9 +1,10 @@
-# From home-manager: https://github.com/nix-community/home-manager/blob/master/modules/lib/booleans.nix
 {lib}: let
   inherit (builtins) isString getAttr;
   inherit (lib.options) mkOption;
-  inherit (lib.types) bool;
+  inherit (lib.types) listOf bool str submodule attrsOf anything;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.nvim.types) luaInline;
 in {
   diagnosticsToLua = {
     lang,
@@ -32,4 +33,31 @@ in {
       type = bool;
       description = "Turn on ${desc} for enabled languages by default";
     };
+
+  lspOptions = submodule {
+    freeformType = attrsOf anything;
+    options = {
+      capabilities = mkOption {
+        type = luaInline;
+        default = mkLuaInline "capabilities";
+        description = "LSP capabilitiess to pass to lspconfig";
+      };
+
+      on_attach = mkOption {
+        type = luaInline;
+        default = mkLuaInline "default_on_attach";
+        description = "Function to execute when an LSP server attaches to a buffer";
+      };
+
+      filetypes = mkOption {
+        type = listOf str;
+        description = "Filetypes to auto-attach LSP in";
+      };
+
+      cmd = mkOption {
+        type = listOf str;
+        description = "Command used to start the LSP server";
+      };
+    };
+  };
 }

--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,7 +1,7 @@
 {lib}: let
   inherit (builtins) isString getAttr;
   inherit (lib.options) mkOption;
-  inherit (lib.types) listOf bool str submodule attrsOf anything;
+  inherit (lib.types) listOf bool str submodule;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.nvim.types) luaInline;
@@ -35,8 +35,13 @@ in {
     };
 
   lspOptions = submodule {
-    freeformType = attrsOf anything;
     options = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Whether to enable this LSP server.";
+      };
+
       capabilities = mkOption {
         type = luaInline;
         default = mkLuaInline "capabilities";

--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -58,6 +58,14 @@ in {
         type = listOf str;
         description = "Command used to start the LSP server";
       };
+
+      root_markers = mkOption {
+        type = listOf str;
+        description = ''
+          "root markers" used to determine the root directory of the workspace, and
+          the filetypes associated with this LSP server.
+        '';
+      };
     };
   };
 }

--- a/modules/neovim/init/default.nix
+++ b/modules/neovim/init/default.nix
@@ -5,6 +5,7 @@
     ./debug.nix
     ./diagnostics.nix
     ./highlight.nix
+    ./lsp.nix
     ./spellcheck.nix
   ];
 }

--- a/modules/neovim/init/lsp.nix
+++ b/modules/neovim/init/lsp.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption;
+  inherit (lib.types) attrsOf;
+  inherit (lib.strings) concatLines;
+  inherit (lib.attrsets) mapAttrsToList attrNames filterAttrs;
+  inherit (lib.nvim.languages) lspOptions;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.lsp;
+
+  lspConfigurations =
+    mapAttrsToList (
+      name: value: ''
+        vim.lsp.config["${name}"] = ${toLuaObject value}
+      ''
+    )
+    cfg.servers;
+
+  enabledServers = filterAttrs (_: u: u.enable) cfg.servers;
+in {
+  options = {
+    vim.lsp.servers = mkOption {
+      type = attrsOf lspOptions;
+      default = {};
+      description = "";
+    };
+  };
+
+  config = mkIf (cfg.servers != {}) {
+    vim.luaConfigRC.lsp-servers = entryAnywhere ''
+      -- Individual LSP configurations managed by nvf.
+      ${(concatLines lspConfigurations)}
+
+      -- Enable configured LSPs explicitly
+      vim.lsp.enable(${toLuaObject (attrNames enabledServers)})
+    '';
+  };
+}

--- a/modules/plugins/languages/nim.nix
+++ b/modules/plugins/languages/nim.nix
@@ -12,6 +12,7 @@
   inherit (lib.types) enum either listOf package str;
   inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.languages) lspOptions;
 
   cfg = config.vim.languages.nim;
 
@@ -19,19 +20,14 @@
   servers = {
     nimlsp = {
       package = pkgs.nimlsp;
-      lspConfig = ''
-        lspconfig.nimls.setup{
-          capabilities = capabilities;
-          on_attach = default_on_attach;
-          cmd = ${
+      options = {
+        cmd =
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package
           else ''
             {"${cfg.lsp.package}/bin/nimlsp"}
-          ''
-        };
-        }
-      '';
+          '';
+      };
     };
   };
 
@@ -56,31 +52,31 @@ in {
     lsp = {
       enable = mkEnableOption "Nim LSP support" // {default = config.vim.languages.enableLSP;};
       server = mkOption {
+        type = listOf (enum (attrNames servers));
+        default = [defaultServer];
         description = "Nim LSP server to use";
-        type = str;
-        default = defaultServer;
       };
 
       package = mkOption {
-        description = "Nim LSP server package, or the command to run as a list of strings";
-        example = ''[lib.getExe pkgs.nimlsp]'';
         type = either package (listOf str);
         default = servers.${cfg.lsp.server}.package;
+        example = ''[lib.getExe pkgs.nimlsp]'';
+        description = "Nim LSP server package, or the command to run as a list of strings";
       };
     };
 
     format = {
       enable = mkEnableOption "Nim formatting" // {default = config.vim.languages.enableFormat;};
       type = mkOption {
-        description = "Nim formatter to use";
         type = enum (attrNames formats);
         default = defaultFormat;
+        description = "Nim formatter to use";
       };
 
       package = mkOption {
-        description = "Nim formatter package";
         type = package;
         default = formats.${cfg.format.type}.package;
+        description = "Nim formatter package";
       };
     };
   };

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -12,6 +12,7 @@
   inherit (lib.lists) isList;
   inherit (lib.strings) optionalString;
   inherit (lib.types) anything attrsOf enum either listOf nullOr package str;
+  inherit (lib.nvim.languages) lspOptions;
   inherit (lib.nvim.types) mkGrammarOption diagnostics;
   inherit (lib.nvim.lua) expToLua toLuaObject;
 
@@ -20,11 +21,12 @@
   useFormat = "on_attach = default_on_attach";
   noFormat = "on_attach = attach_keymaps";
 
-  defaultServer = "nil";
   packageToCmd = package: defaultCmd:
     if isList package
     then expToLua package
     else ''{"${package}/bin/${defaultCmd}"}'';
+
+  defaultServer = "nil";
   servers = {
     nil = {
       package = pkgs.nil;
@@ -145,9 +147,9 @@ in {
     lsp = {
       enable = mkEnableOption "Nix LSP support" // {default = config.vim.languages.enableLSP;};
       server = mkOption {
+        type = listOf (enum (attrNames servers));
+        default = [defaultServer];
         description = "Nix LSP server to use";
-        type = enum (attrNames servers);
-        default = defaultServer;
       };
 
       package = mkOption {
@@ -155,12 +157,6 @@ in {
         example = ''[lib.getExe pkgs.jdt-language-server "-data" "~/.cache/jdtls/workspace"]'';
         type = either package (listOf str);
         default = servers.${cfg.lsp.server}.package;
-      };
-
-      options = mkOption {
-        type = nullOr (attrsOf anything);
-        default = null;
-        description = "Options to pass to nixd LSP server";
       };
     };
 

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -12,6 +12,7 @@
   inherit (lib.trivial) boolToString;
   inherit (lib.lists) isList;
   inherit (lib.types) bool package str listOf either enum;
+  inherit (lib.nvim.languages) lspOptions;
   inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.lua) expToLua;
   inherit (lib.nvim.dag) entryAfter entryAnywhere;

--- a/modules/plugins/languages/scala.nix
+++ b/modules/plugins/languages/scala.nix
@@ -6,13 +6,15 @@
 }: let
   inherit (lib.generators) mkLuaInline;
   inherit (lib.modules) mkIf mkMerge;
+
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib.strings) optionalString;
+  inherit (lib.types) attrsOf anything bool;
+  inherit (lib.nvim.languages) lspOptions;
   inherit (lib.nvim.binds) mkMappingOption;
   inherit (lib.nvim.dag) entryAfter;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.nvim.types) mkGrammarOption luaInline;
-  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
-  inherit (lib.strings) optionalString;
-  inherit (lib.types) attrsOf anything bool;
 
   listCommandsAction =
     if config.vim.telescope.enable

--- a/modules/plugins/languages/vala.nix
+++ b/modules/plugins/languages/vala.nix
@@ -9,6 +9,8 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.types) enum either listOf package str;
+
+  inherit (lib.nvim.languages) lspOptions;
   inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.lua) expToLua;
 
@@ -26,18 +28,13 @@
             --prefix PATH : ${pkgs.uncrustify}/bin
         '';
       };
-      internalFormatter = true;
-      lspConfig = ''
-        lspconfig.vala_ls.setup {
-          capabilities = capabilities;
-          on_attach = default_on_attach;
-          cmd = ${
+
+      options = {
+        cmd =
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package
-          else ''{"${cfg.lsp.package}/bin/vala-language-server"}''
-        },
-        }
-      '';
+          else ''{"${cfg.lsp.package}/bin/vala-language-server"}'';
+      };
     };
   };
 in {
@@ -52,15 +49,15 @@ in {
     lsp = {
       enable = mkEnableOption "Vala LSP support" // {default = config.vim.languages.enableLSP;};
       server = mkOption {
-        description = "Vala LSP server to use";
-        type = enum (attrNames servers);
+        type = listOf (enum (attrNames servers));
         default = defaultServer;
+        description = "Vala LSP server to use";
       };
 
       package = mkOption {
-        description = "Vala LSP server package, or the command to run as a list of strings";
         type = either package (listOf str);
         default = servers.${cfg.lsp.server}.package;
+        description = "Vala LSP server package, or the command to run as a list of strings";
       };
     };
   };

--- a/modules/plugins/languages/wgsl.nix
+++ b/modules/plugins/languages/wgsl.nix
@@ -7,10 +7,11 @@
   inherit (builtins) attrNames;
   inherit (lib.lists) isList;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.lua) expToLua;
-  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.types) either enum listOf package str;
+  inherit (lib.nvim.languages) lspOptions;
+  inherit (lib.nvim.lua) expToLua;
+  inherit (lib.nvim.types) mkGrammarOption;
 
   cfg = config.vim.languages.wgsl;
 
@@ -19,17 +20,12 @@
     wgsl-analyzer = {
       package = pkgs.wgsl-analyzer;
       internalFormatter = true;
-      lspConfig = ''
-        lspconfig.wgsl_analyzer.setup {
-          capabilities = capabilities,
-          on_attach = default_on_attach,
-          cmd = ${
+      options = {
+        cmd =
           if isList cfg.lsp.package
           then expToLua cfg.lsp.package
-          else "{'${cfg.lsp.package}/bin/wgsl_analyzer'}"
-        }
-        }
-      '';
+          else "{'${cfg.lsp.package}/bin/wgsl_analyzer'}";
+      };
     };
   };
 in {
@@ -43,18 +39,17 @@ in {
 
     lsp = {
       enable = mkEnableOption "WGSL LSP support" // {default = config.vim.languages.enableLSP;};
-
       server = mkOption {
-        type = enum (attrNames servers);
+        type = listOf (enum (attrNames servers));
         default = defaultServer;
         description = "WGSL LSP server to use";
       };
 
       package = mkOption {
-        description = "wgsl-analyzer package, or the command to run as a list of strings";
-        example = literalExpression "[(lib.getExe pkgs.wgsl-analyzer)]";
         type = either package (listOf str);
         default = pkgs.wgsl-analyzer;
+        example = literalExpression "[(lib.getExe pkgs.wgsl-analyzer)]";
+        description = "wgsl-analyzer package, or the command to run as a list of strings";
       };
     };
   };

--- a/modules/plugins/languages/zig.nix
+++ b/modules/plugins/languages/zig.nix
@@ -9,6 +9,7 @@
   inherit (lib.modules) mkIf mkMerge mkDefault;
   inherit (lib.lists) isList;
   inherit (lib.types) bool either listOf package str enum;
+  inherit (lib.nvim.languages) lspOptions;
   inherit (lib.nvim.lua) expToLua;
   inherit (lib.nvim.types) mkGrammarOption;
 
@@ -73,7 +74,6 @@ in {
 
     lsp = {
       enable = mkEnableOption "Zig LSP support" // {default = config.vim.languages.enableLSP;};
-
       server = mkOption {
         type = enum (attrNames servers);
         default = defaultServer;
@@ -81,9 +81,9 @@ in {
       };
 
       package = mkOption {
-        description = "ZLS package, or the command to run as a list of strings";
         type = either package (listOf str);
         default = pkgs.zls;
+        description = "ZLS package, or the command to run as a list of strings";
       };
     };
 


### PR DESCRIPTION
Based on the feedback collected from https://github.com/NotAShelf/nvf/discussions/748, and other online spaces, this pull request exposes a low-level `vim.lsp.servers` API that will be consumed internally by language modules, in a way that allows no-overhead LSP setups for both this project and end-user setups. This is, in short, the long-awaited language moduler refactor.

The new API can also be used to override LSP options set by language modules, on top of setting up LSPs not supported directly by nvf. In addition, the language modules now take a *list* of servers to allow supporting multiple servers with ease (relevant: #575)


## Modules not converted:

- [ ] Nix
- [ ] Scala 
- [ ] Rust

## Breaking Changes

1. `vim.languages.rust.crates.enable` has been renamed to `vim.languages.rust.extensions.crates-nvim.enable`


