### PR TITLE
utility/sleuth: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -337,10 +337,13 @@
 
 [Noah765](https://github.com/Noah765):
 
+[vim-sleuth]: https://github.com/tpope/vim-sleuth
+
 - Add missing `flutter-tools.nvim` dependency `plenary.nvim`.
 - Add necessary dependency of `flutter-tools.nvim` on lsp.
 - Add the `vim.languages.dart.flutter-tools.flutterPackage` option.
 - Fix the type of the `highlight` color options.
+- Add [vim-sleuth] plugin under `vim.utility.sleuth`.
 
 [howird](https://github.com/howird):
 

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -18,6 +18,7 @@
     ./oil-nvim
     ./outline
     ./preview
+    ./sleuth
     ./snacks-nvim
     ./surround
     ./telescope

--- a/modules/plugins/utility/sleuth/config.nix
+++ b/modules/plugins/utility/sleuth/config.nix
@@ -1,0 +1,10 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  cfg = config.vim.utility.sleuth;
+in {
+  vim.startPlugins = mkIf cfg.enable ["vim-sleuth"];
+}

--- a/modules/plugins/utility/sleuth/default.nix
+++ b/modules/plugins/utility/sleuth/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./sleuth.nix
+  ];
+}

--- a/modules/plugins/utility/sleuth/sleuth.nix
+++ b/modules/plugins/utility/sleuth/sleuth.nix
@@ -1,0 +1,7 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+in {
+  options.vim.utility.sleuth.enable = mkEnableOption ''
+    automatically adjusting options such as `shiftwidth` or `expandtab`, using `vim-sleuth`
+  '';
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2407,6 +2407,19 @@
       "url": "https://github.com/tpope/vim-repeat/archive/65846025c15494983dafe5e3b46c8f88ab2e9635.tar.gz",
       "hash": "0n8sx6s2sbjb21dv9j6y5lyqda9vvxraffg2jz423daamn96dxqv"
     },
+    "vim-sleuth": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "tpope",
+        "repo": "vim-sleuth"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "be69bff86754b1aa5adcbb527d7fcd1635a84080",
+      "url": "https://github.com/tpope/vim-sleuth/archive/be69bff86754b1aa5adcbb527d7fcd1635a84080.tar.gz",
+      "hash": "0wqxdjgplf04nq428ialw1w03f8nh5vb629a17vl5gc9gf3zfanq"
+    },
     "vim-startify": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
I wasn't sure where to put it, so I put it in `utility`. Let me know if you would like it in a different location.

Closes https://github.com/NotAShelf/nvf/issues/836.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc