### PR TITLE
cmp: use normal priority for default of `sources`

### DIFF
--- a/modules/plugins/completion/nvim-cmp/config.nix
+++ b/modules/plugins/completion/nvim-cmp/config.nix
@@ -60,6 +60,11 @@ in {
         enableSharedCmpSources = true;
 
         nvim-cmp = {
+          sources = {
+            nvim-cmp = null;
+            buffer = "[Buffer]";
+            path = "[Path]";
+          };
           sourcePlugins = ["cmp-buffer" "cmp-path"];
 
           setupOpts = {

--- a/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
+++ b/modules/plugins/completion/nvim-cmp/nvim-cmp.nix
@@ -98,11 +98,15 @@ in {
 
     sources = mkOption {
       type = attrsOf (nullOr str);
-      default = {
+      defaultText = literalMD ''
+        These sources are included by default:
+
+        ```nix
         nvim-cmp = null;
         buffer = "[Buffer]";
         path = "[Path]";
-      };
+        ```
+      '';
       example = {
         nvim-cmp = null;
         buffer = "[Buffer]";


### PR DESCRIPTION
fixes #839

After this change, user configs are "appended" to default ones
instead of overriding them


