### PR TITLE
ci: backport & labeler config

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,55 @@
+# This file is used by .github/workflows/labels.yml
+"topic: plugins":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - modules/plugins/**/*
+
+"topic: modules":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - modules/**/*
+
+"topic: dependencies":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - npins
+        - flake.lock
+
+"topic: CI":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/workflows/*.yml
+        - .github/typos.toml
+        . .github/dependabot.yml
+
+"topic: meta":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/CODEOWNERS
+        - LICENSE
+        - .github/README.md
+        - .github/funding.yml
+        - .github/assets
+        - .github/*_TEMPLATE
+        - .gitignore
+        - .editorconfig
+        - release.json
+
+"topic: documentation":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - docs/**/*
+        - .github/CONTRIBUTING.md
+        - .github/README.md
+"topic: packaging":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+          - flake.nix
+          - flake/packages.nix

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,33 @@
+name: Backport PR on Label
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+# Permissions needed for the korthout/backport-action to create branches and PRs
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Create Backport PR
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true && startsWith(github.event.label.name, 'backport-')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Backport Action
+        uses: korthout/backport-action@v3
+        with:
+          # Regex pattern for labels that should trigger a backport AND extracts the target branch
+          # from the name (e.g. v0.x or v0.x.y; we use zerover). This action will ONLY proceed if
+          # the label that triggered the workflow fully matches this pattern.
+          # Example matching labels: "backport-v0.1", "backport-v0.10.1"
+          # Example non-matching labels: "backport-foo", "backport-v1.0"
+          label_pattern: '^backport-(v0\.\d+(\.\d+)?)$'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,21 @@
+name: "Label PR"
+
+on:
+  pull_request_target:
+    types: [edited, opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labels:
+    name: "Label PR"
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.title, '[skip ci]')"
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
Based on the Nixpkgs CI, this creates a simplified workflow that allows us to
- tag changes based on the affected files
- backport changes to a target branch by specifying a backport label