### PR TITLE
nvim-lint: added required files support

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -290,6 +290,7 @@
 
 - `eslint_d` now checks for configuration files to load.
 - Fixed an error where `eslint_d` fails to load.
+- Added required files support for linters under `vim.diagnostics.nvim-lint.linters.*.required_files`.
 
 [Sc3l3t0n](https://github.com/Sc3l3t0n):
 

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -289,8 +289,9 @@
 [rice-cracker-dev](https://github.com/rice-cracker-dev):
 
 - `eslint_d` now checks for configuration files to load.
-- Fixed an error where `eslint_d` fails to load.
-- Added required files support for linters under `vim.diagnostics.nvim-lint.linters.*.required_files`.
+- Fix an error where `eslint_d` fails to load.
+- Add required files support for linters under `vim.diagnostics.nvim-lint.linters.*.required_files`.
+- Add global function `nvf_lint` under `vim.diagnostics.nvim-lint.lint_function`.
 
 [Sc3l3t0n](https://github.com/Sc3l3t0n):
 

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -29,40 +29,7 @@ in {
             end
           end
 
-          function nvf_lint(buf)
-            local ft = vim.api.nvim_get_option_value("filetype", { buf = buf })
-            local linters = require("lint").linters
-            local linters_from_ft = require("lint").linters_by_ft[ft]
-
-            -- if no linter is configured for this filetype, stops linting
-            if linters_from_ft == nil then return end
-
-            for _, name in ipairs(linters_from_ft) do
-              local linter = linters[name]
-              assert(linter, 'Linter with name `' .. name .. '` not available')
-
-              if type(linter) == "function" then
-                linter = linter()
-              end
-              -- for require("lint").lint() to work, linter.name must be set
-              linter.name = linter.name or name
-              local cwd = linter.required_files
-
-              -- if no configuration files are configured, lint
-              if cwd == nil then
-                require("lint").lint(linter)
-              else
-                -- if configuration files are configured and present in the project, lint
-                for _, fn in ipairs(cwd) do
-                  local path = vim.fs.joinpath(linter.cwd or vim.fn.getcwd(), fn);
-                  if vim.uv.fs_stat(path) then
-                    require("lint").lint(linter)
-                    break
-                  end
-                end
-              end
-            end
-          end
+          nvf_lint = ${toLuaObject cfg.lint_function}
         '';
       };
     })

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -28,6 +28,41 @@ in {
               end
             end
           end
+
+          function nvf_lint(buf)
+            local ft = vim.api.nvim_get_option_value("filetype", { buf = buf })
+            local linters = require("lint").linters
+            local linters_from_ft = require("lint").linters_by_ft[ft]
+
+            -- if no linter is configured for this filetype, stops linting
+            if linters_from_ft == nil then return end
+
+            for _, name in ipairs(linters_from_ft) do
+              local linter = linters[name]
+              assert(linter, 'Linter with name `' .. name .. '` not available')
+
+              if type(linter) == "function" then
+                linter = linter()
+              end
+              -- for require("lint").lint() to work, linter.name must be set
+              linter.name = linter.name or name
+              local cwd = linter.required_files
+
+              -- if no configuration files are configured, lint
+              if cwd == nil then
+                require("lint").lint(linter)
+              else
+                -- if configuration files are configured and present in the project, lint
+                for _, fn in ipairs(cwd) do
+                  local path = vim.fs.joinpath(linter.cwd or vim.fn.getcwd(), fn);
+                  if vim.uv.fs_stat(path) then
+                    require("lint").lint(linter)
+                    break
+                  end
+                end
+              end
+            end
+          end
         '';
       };
     })
@@ -39,38 +74,7 @@ in {
             event = ["BufWritePost"];
             callback = mkLuaInline ''
               function(args)
-                local ft = vim.api.nvim_get_option_value("filetype", { buf = args.buf })
-                local linters = require("lint").linters
-                local linters_from_ft = require("lint").linters_by_ft[ft]
-
-                -- if no linter is configured for this filetype, stops linting
-                if linters_from_ft == nil then return end
-
-                for _, name in ipairs(linters_from_ft) do
-                  local linter = linters[name]
-                  assert(linter, 'Linter with name `' .. name .. '` not available')
-
-                  if type(linter) == "function" then
-                    linter = linter()
-                  end
-                  -- for require("lint").lint() to work, linter.name must be set
-                  linter.name = linter.name or name
-                  local cwd = linter.required_files
-
-                  -- if no configuration files are configured, lint
-                  if cwd == nil then
-                    require("lint").lint(linter)
-                  else
-                    -- if configuration files are configured and present in the project, lint
-                    for _, fn in ipairs(cwd) do
-                      local path = vim.fs.joinpath(linter.cwd or vim.fn.getcwd(), fn);
-                      if vim.uv.fs_stat(path) then
-                        require("lint").lint(linter)
-                        break
-                      end
-                    end
-                  end
-                end
+                nvf_lint(args.buf)
               end
             '';
           }

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -57,7 +57,7 @@ in {
 
                   -- if no configuration files are configured, lint
                   if cwd == nil then
-                    require("lint").try_lint(name)
+                    require("lint").lint(linter)
                   else
                     -- if configuration files are configured and present in the project, lint
                     for _, fn in ipairs(cwd) do

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -53,6 +53,8 @@ in {
                   if type(linter) == "function" then
                     linter = linter()
                   end
+                  -- for require("lint").lint() to work, linter.name must be set
+                  linter.name = linter.name or name
                   local cwd = linter.required_files
 
                   -- if no configuration files are configured, lint
@@ -61,8 +63,10 @@ in {
                   else
                     -- if configuration files are configured and present in the project, lint
                     for _, fn in ipairs(cwd) do
-                      if vim.uv.fs_stat(fn) then
-                        require("lint").try_lint(name)
+                      local path = vim.fs.joinpath(linter.cwd or vim.fn.getcwd(), fn);
+                      if vim.uv.fs_stat(path) then
+                        require("lint").lint(linter)
+                        break
                       end
                     end
                   end

--- a/modules/plugins/diagnostics/nvim-lint/config.nix
+++ b/modules/plugins/diagnostics/nvim-lint/config.nix
@@ -47,7 +47,13 @@ in {
                 if linters_from_ft == nil then return end
 
                 for _, name in ipairs(linters_from_ft) do
-                  local cwd = linters[name].required_files
+                  local linter = linters[name]
+                  assert(linter, 'Linter with name `' .. name .. '` not available')
+
+                  if type(linter) == "function" then
+                    linter = linter()
+                  end
+                  local cwd = linter.required_files
 
                   -- if no configuration files are configured, lint
                   if cwd == nil then

--- a/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
+++ b/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
@@ -69,6 +69,13 @@
         default = null;
         description = "Parser function";
       };
+
+      required_files = mkOption {
+        type = nullOr (listOf str);
+        default = null;
+        description = "Required files to lint";
+        example = ["eslint.config.js"];
+      };
     };
   };
 in {

--- a/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
+++ b/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
@@ -1,7 +1,8 @@
 {lib, ...}: let
-  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
   inherit (lib.types) nullOr attrsOf listOf str either submodule bool enum;
   inherit (lib.nvim.types) luaInline;
+  inherit (lib.generators) mkLuaInline;
 
   linterType = submodule {
     options = {
@@ -73,8 +74,11 @@
       required_files = mkOption {
         type = nullOr (listOf str);
         default = null;
-        description = "Required files to lint. These files must exist relative to the cwd of the linter or else this linter will be skipped";
         example = ["eslint.config.js"];
+        description = ''
+          Required files to lint. These files must exist relative to the cwd
+          of the linter or else this linter will be skipped
+        '';
       };
     };
   };
@@ -124,5 +128,53 @@ in {
     };
 
     lint_after_save = mkEnableOption "autocmd to lint after each save" // {default = true;};
+
+    lint_function = mkOption {
+      type = luaInline;
+      default = mkLuaInline ''
+        function(buf)
+          local ft = vim.api.nvim_get_option_value("filetype", { buf = buf })
+          local linters = require("lint").linters
+          local linters_from_ft = require("lint").linters_by_ft[ft]
+
+          -- if no linter is configured for this filetype, stops linting
+          if linters_from_ft == nil then return end
+
+          for _, name in ipairs(linters_from_ft) do
+            local linter = linters[name]
+            assert(linter, 'Linter with name `' .. name .. '` not available')
+
+            if type(linter) == "function" then
+              linter = linter()
+            end
+            -- for require("lint").lint() to work, linter.name must be set
+            linter.name = linter.name or name
+            local cwd = linter.required_files
+
+            -- if no configuration files are configured, lint
+            if cwd == nil then
+              require("lint").lint(linter)
+            else
+              -- if configuration files are configured and present in the project, lint
+              for _, fn in ipairs(cwd) do
+                local path = vim.fs.joinpath(linter.cwd or vim.fn.getcwd(), fn);
+                if vim.uv.fs_stat(path) then
+                  require("lint").lint(linter)
+                  break
+                end
+              end
+            end
+          end
+        end
+      '';
+      example = literalExpression ''
+        mkLuaInline '''
+          function(buf)
+            require("lint").try_lint()
+          end
+        '''
+      '';
+      description = "Define the global function nvf_lint which is used by nvf to lint.";
+    };
   };
 }

--- a/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
+++ b/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
@@ -78,6 +78,13 @@
         description = ''
           Required files to lint. These files must exist relative to the cwd
           of the linter or else this linter will be skipped
+
+          ::: {.note}
+          This option is an nvf extension that only takes effect if you
+          use the `nvf_lint()` lua function.
+
+          See {option}`vim.diagnostics.nvim-lint.lint_function`.
+          :::
         '';
       };
     };

--- a/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
+++ b/modules/plugins/diagnostics/nvim-lint/nvim-lint.nix
@@ -73,7 +73,7 @@
       required_files = mkOption {
         type = nullOr (listOf str);
         default = null;
-        description = "Required files to lint";
+        description = "Required files to lint. These files must exist relative to the cwd of the linter or else this linter will be skipped";
         example = ["eslint.config.js"];
       };
     };

--- a/modules/plugins/languages/svelte.nix
+++ b/modules/plugins/languages/svelte.nix
@@ -55,21 +55,14 @@
       package = pkg;
       config = {
         cmd = getExe pkg;
-        # HACK: change if nvim-lint gets a dynamic enable thing
-        parser = mkLuaInline ''
-          function(output, bufnr, cwd)
-            local markers = { "eslint.config.js", "eslint.config.mjs",
-              ".eslintrc", ".eslintrc.json", ".eslintrc.js", ".eslintrc.yml", }
-            for _, filename in ipairs(markers) do
-              local path = vim.fs.joinpath(cwd, filename)
-              if vim.loop.fs_stat(path) then
-                return require("lint.linters.eslint_d").parser(output, bufnr, cwd)
-              end
-            end
-
-            return {}
-          end
-        '';
+        required_files = [
+          "eslint.config.js"
+          "eslint.config.mjs"
+          ".eslintrc"
+          ".eslintrc.json"
+          ".eslintrc.js"
+          ".eslintrc.yml"
+        ];
       };
     };
   };

--- a/npins/sources.nix
+++ b/npins/sources.nix
@@ -98,7 +98,9 @@ builtins.mapAttrs
             Channel = getZip;
             Tarball = getUrl;
           }
-          .${spec.type}
+          .${
+            spec.type
+          }
           or (builtins.throw "Unknown source type ${spec.type}");
       in
         spec // {outPath = mayOverride (func spec);}


### PR DESCRIPTION
This adds the ability to only lint when specific files are present.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`