### PR TITLE
ui/dressing: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -303,6 +303,7 @@
 - Disable mini.indentscope for applicable filetypes.
 - Fix fzf-lua having a hard dependency on fzf.
 - Enable inlay hints support - `config.vim.lsp.inlayHints`.
+- Add [dressing.nvim](https://github.com/stevearc/dressing.nvim) to ui module.
 
 [tebuevd](https://github.com/tebuevd):
 

--- a/modules/plugins/ui/default.nix
+++ b/modules/plugins/ui/default.nix
@@ -6,6 +6,7 @@
     ./notifications
     ./smartcolumn
     ./colorizer
+    ./dressing
     ./illuminate
     ./breadcrumbs
     ./borders

--- a/modules/plugins/ui/dressing/config.nix
+++ b/modules/plugins/ui/dressing/config.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+
+  cfg = config.vim.ui.dressing;
+in {
+  vim = {
+    fzf-lua = mkIf (builtins.elem "fzf_lua" cfg.setupOpts.select.backend) {
+      enable = true;
+    };
+
+    lazy.plugins."dressing-nvim" = mkIf cfg.enable {
+      package = "dressing-nvim";
+      setupModule = "dressing";
+      inherit (cfg) setupOpts;
+    };
+  };
+}

--- a/modules/plugins/ui/dressing/default.nix
+++ b/modules/plugins/ui/dressing/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./dressing.nix
+  ];
+}

--- a/modules/plugins/ui/dressing/dressing.nix
+++ b/modules/plugins/ui/dressing/dressing.nix
@@ -1,0 +1,21 @@
+{lib, ...}: let
+  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (lib.options) literalMD mkEnableOption mkOption;
+  inherit (lib.types) listOf str;
+in {
+  options.vim.ui.dressing = {
+    enable = mkEnableOption "auto-save";
+    setupOpts = mkPluginSetupOption "dressing" {
+      select = {
+        backend = mkOption {
+          type = listOf str;
+          default = ["fzf_lua"];
+          description = literalMD ''
+            Priority list of preferred `vim.select` implementations.
+            Note: Using the default value(`["fzf_lua"]`) will also enable `fzf-lua`.
+          '';
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
This PR adds [dressing.nvim](https://github.com/stevearc/dressing.nvim) to the ui module


## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/dressing-init";
```

with `config.vim.ui.dressing.enable = false`,

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/4d82ffd8-44df-47b4-8867-082df3887e9a" />

with `config.vim.ui.dressing.enable = true`,

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/2cdb5ef3-eb45-4be2-ab3f-34537425e945" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc