### PR TITLE
neovim/lsp: expose low-level API

### DIFF
--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,9 +1,10 @@
-# From home-manager: https://github.com/nix-community/home-manager/blob/master/modules/lib/booleans.nix
 {lib}: let
   inherit (builtins) isString getAttr;
   inherit (lib.options) mkOption;
-  inherit (lib.types) bool;
+  inherit (lib.types) listOf bool str submodule attrsOf anything;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.nvim.types) luaInline;
 in {
   diagnosticsToLua = {
     lang,
@@ -32,4 +33,31 @@ in {
       type = bool;
       description = "Turn on ${desc} for enabled languages by default";
     };
+
+  lspOptions = submodule {
+    freeformType = attrsOf anything;
+    options = {
+      capabilities = mkOption {
+        type = luaInline;
+        default = mkLuaInline "capabilities";
+        description = "LSP capabilitiess to pass to lspconfig";
+      };
+
+      on_attach = mkOption {
+        type = luaInline;
+        default = mkLuaInline "default_on_attach";
+        description = "Function to execute when an LSP server attaches to a buffer";
+      };
+
+      filetypes = mkOption {
+        type = listOf str;
+        description = "Filetypes to auto-attach LSP in";
+      };
+
+      cmd = mkOption {
+        type = listOf str;
+        description = "Command used to start the LSP server";
+      };
+    };
+  };
 }

--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -58,6 +58,14 @@ in {
         type = listOf str;
         description = "Command used to start the LSP server";
       };
+
+      root_markers = mkOption {
+        type = listOf str;
+        description = ''
+          "root markers" used to determine the root directory of the workspace, and
+          the filetypes associated with this LSP server.
+        '';
+      };
     };
   };
 }

--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,11 +1,11 @@
 {lib}: let
   inherit (builtins) isString getAttr;
   inherit (lib.options) mkOption;
-  inherit (lib.types) listOf bool str submodule attrsOf anything;
-  inherit (lib.generators) mkLuaInline;
+  inherit (lib.types) listOf bool str submodule attrsOf anything either nullOr;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.nvim.types) luaInline;
 in {
+  # TODO: remove
   diagnosticsToLua = {
     lang,
     config,
@@ -37,30 +37,39 @@ in {
   lspOptions = submodule {
     freeformType = attrsOf anything;
     options = {
+      enable = mkOption {
+        type = bool;
+        default = true;
+        description = "Whether to enable this LSP server.";
+      };
+
       capabilities = mkOption {
-        type = luaInline;
-        default = mkLuaInline "capabilities";
+        type = nullOr (either luaInline (attrsOf anything));
+        default = null;
         description = "LSP capabilitiess to pass to lspconfig";
       };
 
       on_attach = mkOption {
-        type = luaInline;
-        default = mkLuaInline "default_on_attach";
+        type = nullOr luaInline;
+        default = null;
         description = "Function to execute when an LSP server attaches to a buffer";
       };
 
       filetypes = mkOption {
-        type = listOf str;
+        type = nullOr (listOf str);
+        default = null;
         description = "Filetypes to auto-attach LSP in";
       };
 
       cmd = mkOption {
-        type = listOf str;
+        type = nullOr (listOf str);
+        default = null;
         description = "Command used to start the LSP server";
       };
 
       root_markers = mkOption {
-        type = listOf str;
+        type = nullOr (listOf str);
+        default = null;
         description = ''
           "root markers" used to determine the root directory of the workspace, and
           the filetypes associated with this LSP server.

--- a/modules/neovim/init/default.nix
+++ b/modules/neovim/init/default.nix
@@ -5,6 +5,7 @@
     ./debug.nix
     ./diagnostics.nix
     ./highlight.nix
+    ./lsp.nix
     ./spellcheck.nix
   ];
 }

--- a/modules/neovim/init/lsp.nix
+++ b/modules/neovim/init/lsp.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption;
+  inherit (lib.types) attrsOf;
+  inherit (lib.strings) concatLines;
+  inherit (lib.attrsets) mapAttrsToList attrNames filterAttrs;
+  inherit (lib.nvim.languages) lspOptions;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.lsp;
+
+  lspConfigurations =
+    mapAttrsToList (
+      name: value: ''
+        vim.lsp.config["${name}"] = ${toLuaObject value}
+      ''
+    )
+    cfg.servers;
+
+  enabledServers = filterAttrs (_: u: u.enable) cfg.servers;
+in {
+  options = {
+    vim.lsp.servers = mkOption {
+      type = attrsOf lspOptions;
+      default = {};
+      description = "";
+    };
+  };
+
+  config = mkIf (cfg.servers != {}) {
+    vim.luaConfigRC.lsp-servers = entryAnywhere ''
+      -- Individual LSP configurations managed by nvf.
+      ${(concatLines lspConfigurations)}
+
+      -- Enable configured LSPs explicitly
+      vim.lsp.enable(${toLuaObject (attrNames enabledServers)})
+    '';
+  };
+}

--- a/modules/neovim/init/lsp.nix
+++ b/modules/neovim/init/lsp.nix
@@ -30,7 +30,34 @@ in {
     vim.lsp.servers = mkOption {
       type = attrsOf lspOptions;
       default = {};
-      description = "";
+      example = ''
+        {
+          "*" = {
+            root_markers = [".git"];
+            capabilities = {
+              textDocument = {
+                semanticTokens = {
+                  multilineTokenSupport = true;
+                };
+              };
+            };
+          };
+
+          "clangd" = {
+            filetypes = ["c"];
+          };
+        }
+      '';
+      description = ''
+        LSP configurations that will be managed using `vim.lsp.config()` and
+        related utilities added in Neovim 0.11. LSPs defined here will be
+        added to the resulting {file}`init.lua` using `vim.lsp.config` and
+        enabled through `vim.lsp.enable` below the configuration table.
+
+        You may review the generated configuration by running {command}`nvf-print-config`
+        in a shell. Please see {command}`:help lsp-config` for more details
+        on the underlying API.
+      '';
     };
   };
 
@@ -45,7 +72,7 @@ in {
     (mkIf (cfg.servers != {}) {
       vim.luaConfigRC.lsp-servers = entryAnywhere ''
         -- Individual LSP configurations managed by nvf.
-        ${(concatLines lspConfigurations)}
+        ${concatLines lspConfigurations}
 
         -- Enable configured LSPs explicitly
         vim.lsp.enable(${toLuaObject (filter (name: name != "*") (attrNames enabledServers))})

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -1,4 +1,8 @@
-{lib, ...}: let
+{
+  config,
+  lib,
+  ...
+}: let
   inherit (lib.nvim.languages) mkEnable;
 in {
   imports = [
@@ -47,7 +51,11 @@ in {
   ];
 
   options.vim.languages = {
-    enableLSP = mkEnable "LSP";
+    # LSPs are now built into Neovim, and we should enable them by default
+    # if `vim.lsp.enable` is true.
+    enableLSP = mkEnable "LSP" // {default = config.vim.lsp.enable;};
+
+    # Those are still managed by plugins, and should be enabled here.
     enableDAP = mkEnable "Debug Adapter";
     enableTreesitter = mkEnable "Treesitter";
     enableFormat = mkEnable "Formatting";


### PR DESCRIPTION
- **lib/languages: add `lspOptions` submodule type for freeform LSP config**
- **lib/languages: add `root_marker` to `lspOptions` type**
- **neovim/lsp: init**
- **lib/languages: add explicit enable to LSP submodule**
- **lib/lua: deprecate old Lua helpers superseded by `toLuaObject`**

This exposes a low(er) level API for configuring LSPs _directly_ with the new
options provided by Neovim 0.11. The idea is to allow configuring LSPs without
relying on the inclusion of language modules into nvf, or allowing language
modules in user configurations.

The language modules still use the old API, and will be migrated in due time.
Changes here are split off to avoid withholding important additions to the
module system until all language modules are converted. Language modules, of
course, will still need to be converted to this new API, after which lspconfig
shall be made into a regular plugin module instead of its current, specially
treated "variant."

Related: https://github.com/NotAShelf/nvf/discussions/748
