### PR TITLE
highlight: fix color type

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -338,6 +338,7 @@
 - Add missing `flutter-tools.nvim` dependency `plenary.nvim`.
 - Add necessary dependency of `flutter-tools.nvim` on lsp.
 - Add the `vim.languages.dart.flutter-tools.flutterPackage` option.
+- Fix the type of the `highlight` color options.
 
 [howird](https://github.com/howird):
 

--- a/modules/neovim/init/highlight.nix
+++ b/modules/neovim/init/highlight.nix
@@ -5,15 +5,14 @@
 }: let
   inherit (lib.options) mkOption;
   inherit (lib.types) nullOr attrsOf listOf submodule bool ints str enum;
-  inherit (lib.strings) hasPrefix concatLines;
+  inherit (lib.strings) concatLines;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.nvim.dag) entryBetween;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.types) hexColor;
 
   mkColorOption = target:
     mkOption {
-      type = nullOr hexColor;
+      type = nullOr str;
       default = null;
       example = "#ebdbb2";
       description = ''


### PR DESCRIPTION
The color options also allow color definitions in the form of color names.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc