### PR TITLE
languages/emmet: add module

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -69,6 +69,7 @@ isMaximal: {
       # Language modules that are not as common.
       assembly.enable = false;
       astro.enable = false;
+      emmet.enable = false;
       nu.enable = false;
       csharp.enable = false;
       julia.enable = false;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -97,6 +97,12 @@
 
 - Add Haskell support under `vim.languages.haskell` using [haskell-tools.nvim].
 
+[Bliztle](https://github.com/Bliztle):
+
+[emmet-language-server]: https://github.com/olrtg/emmet-language-server
+
+- Add Emmet support under `vim.languages.emmet` using [emmet-language-server].
+
 [horriblename](https://github.com/horriblename):
 
 [blink.cmp]: https://github.com/saghen/blink.cmp

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -14,6 +14,7 @@ in {
     ./clang.nix
     ./css.nix
     ./elixir.nix
+    ./emmet.nix
     ./fsharp.nix
     ./gleam.nix
     ./go.nix

--- a/modules/plugins/languages/emmet.nix
+++ b/modules/plugins/languages/emmet.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) package;
+
+  cfg = config.vim.languages.emmet;
+in {
+  options.vim.languages.emmet = {
+    enable = mkEnableOption "Emmet support";
+    # No treesitter options, as this lsp only adds completions
+
+    lsp = {
+      enable = mkEnableOption "Emmet LSP support (emmet-language-server)" // {default = config.vim.languages.enableLSP;};
+
+      package = mkOption {
+        type = package;
+        default = pkgs.emmet-language-server;
+        description = "emmet-language-server package";
+      };
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.emmet_language_server = ''
+        lspconfig.emmet_language_server.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = { "${cfg.lsp.package}/bin/emmet-language-server", "--stdio" }
+        }
+      '';
+    })
+  ]);
+}


### PR DESCRIPTION
Added emmet lsp for html shorthand completions such as div>ul>li*3. This only adds a single, simple language module, contained to a single file.

I briefly considered if this should have been added as an extension to vim.languages.html, but took decided on making it its own module since it also integrates with jsx and other html-like frontend frameworks. I have no strong feelings about his however.

If there is anything I've missed or need to change please do tell, and I will happily see to it!

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc