### PR TITLE
languages/python: change DAP name from "python" to "debugpy"

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -290,8 +290,10 @@
 
 - `eslint_d` now checks for configuration files to load.
 - Fix an error where `eslint_d` fails to load.
-- Add required files support for linters under `vim.diagnostics.nvim-lint.linters.*.required_files`.
-- Add global function `nvf_lint` under `vim.diagnostics.nvim-lint.lint_function`.
+- Add required files support for linters under
+  `vim.diagnostics.nvim-lint.linters.*.required_files`.
+- Add global function `nvf_lint` under
+  `vim.diagnostics.nvim-lint.lint_function`.
 
 [Sc3l3t0n](https://github.com/Sc3l3t0n):
 
@@ -334,3 +336,7 @@
 [Noah765](https://github.com/Noah765):
 
 - Add missing `flutter-tools.nvim` dependency `plenary.nvim`.
+
+[howird](https://github.com/howird):
+
+- Change python dap adapter name from `python` to commonly expected `debugpy`.

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -99,7 +99,7 @@
       # idk if this is the best way to install/run debugpy
       package = pkgs.python3.withPackages (ps: with ps; [debugpy]);
       dapConfig = ''
-        dap.adapters.python = function(cb, config)
+        dap.adapters.debugpy = function(cb, config)
           if config.request == 'attach' then
             ---@diagnostic disable-next-line: undefined-field
             local port = (config.connect or config).port
@@ -125,10 +125,10 @@
           end
         end
 
-        dap.configurations.python = {
+        dap.configurations.debugpy = {
           {
             -- The first three options are required by nvim-dap
-            type = 'python'; -- the type here established the link to the adapter definition: `dap.adapters.python`
+            type = 'debugpy'; -- the type here established the link to the adapter definition: `dap.adapters.debugpy`
             request = 'launch';
             name = "Launch file";
 


### PR DESCRIPTION
- Most dap configurations expect `"debugpy"` as the adapter name, not `"python"`.
- This causes breakages in the very common case in many python repositories which have their debug config set up in `.vscode/launch.json` with `type: "debugpy"` and not `type: "python"`.
- Most people with vscode will be configuring their `launch.json` as shown [here](https://code.visualstudio.com/docs/python/debugging#_set-configuration-options).
- nvim-dap will automatically use the configuration in `.vscode/launch.json` if it exists, thus to avoid errors for nvf users that are working on repositories containing this file, we should use the same adapter as well.
- While `"python"` makes more sense as it is more general, there are no other commonly used python daps so I think renaming it to this specific implementation still makes sense.