### PR TITLE
assistant/avante-nvim: add avante.nvim plugin 

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -344,3 +344,10 @@
 [howird](https://github.com/howird):
 
 - Change python dap adapter name from `python` to commonly expected `debugpy`.
+
+[aionoid](https://github.com/aionoid):
+
+[avante-nvim]: https://github.com/yetone/avante.nvim
+
+- Add [avante.nvim] plugin under `vim.assistant.avante-nvim`.
+- Fix [render-markdown.nvim] file_types option type to list, to accept merging.

--- a/modules/plugins/assistant/avante/avante-nvim.nix
+++ b/modules/plugins/assistant/avante/avante-nvim.nix
@@ -1,7 +1,7 @@
 {lib, ...}: let
   inherit (lib.options) mkOption mkEnableOption literalMD;
-  inherit (lib.types) int str enum nullOr attrs either;
-  inherit (lib.nvim.types) mkPluginSetupOption luaInline;
+  inherit (lib.types) int str enum nullOr attrs;
+  inherit (lib.nvim.types) mkPluginSetupOption;
 in {
   options.vim.assistant = {
     avante-nvim = {
@@ -63,24 +63,25 @@ in {
             mkEnableOption ""
             // {
               default = false;
-              description = ''
-                enable/disable dual boost.
-              '';
+              description = "Whether to enable dual_boost mode.";
             };
 
           first_provider = mkOption {
             type = str;
             default = "openai";
+            description = "The first provider to generate response.";
           };
 
           second_provider = mkOption {
             type = str;
             default = "claude";
+            description = "The second provider to generate response.";
           };
 
           prompt = mkOption {
             type = str;
             default = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]";
+            description = "The prompt to generate response based on the two reference outputs.";
           };
 
           timeout = mkOption {
@@ -95,30 +96,35 @@ in {
             mkEnableOption ""
             // {
               default = false;
+              description = "Whether to enable auto suggestions.";
             };
 
           auto_set_highlight_group =
             mkEnableOption ""
             // {
               default = true;
+              description = "Whether to automatically set the highlight group for the current line.";
             };
 
           auto_set_keymaps =
             mkEnableOption ""
             // {
               default = true;
+              description = "Whether to automatically set the keymap for the current line.";
             };
 
           auto_apply_diff_after_generation =
             mkEnableOption ""
             // {
               default = false;
+              description = "Whether to automatically apply diff after LLM response.";
             };
 
           support_paste_from_clipboard =
             mkEnableOption ""
             // {
               default = false;
+              description = "Whether to support pasting image from clipboard. This will be determined automatically based whether img-clip is available or not.";
             };
 
           minimize_diff =
@@ -239,6 +245,7 @@ in {
               mkEnableOption ""
               // {
                 default = true;
+                description = "Enable rounded sidebar header";
               };
           };
 
@@ -246,6 +253,7 @@ in {
             prefix = mkOption {
               type = str;
               default = "> ";
+              description = "The prefix used on the user input.";
             };
 
             height = mkOption {
@@ -261,6 +269,7 @@ in {
             border = mkOption {
               type = str;
               default = "rounded";
+              description = "The border type on the edit window.";
             };
 
             start_insert =
@@ -295,26 +304,13 @@ in {
             border = mkOption {
               type = str;
               default = "rounded";
+              description = "The border type on the ask window.";
             };
 
             focus_on_apply = mkOption {
               type = enum ["ours" "theirs"];
               default = "ours";
-              description = "which diff to focus after applying.";
-            };
-          };
-        };
-
-        highlights = {
-          diff = {
-            current = mkOption {
-              type = str;
-              default = "DiffText";
-            };
-
-            incoming = mkOption {
-              type = str;
-              default = "DiffAdd";
+              description = "Which diff to focus after applying.";
             };
           };
         };
@@ -324,12 +320,8 @@ in {
             mkEnableOption ""
             // {
               default = true;
+              description = "Automatically jumps to the next change.";
             };
-
-          list_opener = mkOption {
-            type = either str luaInline;
-            default = "copen";
-          };
 
           override_timeoutlen = mkOption {
             type = int;
@@ -346,11 +338,13 @@ in {
           debounce = mkOption {
             type = int;
             default = 600;
+            description = "Suggestion debounce in milliseconds.";
           };
 
           throttle = mkOption {
             type = int;
             default = 600;
+            description = "Suggestion throttle in milliseconds.";
           };
         };
       };

--- a/modules/plugins/assistant/avante/avante-nvim.nix
+++ b/modules/plugins/assistant/avante/avante-nvim.nix
@@ -1,0 +1,359 @@
+{lib, ...}: let
+  inherit (lib.options) mkOption mkEnableOption literalMD;
+  inherit (lib.types) int str enum nullOr attrs either;
+  inherit (lib.nvim.types) mkPluginSetupOption luaInline;
+in {
+  options.vim.assistant = {
+    avante-nvim = {
+      enable = mkEnableOption "complementary neovim plugin for avante.nvim";
+      setupOpts = mkPluginSetupOption "avante-nvim" {
+        provider = mkOption {
+          type = nullOr str;
+          default = null;
+          description = "The provider used in Aider mode or in the planning phase of Cursor Planning Mode.";
+        };
+
+        vendors = mkOption {
+          type = nullOr attrs;
+          default = null;
+          description = "Define Your Custom providers.";
+          example = literalMD ''
+            ```nix
+            ollama = {
+              __inherited_from = "openai";
+              api_key_name = "";
+              endpoint = "http://127.0.0.1:11434/v1";
+              model = "qwen2.5u-coder:7b";
+              max_tokens = 4096;
+              disable_tools = true;
+            };
+            ollama_ds = {
+              __inherited_from = "openai";
+              api_key_name = "";
+              endpoint = "http://127.0.0.1:11434/v1";
+              model = "deepseek-r1u:7b";
+              max_tokens = 4096;
+              disable_tools = true;
+            };
+            ```
+          '';
+        };
+
+        auto_suggestions_provider = mkOption {
+          type = str;
+          default = "claude";
+          description = ''
+            Since auto-suggestions are a high-frequency operation and therefore expensive,
+            currently designating it as `copilot` provider is dangerous because: https://github.com/yetone/avante.nvim/issues/1048
+            Of course, you can reduce the request frequency by increasing `suggestion.debounce`.
+          '';
+        };
+
+        cursor_applying_provider = mkOption {
+          type = nullOr str;
+          default = null;
+          description = ''
+            The provider used in the applying phase of Cursor Planning Mode, defaults to nil,
+            when nil uses Config.provider as the provider for the applying phase
+          '';
+        };
+
+        dual_boost = {
+          enabled =
+            mkEnableOption ""
+            // {
+              default = false;
+              description = ''
+                enable/disable dual boost.
+              '';
+            };
+
+          first_provider = mkOption {
+            type = str;
+            default = "openai";
+          };
+
+          second_provider = mkOption {
+            type = str;
+            default = "claude";
+          };
+
+          prompt = mkOption {
+            type = str;
+            default = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]";
+          };
+
+          timeout = mkOption {
+            type = int;
+            default = 60000;
+            description = "Timeout in milliseconds.";
+          };
+        };
+
+        behaviour = {
+          auto_suggestions =
+            mkEnableOption ""
+            // {
+              default = false;
+            };
+
+          auto_set_highlight_group =
+            mkEnableOption ""
+            // {
+              default = true;
+            };
+
+          auto_set_keymaps =
+            mkEnableOption ""
+            // {
+              default = true;
+            };
+
+          auto_apply_diff_after_generation =
+            mkEnableOption ""
+            // {
+              default = false;
+            };
+
+          support_paste_from_clipboard =
+            mkEnableOption ""
+            // {
+              default = false;
+            };
+
+          minimize_diff =
+            mkEnableOption ""
+            // {
+              default = true;
+              description = "Whether to remove unchanged lines when applying a code block.";
+            };
+
+          enable_token_counting =
+            mkEnableOption ""
+            // {
+              default = true;
+              description = "Whether to enable token counting. Default to true.";
+            };
+
+          enable_cursor_planning_mode =
+            mkEnableOption ""
+            // {
+              default = false;
+              description = "Whether to enable Cursor Planning Mode. Default to false.";
+            };
+
+          enable_claude_text_editor_tool_mode =
+            mkEnableOption ""
+            // {
+              default = false;
+              description = "Whether to enable Claude Text Editor Tool Mode.";
+            };
+        };
+
+        mappings = {
+          diff = mkOption {
+            type = nullOr attrs;
+            default = null;
+            description = "Define or override the default keymaps for diff.";
+          };
+
+          suggestion = mkOption {
+            type = nullOr attrs;
+            default = null;
+            description = "Define or override the default keymaps for suggestion actions.";
+          };
+
+          jump = mkOption {
+            type = nullOr attrs;
+            default = null;
+            description = "Define or override the default keymaps for jump actions.";
+          };
+
+          submit = mkOption {
+            type = nullOr attrs;
+            default = null;
+            description = "Define or override the default keymaps for submit actions.";
+          };
+
+          cancel = mkOption {
+            type = nullOr attrs;
+            default = null;
+            description = "Define or override the default keymaps for cancel actions.";
+          };
+
+          sidebar = mkOption {
+            type = nullOr attrs;
+            default = null;
+            description = "Define or override the default keymaps for sidebar actions.";
+          };
+        };
+
+        hints.enabled =
+          mkEnableOption ""
+          // {
+            default = true;
+            description = ''
+              Whether to enable hints.
+            '';
+          };
+
+        windows = {
+          position = mkOption {
+            type = enum ["right" "left" "top" "bottom"];
+            default = "right";
+            description = "The position of the sidebar.";
+          };
+
+          wrap =
+            mkEnableOption ""
+            // {
+              default = true;
+              description = ''
+                similar to vim.o.wrap.
+              '';
+            };
+
+          width = mkOption {
+            type = int;
+            default = 30;
+            description = "Default % based on available width.";
+          };
+
+          sidebar_header = {
+            enabled =
+              mkEnableOption ""
+              // {
+                default = true;
+                description = ''
+                  enable/disable the header.
+                '';
+              };
+
+            align = mkOption {
+              type = enum ["right" "center" "left"];
+              default = "center";
+              description = "Position of the title.";
+            };
+
+            rounded =
+              mkEnableOption ""
+              // {
+                default = true;
+              };
+          };
+
+          input = {
+            prefix = mkOption {
+              type = str;
+              default = "> ";
+            };
+
+            height = mkOption {
+              type = int;
+              default = 8;
+              description = ''
+                Height of the input window in vertical layout.
+              '';
+            };
+          };
+
+          edit = {
+            border = mkOption {
+              type = str;
+              default = "rounded";
+            };
+
+            start_insert =
+              mkEnableOption ""
+              // {
+                default = true;
+                description = ''
+                  Start insert mode when opening the edit window.
+                '';
+              };
+          };
+
+          ask = {
+            floating =
+              mkEnableOption ""
+              // {
+                default = false;
+                description = ''
+                  Open the 'AvanteAsk' prompt in a floating window.
+                '';
+              };
+
+            start_insert =
+              mkEnableOption ""
+              // {
+                default = true;
+                description = ''
+                  Start insert mode when opening the ask window.
+                '';
+              };
+
+            border = mkOption {
+              type = str;
+              default = "rounded";
+            };
+
+            focus_on_apply = mkOption {
+              type = enum ["ours" "theirs"];
+              default = "ours";
+              description = "which diff to focus after applying.";
+            };
+          };
+        };
+
+        highlights = {
+          diff = {
+            current = mkOption {
+              type = str;
+              default = "DiffText";
+            };
+
+            incoming = mkOption {
+              type = str;
+              default = "DiffAdd";
+            };
+          };
+        };
+
+        diff = {
+          autojump =
+            mkEnableOption ""
+            // {
+              default = true;
+            };
+
+          list_opener = mkOption {
+            type = either str luaInline;
+            default = "copen";
+          };
+
+          override_timeoutlen = mkOption {
+            type = int;
+            default = 500;
+            description = ''
+              Override the 'timeoutlen' setting while hovering over a diff (see :help timeoutlen).
+              Helps to avoid entering operator-pending mode with diff mappings starting with `c`.
+              Disable by setting to -1.
+            '';
+          };
+        };
+
+        suggestion = {
+          debounce = mkOption {
+            type = int;
+            default = 600;
+          };
+
+          throttle = mkOption {
+            type = int;
+            default = 600;
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/plugins/assistant/avante/config.nix
+++ b/modules/plugins/assistant/avante/config.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+
+  cfg = config.vim.assistant.avante-nvim;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = [
+        "plenary-nvim"
+        "dressing-nvim"
+        "nui-nvim"
+      ];
+
+      lazy.plugins = {
+        "avante.nvim" = with pkgs.vimPlugins; {
+          package = avante-nvim;
+          setupModule = "avante";
+          inherit (cfg) setupOpts;
+          after =
+            /*
+            lua
+            */
+            ''
+              vim.opt.laststatus = 3
+            '';
+        };
+      };
+
+      treesitter.enable = true;
+
+      autocomplete.nvim-cmp = {
+        sources = {"avante.nvim" = "[avante]";};
+        sourcePlugins = ["avante-nvim"];
+      };
+
+      languages.markdown.extensions.render-markdown-nvim.setupOpts.file_types = lib.mkAfter ["Avante"];
+    };
+  };
+}

--- a/modules/plugins/assistant/avante/default.nix
+++ b/modules/plugins/assistant/avante/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./avante-nvim.nix
+  ];
+}

--- a/modules/plugins/assistant/default.nix
+++ b/modules/plugins/assistant/default.nix
@@ -3,5 +3,6 @@
     ./chatgpt
     ./copilot
     ./codecompanion
+    ./avante
   ];
 }

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -9,7 +9,7 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.lists) isList;
-  inherit (lib.types) bool enum either package listOf str;
+  inherit (lib.types) bool enum either package listOf str nullOr;
   inherit (lib.nvim.lua) expToLua toLuaObject;
   inherit (lib.nvim.types) diagnostics mkGrammarOption mkPluginSetupOption;
   inherit (lib.nvim.dag) entryAnywhere;
@@ -117,7 +117,12 @@ in {
             '';
           };
 
-        setupOpts = mkPluginSetupOption "render-markdown" {};
+        setupOpts = mkPluginSetupOption "render-markdown" {
+          file_types = lib.mkOption {
+            type = listOf (nullOr str);
+            default = [];
+          };
+        };
       };
     };
 

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -121,6 +121,7 @@ in {
           file_types = lib.mkOption {
             type = listOf (nullOr str);
             default = [];
+            description = "List of buffer filetypes to enable this plugin in. This will cause the plugin to attach to new buffers who have any of these filetypes.";
           };
         };
       };

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -26,6 +26,19 @@
       "url": "https://github.com/goolord/alpha-nvim/archive/de72250e054e5e691b9736ee30db72c65d560771.tar.gz",
       "hash": "0c1jkhxamfn2md7m1r5b2wpxa26y90b98yzjwf68m3fymalvkn5h"
     },
+    "avante-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "yetone",
+        "repo": "avante.nvim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "eb1cd44731783024621beafe4e46204cbc9a4320",
+      "url": "https://github.com/yetone/avante.nvim/archive/eb1cd44731783024621beafe4e46204cbc9a4320.tar.gz",
+      "hash": "1hdb1b74mxq6j10fv0zh6fniwpijwbxjxc59k7xzkqj6q20lad07"
+    },
     "base16": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
this PR add [Avante.nvim](https://github.com/yetone/avante.nvim):

# Testing:
using `configuration.nix` and `nix run .#nix`  with :
```nix
      programs.nvf.settings.vim.assistant = {
        avante-nvim = {
          enable = true;
          setupOpts = {
            provider = "ollama";
            vendors = {
              ollama = {
                __inherited_from = "openai";
                api_key_name = "";
                endpoint = "http://127.0.0.1:11434/v1";
                model = "qwen2.5u-coder:7b";
                max_tokens = 4096;
                disable_tools = true;
              };
            };
          };
        };
      };
```

https://github.com/user-attachments/assets/6ee64569-2143-4114-98bf-7af3438a940a

and plus markdown support and  `nix run .#maximal` :
```nix
      programs.nvf.settings.vim.languages = {
        markdown = {
          enable = true;
          extensions.render-markdown-nvim = {
            enable = true;
          };
        };
      };
```

https://github.com/user-attachments/assets/83194640-e066-4522-a17b-11e4fc0d7e14



<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc