### PR TITLE
utility/snacks-nvim: add lualine, bufferline extension / offset

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -298,12 +298,12 @@
 - Add lint (luacheck) and formatting (stylua) support for Lua.
 - Add lint (markdownlint-cli2) support for Markdown.
 - Add catppuccin integration for Bufferline, Lspsaga.
-- Add neo-tree integration for Bufferline.
+- Add `neo-tree`, `snacks.explorer` integrations to `bufferline`.
 - Add more applicable filetypes to illuminate denylist.
 - Disable mini.indentscope for applicable filetypes.
 - Fix fzf-lua having a hard dependency on fzf.
 - Enable inlay hints support - `config.vim.lsp.inlayHints`.
-- Add `neo-tree` extension to `lualine`.
+- Add `neo-tree`, `snacks.picker` extensions to `lualine`.
 
 [tebuevd](https://github.com/tebuevd):
 

--- a/modules/plugins/statusline/lualine/config.nix
+++ b/modules/plugins/statusline/lualine/config.nix
@@ -14,17 +14,28 @@
   bCfg = config.vim.ui.breadcrumbs;
 in {
   config = mkMerge [
-    (mkIf config.vim.filetree.nvimTree.enable {
-      vim.statusline.lualine.setupOpts = {
-        extensions = ["nvim-tree"];
-      };
-    })
-
-    (mkIf config.vim.filetree.neo-tree.enable {
-      vim.statusline.lualine.setupOpts = {
-        extensions = ["neo-tree"];
-      };
-    })
+    {
+      vim.statusline.lualine.setupOpts.extensions =
+        (lib.optionals config.vim.filetree.nvimTree.enable ["nvim-tree"])
+        ++ (lib.optionals config.vim.filetree.neo-tree.enable ["neo-tree"])
+        ++ (lib.optionals config.vim.utility.snacks-nvim.enable [
+          {
+            # same extensions as nerdtree / neo-tree
+            # https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine/extensions/nerdtree.lua
+            # https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine/extensions/neo-tree.lua
+            sections = {
+              lualine_a = mkLuaInline ''
+                {
+                  function()
+                    return vim.fn.fnamemodify(vim.fn.getcwd(), ":~")
+                  end,
+                }
+              '';
+            };
+            filetypes = ["snacks_picker_list" "snacks_picker_input"];
+          }
+        ]);
+    }
 
     (mkIf (bCfg.enable && bCfg.lualine.winbar.enable && bCfg.source == "nvim-navic") {
       vim.statusline.lualine.setupOpts = {

--- a/modules/plugins/tabline/nvim-bufferline/nvim-bufferline.nix
+++ b/modules/plugins/tabline/nvim-bufferline/nvim-bufferline.nix
@@ -272,20 +272,12 @@ in {
 
         offsets = mkOption {
           type = listOf attrs;
-          default = [
-            {
-              filetype = "NvimTree";
-              text = "File Explorer";
-              highlight = "Directory";
-              separator = true;
-            }
-            {
-              filetype = "neo-tree";
-              text = "File Explorer";
-              highlight = "Directory";
-              separator = true;
-            }
-          ];
+          default = map (filetype: {
+            inherit filetype;
+            text = "File Explorer";
+            highlight = "Directory";
+            separator = true;
+          }) ["NvimTree" "neo-tree" "snacks_layout_box"];
           description = "The windows to offset bufferline above, see `:help bufferline-offset`";
         };
 


### PR DESCRIPTION
More Integrations!

This PR adds,

1. `bufferline` offset for `snacks.explorer`
2. `lualine` extension for `snacks.picker`

References

1. https://github.com/folke/snacks.nvim/discussions/1340
2. https://github.com/folke/snacks.nvim/issues/1694
3. https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine/extensions/nerdtree.lua
4. https://github.com/nvim-lualine/lualine.nvim/blob/master/lua/lualine/extensions/neo-tree.lua

## Testing:

Tested my changes by changing the `nvf` url to the branch from my fork

```
nvf.url = "github:venkyr77/nvf/snacks-integrations";
```

before,

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ae36cf3b-c5e7-455f-b030-a0556b95eb97" />

after,

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/6b038b3b-e050-4e4d-9548-b5fa6a858fae" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc