### PR TITLE
languages/dart: address hidden dependencies of flutter-tools.nvim

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -332,3 +332,4 @@
 [Noah765](https://github.com/Noah765):
 
 - Add missing `flutter-tools.nvim` dependency `plenary.nvim`.
+- Add necessary dependency of `flutter-tools.nvim` on lsp

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -332,4 +332,5 @@
 [Noah765](https://github.com/Noah765):
 
 - Add missing `flutter-tools.nvim` dependency `plenary.nvim`.
-- Add necessary dependency of `flutter-tools.nvim` on lsp
+- Add necessary dependency of `flutter-tools.nvim` on lsp.
+- Add the `vim.languages.dart.flutter-tools.flutterPackage` option.

--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -158,7 +158,6 @@ in {
 
             capabilities = capabilities,
             on_attach = default_on_attach;
-            flags = lsp_flags,
           },
           ${optionalString cfg.dap.enable ''
           debugger = {

--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -94,10 +94,12 @@ in {
           Whether to patch flutter-tools so that it doesn't resolve
           symlinks when detecting flutter path.
 
-          This is required if flutterPackage is set to null and the flutter
-          package in your PATH was built with nix. If you are using a flutter
+          ::: {.note}
+          This is required if `flutterPackage` is set to null and the flutter
+          package in your `PATH` was built with Nix. If you are using a flutter
           SDK installed from a different source and encounter the error "`dart`
-          missing from PATH", leave this option disabled.
+          missing from `PATH`", leave this option disabled.
+          :::
         '';
       };
 

--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -13,7 +13,7 @@
   inherit (lib.strings) optionalString;
   inherit (lib.nvim.lua) expToLua;
   inherit (lib.nvim.types) mkGrammarOption;
-  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.dag) entryAfter;
 
   cfg = config.vim.languages.dart;
   ftcfg = cfg.flutter-tools;
@@ -122,19 +122,21 @@ in {
     };
   };
 
-  config = mkIf cfg.enable (mkMerge [
+  config.vim = mkIf cfg.enable (mkMerge [
     (mkIf cfg.treesitter.enable {
-      vim.treesitter.enable = true;
-      vim.treesitter.grammars = [cfg.treesitter.package];
+      treesitter.enable = true;
+      treesitter.grammars = [cfg.treesitter.package];
     })
 
     (mkIf cfg.lsp.enable {
-      vim.lsp.lspconfig.enable = true;
-      vim.lsp.lspconfig.sources.dart-lsp = servers.${cfg.lsp.server}.lspConfig;
+      lsp.lspconfig.enable = true;
+      lsp.lspconfig.sources.dart-lsp = servers.${cfg.lsp.server}.lspConfig;
     })
 
     (mkIf ftcfg.enable {
-      vim.startPlugins = [
+      lsp.enable = true;
+
+      startPlugins = [
         (
           if ftcfg.enableNoResolvePatch
           then "flutter-tools-patched"
@@ -143,7 +145,7 @@ in {
         "plenary-nvim"
       ];
 
-      vim.pluginRC.flutter-tools = entryAnywhere ''
+      pluginRC.flutter-tools = entryAfter ["lsp-setup"] ''
         require('flutter-tools').setup {
           lsp = {
             color = { -- show the derived colours for dart variables

--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -81,16 +81,23 @@ in {
         description = "Enable flutter-tools for flutter support";
       };
 
+      flutterPackage = mkOption {
+        type = nullOr package;
+        default = pkgs.flutter;
+        description = "Flutter package, or null to detect the flutter path at runtime instead.";
+      };
+
       enableNoResolvePatch = mkOption {
         type = bool;
-        default = true;
+        default = false;
         description = ''
           Whether to patch flutter-tools so that it doesn't resolve
           symlinks when detecting flutter path.
 
-          This is required if you want to use a flutter package built with nix.
-          If you are using a flutter SDK installed from a different source
-          and encounter the error "`dart` missing from PATH", disable this option.
+          This is required if flutterPackage is set to null and the flutter
+          package in your PATH was built with nix. If you are using a flutter
+          SDK installed from a different source and encounter the error "`dart`
+          missing from PATH", leave this option disabled.
         '';
       };
 
@@ -147,6 +154,7 @@ in {
 
       pluginRC.flutter-tools = entryAfter ["lsp-setup"] ''
         require('flutter-tools').setup {
+          ${optionalString (ftcfg.flutterPackage != null) "flutter_path = \"${ftcfg.flutterPackage}/bin/flutter\","}
           lsp = {
             color = { -- show the derived colours for dart variables
               enabled = ${boolToString ftcfg.color.enable}, -- whether or not to highlight color variables at all, only supported on flutter >= 2.10


### PR DESCRIPTION
The commit messages should explain what I changed and why.

The color options currently don't work when nvim is transparent, so there will be another PR to fix that, or to update `flutter-tools.nvim` once https://github.com/nvim-flutter/flutter-tools.nvim/issues/466 is resolved.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc