### PR TITLE
filetree/nvimTree: add misising icon options

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -362,3 +362,11 @@
 [Hardtime.nvim]: https://github.com/m4xshen/hardtime.nvim
 
 - Add Plugin [Hardtime.nvim] under `vim.binds.hardtime-nvim` with `enable` and `setupOpts` options
+
+[taylrfnt](https://github.com/taylrfnt):
+
+[nvim-tree](https://github.com/nvim-tree/nvim-tree.lua):
+
+- Add missing `right_align` option for existing `renderer.icons` options.
+- Add missing `render.icons` options (`hidden_placement`,
+  `diagnostics_placement`, and `bookmarks_placement`).

--- a/modules/plugins/filetree/nvimtree/nvimtree.nix
+++ b/modules/plugins/filetree/nvimtree/nvimtree.nix
@@ -683,15 +683,48 @@ in {
               };
 
               git_placement = mkOption {
-                type = enum ["before" "after" "signcolumn"];
-                description = "Place where the git icons will be rendered. `signcolumn` requires `view.signcolumn` to be enabled.";
+                type = enum ["before" "after" "signcolumn" "right_align"];
                 default = "before";
+                description = ''
+                  Place where the git icons will be rendered.
+                  `signcolumn` requires `view.signcolumn` to be enabled.
+                '';
               };
 
               modified_placement = mkOption {
-                type = enum ["before" "after" "signcolumn"];
-                description = "Place where the modified icons will be rendered. `signcolumn` requires `view.signcolumn` to be enabled.";
+                type = enum ["before" "after" "signcolumn" "right_align"];
                 default = "after";
+                description = ''
+                  Place where the modified icons will be rendered.
+                  `signcolumn` requires `view.signcolumn` to be enabled.
+                '';
+              };
+
+              hidden_placement = mkOption {
+                type = enum ["before" "after" "signcolumn" "right_align"];
+                default = "after";
+                description = ''
+                  Place where the hidden icons will be rendered.
+                  `signcolumn` requires `view.signcolumn` to be enabled.
+                '';
+              };
+
+              diagnostics_placement = mkOption {
+                type = enum ["before" "after" "signcolumn" "right_align"];
+                default = "after";
+                description = ''
+                  Place where the diagnostics icons will be rendered.
+                  `signcolumn` requires `view.signcolumn` to be enabled.
+                '';
+              };
+
+              bookmarks_placement = mkOption {
+                type = enum ["before" "after" "signcolumn" "right_align"];
+                default = "after";
+                description = ''
+                  Place where the bookmark icons will be rendered.
+                  `signcolumn` requires `view.signcolumn` to be enabled.
+                '';
               };
 
               padding = mkOption {


### PR DESCRIPTION
This PR addresses the issues mentioned in #876:
1. Missing `right_align` option for icon placements.
2. Missing several icon type `*_placement` options for configuration.

I did as extensive of testing as I could, and you can see the changes were successful (using one of the new options, 
```nix
nvimTree.setupOpts.renderer.icons.diagnostics_placement = "right_align";
```
As shown below, it is working as expected:
![image](https://github.com/user-attachments/assets/df08135d-fec9-4df9-907b-c8fea4b77ee2)

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc