### PR TITLE
languages/render-markdown-nvim: add file_types as list

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -344,3 +344,7 @@
 [howird](https://github.com/howird):
 
 - Change python dap adapter name from `python` to commonly expected `debugpy`.
+
+[aionoid](https://github.com/aionoid):
+
+- Fix [render-markdown.nvim] file_types option type to list, to accept merging.

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -9,7 +9,7 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.lists) isList;
-  inherit (lib.types) bool enum either package listOf str;
+  inherit (lib.types) bool enum either package listOf str nullOr;
   inherit (lib.nvim.lua) expToLua toLuaObject;
   inherit (lib.nvim.types) diagnostics mkGrammarOption mkPluginSetupOption;
   inherit (lib.nvim.dag) entryAnywhere;
@@ -117,7 +117,13 @@ in {
             '';
           };
 
-        setupOpts = mkPluginSetupOption "render-markdown" {};
+        setupOpts = mkPluginSetupOption "render-markdown" {
+          file_types = lib.mkOption {
+            type = listOf (nullOr str);
+            default = [];
+            description = "List of buffer filetypes to enable this plugin in. This will cause the plugin to attach to new buffers who have any of these filetypes.";
+          };
+        };
       };
     };
 


### PR DESCRIPTION
this PR fix assigning multiple file_types from different configs like 
```nix
# in avante-nivm
languages.markdown.extensions.render-markdown-nvim.setupOps.file_types = lib.mkAfter [ "avante"];
# in codecompanion-nvim 
languages.markdown.extensions.render-markdown-nvim.setupOps.file_types = [ "codecompanion"];
```
will throw 
```bash 
The option `programs.nvf.settings.vim.languages.markdown.extensions.render-markdown-nvim.setupOpts.file_types' has conflicting definition values:
```
# Testing:
using `configuration.nix` and nix run .#maximal with :
```nix
      programs.nvf.settings.vim.languages.markdown = {
        enable = true;
        extensions.render-markdown-nvim = {
          enable = true;
          setupOpts.file_types = ["markdown" "marksman"];
        };
      };
```
open file `docs/release-notes/rl-0.8.md` with file_type `marksman`
![Screenshot_2025-04-22-18-28-13_ovo](https://github.com/user-attachments/assets/811a4d38-6c64-4e72-91bc-b219f2271aed)

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc