### PR TITLE
utility/telescope: fix ignore patterns

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -316,6 +316,7 @@
 
 - Fix oil config referencing snacks
 - Add [flash.nvim] plugin to `vim.utility.motion.flash-nvim`
+- Fix default telescope ignore list entry for '.git/' to properly match
 
 [rrvsh](https://github.com/rrvsh):
 

--- a/modules/plugins/utility/telescope/telescope.nix
+++ b/modules/plugins/utility/telescope/telescope.nix
@@ -117,7 +117,7 @@
       file_ignore_patterns = mkOption {
         description = "A table of lua regex that define the files that should be ignored.";
         type = listOf str;
-        default = ["node_modules" ".git/" "dist/" "build/" "target/" "result/"];
+        default = ["node_modules" "%.git/" "dist/" "build/" "target/" "result/"];
       };
       color_devicons = mkOption {
         description = "Boolean if devicons should be enabled or not.";


### PR DESCRIPTION
".git" is a regex, so because of the '.' it matches more than just the .git directory, so escape the dot to make it literal. Here, that's done with a '%'.