### PR TITLE
fix: bad option in custom-config example

### DIFF
--- a/docs/manual/installation/custom-configuration.md
+++ b/docs/manual/installation/custom-configuration.md
@@ -39,7 +39,7 @@ An example flake that exposes your custom Neovim configuration might look like
                 theme.enable = true;
 
                 # Enable Treesitter
-                tree-sitter.enable = true;
+                treesitter.enable = true;
 
                 # Other options will go here. Refer to the config
                 # reference in Appendix B of the nvf manual.


### PR DESCRIPTION
`tree-sitter` should be `treesitter`. `nix run` gives an error when using the example config verbatim.