### PR TITLE
ui/breadcrumbs: update navbuddy

### DIFF
--- a/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
+++ b/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
@@ -215,6 +215,24 @@ in {
           description = "move focused node up";
         };
 
+        togglePreview = mkOption {
+          type = str;
+          default = "s";
+          description = "show preview of current node";
+        };
+
+        vsplit = mkOption {
+          type = str;
+          default = "<C-v>";
+          description = "open selected node in a vertical split";
+        };
+
+        hsplit = mkOption {
+          type = str;
+          default = "<C-s>";
+          description = "open selected node in a horizontal split";
+        };
+
         telescope = mkOption {
           type = str;
           default = "t";

--- a/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
+++ b/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
@@ -74,7 +74,7 @@ in {
           ::: {.note}
           This will pass `draw_empty` to the `nvim_navic` winbar
           component, which causes the component to be drawn even
-          if it's empty
+          if it's empty.
           :::
         '';
       };
@@ -86,163 +86,163 @@ in {
         close = mkOption {
           type = str;
           default = "<esc>";
-          description = "keybinding to close Navbuddy UI";
+          description = "Close and return the cursor to its original location.";
         };
 
         nextSibling = mkOption {
           type = str;
           default = "j";
-          description = "keybinding to navigate to the next sibling node";
+          description = "Navigate to the next sibling node.";
         };
 
         previousSibling = mkOption {
           type = str;
           default = "k";
-          description = "keybinding to navigate to the previous sibling node";
+          description = "Navigate to the previous sibling node.";
         };
 
         parent = mkOption {
           type = str;
           default = "h";
-          description = "keybinding to navigate to the parent node";
+          description = "Navigate to the parent node.";
         };
 
         children = mkOption {
           type = str;
           default = "l";
-          description = "keybinding to navigate to the child node";
+          description = "Navigate to the child node.";
         };
 
         root = mkOption {
           type = str;
           default = "0";
-          description = "keybinding to navigate to the root node";
+          description = "Navigate to the root node.";
         };
 
         visualName = mkOption {
           type = str;
           default = "v";
-          description = "visual selection of name";
+          description = "Select the name visually.";
         };
 
         visualScope = mkOption {
           type = str;
           default = "V";
-          description = "visual selection of scope";
+          description = "Select the scope visually.";
         };
 
         yankName = mkOption {
           type = str;
           default = "y";
-          description = "yank the name to system clipboard";
+          description = "Yank the name to system clipboard.";
         };
 
         yankScope = mkOption {
           type = str;
           default = "Y";
-          description = "yank the scope to system clipboard";
+          description = "Yank the scope to system clipboard.";
         };
 
         insertName = mkOption {
           type = str;
           default = "i";
-          description = "insert at start of name";
+          description = "Insert at the start of name.";
         };
 
         insertScope = mkOption {
           type = str;
           default = "I";
-          description = "insert at start of scope";
+          description = "Insert at the start of scope.";
         };
 
         appendName = mkOption {
           type = str;
           default = "a";
-          description = "insert at end of name";
+          description = "Insert at the end of name.";
         };
 
         appendScope = mkOption {
           type = str;
           default = "A";
-          description = "insert at end of scope";
+          description = "Insert at the end of scope.";
         };
 
         rename = mkOption {
           type = str;
           default = "r";
-          description = "rename the node";
+          description = "Rename the node.";
         };
 
         delete = mkOption {
           type = str;
           default = "d";
-          description = "delete the node";
+          description = "Delete the node.";
         };
 
         foldCreate = mkOption {
           type = str;
           default = "f";
-          description = "create a new fold";
+          description = "Create a new fold of the node.";
         };
 
         foldDelete = mkOption {
           type = str;
           default = "F";
-          description = "delete the current fold";
+          description = "Delete the current fold of the node.";
         };
 
         comment = mkOption {
           type = str;
           default = "c";
-          description = "comment the node";
+          description = "Comment the node.";
         };
 
         select = mkOption {
           type = str;
           default = "<enter>";
-          description = "goto selected symbol";
+          description = "Goto the node.";
         };
 
         moveDown = mkOption {
           type = str;
           default = "J";
-          description = "move focused node down";
+          description = "Move the node down.";
         };
 
         moveUp = mkOption {
           type = str;
           default = "K";
-          description = "move focused node up";
+          description = "Move the node up.";
         };
 
         togglePreview = mkOption {
           type = str;
           default = "s";
-          description = "show preview of current node";
+          description = "Toggle the preview.";
         };
 
         vsplit = mkOption {
           type = str;
           default = "<C-v>";
-          description = "open selected node in a vertical split";
+          description = "Open the node in a vertical split.";
         };
 
         hsplit = mkOption {
           type = str;
           default = "<C-s>";
-          description = "open selected node in a horizontal split";
+          description = "Open the node in a horizontal split.";
         };
 
         telescope = mkOption {
           type = str;
           default = "t";
-          description = "fuzzy finder at current level";
+          description = "Start fuzzy finder at the current level.";
         };
 
         help = mkOption {
           type = str;
           default = "g?";
-          description = "open mapping help window";
+          description = "Open the mappings help window.";
         };
       };
 
@@ -250,7 +250,7 @@ in {
         useDefaultMappings = mkOption {
           type = bool;
           default = true;
-          description = "use default Navbuddy keybindings (disables user-specified keybinds)";
+          description = "Add the default Navbuddy keybindings in addition to the keybinding added by this module.";
         };
 
         window = {
@@ -260,13 +260,13 @@ in {
           border = mkOption {
             type = borderType;
             default = config.vim.ui.borders.globalStyle;
-            description = "border style to use";
+            description = "The border style to use.";
           };
 
           scrolloff = mkOption {
             type = nullOr int;
             default = null;
-            description = "Scrolloff value within navbuddy window";
+            description = "The scrolloff value within a navbuddy window.";
           };
 
           sections = {
@@ -283,7 +283,7 @@ in {
               border = mkOption {
                 type = borderType;
                 default = config.vim.ui.borders.globalStyle;
-                description = "border style to use for the left section of Navbuddy UI";
+                description = "The border style to use for the left section of the Navbuddy UI.";
               };
             };
 
@@ -300,7 +300,7 @@ in {
               border = mkOption {
                 type = borderType;
                 default = config.vim.ui.borders.globalStyle;
-                description = "border style to use for the middle section of Navbuddy UI";
+                description = "The border style to use for the middle section of the Navbuddy UI.";
               };
             };
 
@@ -310,13 +310,13 @@ in {
               border = mkOption {
                 type = borderType;
                 default = config.vim.ui.borders.globalStyle;
-                description = "border style to use for the right section of Navbuddy UI";
+                description = "The border style to use for the right section of the Navbuddy UI.";
               };
 
               preview = mkOption {
                 type = enum ["leaf" "always" "never"];
                 default = "leaf";
-                description = "display mode of the preview on the right section";
+                description = "The display mode of the preview on the right section.";
               };
             };
           };
@@ -335,13 +335,13 @@ in {
           auto_attach = mkOption {
             type = bool;
             default = true;
-            description = "Whether to attach to LSP server manually";
+            description = "Whether to attach to LSP server manually.";
           };
 
           preference = mkOption {
             type = nullOr (listOf str);
             default = null;
-            description = "list of lsp server names in order of preference";
+            description = "The preference list ranking LSP servers.";
           };
         };
 
@@ -349,25 +349,25 @@ in {
           followNode = mkOption {
             type = bool;
             default = true;
-            description = "keep the current node in focus on the source buffer";
+            description = "Whether to keep the current node in focus in the source buffer.";
           };
 
           highlight = mkOption {
             type = bool;
             default = true;
-            description = "highlight the currently focused node";
+            description = "Whether to highlight the currently focused node in the source buffer.";
           };
 
           reorient = mkOption {
             type = enum ["smart" "top" "mid" "none"];
             default = "smart";
-            description = "reorient buffer after changing nodes";
+            description = "The mode for reorienting the source buffer after moving nodes.";
           };
 
           scrolloff = mkOption {
             type = nullOr int;
             default = null;
-            description = "scrolloff value when navbuddy is open";
+            description = "The scrolloff value in the source buffer when Navbuddy is open.";
           };
         };
 

--- a/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
+++ b/modules/plugins/ui/breadcrumbs/breadcrumbs.nix
@@ -4,7 +4,7 @@
   ...
 }: let
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.types) nullOr listOf enum bool str int either;
+  inherit (lib.types) nullOr listOf enum bool str int;
   inherit (lib.modules) mkRenamedOptionModule;
   inherit (lib.nvim.types) mkPluginSetupOption borderType;
   mkSimpleIconOption = default:

--- a/modules/plugins/ui/breadcrumbs/config.nix
+++ b/modules/plugins/ui/breadcrumbs/config.nix
@@ -64,6 +64,11 @@ in {
         ${cfg.navbuddy.mappings.moveDown} = mkLuaInline "actions.move_down()";
         ${cfg.navbuddy.mappings.moveUp} = mkLuaInline "actions.move_up()";
 
+        ${cfg.navbuddy.mappings.togglePreview} = mkLuaInline "actions.toggle_preview()";
+
+        ${cfg.navbuddy.mappings.vsplit} = mkLuaInline "actions.vsplit()";
+        ${cfg.navbuddy.mappings.hsplit} = mkLuaInline "actions.hsplit()";
+
         ${cfg.navbuddy.mappings.telescope} = mkLuaInline ''
           actions.telescope({
             layout_strategy = "horizontal",


### PR DESCRIPTION
I added missing Navbuddy mappings and cleaned up the module's option descriptions.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
