### PR TITLE
languages/python: fix python dap configuration regression

### DIFF
--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -125,7 +125,7 @@
           end
         end
 
-        dap.configurations.debugpy = {
+        dap.configurations.python = {
           {
             -- The first three options are required by nvim-dap
             type = 'debugpy'; -- the type here established the link to the adapter definition: `dap.adapters.debugpy`


### PR DESCRIPTION
- [this PR](https://github.com/NotAShelf/nvf/pull/841) changed the dap adaptor name for python from `"python"` to `"debugpy"` to conform with the common case where many `.vscode/launch.json`s will reference `"debugpy"`
- Unfortunately, I introduced a regression by mistakenly changing the dap configuration name to `debugpy` as well. While the dap adaptor name refers to the adaptor type, the dap configuration name refers to the language so I reverted that one line
- I initially missed this error since I only tested the PR in a repo containing a `launch.json` so it overrode the default config, but it was brought up in [this issue](https://github.com/NotAShelf/nvf/issues/850)
- This PR has been tested __both__ in a repo containing a `launch.json` and without