### PR TITLE
plugins/gitsigns: fix null-ls issue

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -352,3 +352,7 @@
 [aionoid](https://github.com/aionoid):
 
 - Fix [render-markdown.nvim] file_types option type to list, to accept merging.
+
+[poz](https://poz.pet):
+
+- Fix gitsigns null-ls issue.

--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -81,9 +81,11 @@ in {
     (mkIf cfg.codeActions.enable {
       vim.lsp.null-ls = {
         enable = true;
-        setupOpts.sources.gitsigns-ca = mkLuaInline ''
-          require("null-ls").builtins.code_actions.gitsigns
-        '';
+        setupOpts.sources = [
+          (mkLuaInline ''
+            require("null-ls").builtins.code_actions.gitsigns
+          '')
+        ];
       };
     })
   ]);


### PR DESCRIPTION
this was the error before
```
       error: A definition for option `home-manager.users.jacek.programs.nvf.settings.vim.lsp.null-ls.setupOpts.sources' is not of type `null or (list of (luaInline))'. Definition values:
       - In `/nix/store/7zf02n9i01b02dvlqx54ksgllzrhxhck-source/modules/plugins/git/gitsigns/config.nix':
           {
             gitsigns-ca = {
               _type = "lua-inline";
               expr = ''
                 require("null-ls").builtins.code_actions.gitsigns
```