### PR TITLE
languages/dart: fix infinite recursion

### DIFF
--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -143,8 +143,6 @@ in {
     })
 
     (mkIf ftcfg.enable {
-      lsp.enable = true;
-
       startPlugins = [
         (
           if ftcfg.enableNoResolvePatch


### PR DESCRIPTION
The default value of the flutter-tools.enable option conflicted with the
lsp.enable definition, which was conditionally defined based on
flutter-tools.enable. However, the lsp.enable definition isn't required
for flutter-tools' LSP functionality, so it can be removed.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
