### PR TITLE
utility/fzf-lua: fix type for fzf-bin

### DIFF
--- a/modules/plugins/utility/fzf-lua/fzf-lua.nix
+++ b/modules/plugins/utility/fzf-lua/fzf-lua.nix
@@ -4,7 +4,7 @@
   pkgs,
   ...
 }: let
-  inherit (lib.types) enum package;
+  inherit (lib.types) enum str;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.nvim.types) mkPluginSetupOption borderType;
 in {
@@ -12,9 +12,9 @@ in {
     enable = mkEnableOption "fzf-lua";
     setupOpts = mkPluginSetupOption "fzf-lua" {
       fzf_bin = mkOption {
-        type = package;
+        type = str;
         default = "${lib.getExe pkgs.fzf}";
-        description = "fzf package to use";
+        description = "Path to fzf executable";
       };
       winopts.border = mkOption {
         type = borderType;


### PR DESCRIPTION
Followup from https://github.com/NotAShelf/nvf/pull/795

I missed `nix flake update` during testing after changing the type, the type is actually a string, not a package

## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/fzf-lua-type-fix";
```

tested with `config.vim.fzf-lua.enable = true` and `config.vim.fzf-lua.enable = false`.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc