### PR TITLE
Make python debugger name debugpy

### DIFF
--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -99,7 +99,7 @@
       # idk if this is the best way to install/run debugpy
       package = pkgs.python3.withPackages (ps: with ps; [debugpy]);
       dapConfig = ''
-        dap.adapters.python = function(cb, config)
+        dap.adapters.debugpy = function(cb, config)
           if config.request == 'attach' then
             ---@diagnostic disable-next-line: undefined-field
             local port = (config.connect or config).port
@@ -125,10 +125,10 @@
           end
         end
 
-        dap.configurations.python = {
+        dap.configurations.debugpy = {
           {
             -- The first three options are required by nvim-dap
-            type = 'python'; -- the type here established the link to the adapter definition: `dap.adapters.python`
+            type = 'python'; -- the type here established the link to the adapter definition: `dap.adapters.debugpy`
             request = 'launch';
             name = "Launch file";
 


### PR DESCRIPTION
- Most dap configurations expect `"debugpy"` as the adapter name, not `"python"`.
- This causes breakages in the very common case in many python repositories which have their debug config set up in `.vscode/launch.json` with `type: "debugpy"` and not `type: "python"`.
- Most people with vscode will be configuring their `launch.json` as shown [here](https://code.visualstudio.com/docs/python/debugging#_set-configuration-options).
- nvim-dap will automatically use the configuration in `.vscode/launch.json` if it exists, thus to avoid errors for nvf users that are working on repositories containing this file, we should use the same adapter as well.
- While `"python"` makes more sense as it is more general, there are no other commonly used python daps so I think renaming it to this specific implementation still makes sense.