### PR TITLE
feat: add treesitter textobjects

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -329,11 +329,13 @@
 
 [flash.nvim]: https://github.com/folke/flash.nvim
 [gitlinker.nvim]: https://github.com/linrongbin16/gitlinker.nvim
+[nvim-treesitter-textobjects]: https://github.com/nvim-treesitter/nvim-treesitter-textobjects
 
 - Fix oil config referencing snacks
 - Add [flash.nvim] plugin to `vim.utility.motion.flash-nvim`
 - Fix default telescope ignore list entry for '.git/' to properly match
 - Add [gitlinker.nvim] plugin to `vim.git.gitlinker-nvim`
+- Add [nvim-treesitter-textobjects] plugin to `vim.treesitter.textobjects`
 
 [rrvsh](https://github.com/rrvsh):
 

--- a/modules/plugins/treesitter/default.nix
+++ b/modules/plugins/treesitter/default.nix
@@ -2,6 +2,7 @@
   imports = [
     # treesitter extras
     ./ts-context
+    ./ts-textobjects
 
     ./treesitter.nix
     ./config.nix

--- a/modules/plugins/treesitter/ts-textobjects/config.nix
+++ b/modules/plugins/treesitter/ts-textobjects/config.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAfter;
+
+  inherit (config.vim) treesitter;
+  cfg = treesitter.textobjects;
+in {
+  config = mkIf (treesitter.enable && cfg.enable) {
+    vim = {
+      startPlugins = ["nvim-treesitter-textobjects"];
+
+      # set up treesitter-textobjects after Treesitter, whose config we're adding to.
+      pluginRC.treesitter-textobjects = entryAfter ["treesitter"] ''
+        require("nvim-treesitter.configs").setup({textobjects = ${toLuaObject cfg.setupOpts}})
+      '';
+    };
+  };
+}

--- a/modules/plugins/treesitter/ts-textobjects/default.nix
+++ b/modules/plugins/treesitter/ts-textobjects/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./textobjects.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/treesitter/ts-textobjects/textobjects.nix
+++ b/modules/plugins/treesitter/ts-textobjects/textobjects.nix
@@ -1,0 +1,21 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.treesitter.textobjects = {
+    enable = mkEnableOption "Treesitter textobjects";
+    setupOpts =
+      mkPluginSetupOption "treesitter-textobjects" {}
+      // {
+        example = {
+          select = {
+            enable = true;
+            lookahead = true;
+            keymaps = {
+              af = "@function.outer";
+            };
+          };
+        };
+      };
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1906,6 +1906,19 @@
       "url": "https://github.com/nvim-treesitter/nvim-treesitter-context/archive/6daca3ad780f045550b820f262002f35175a6c04.tar.gz",
       "hash": "0qprwd44hw9sz0vh14p6lpvs9vxrick462pfkradmal6ak1kfwn3"
     },
+    "nvim-treesitter-textobjects": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "nvim-treesitter",
+        "repo": "nvim-treesitter-textobjects"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "0e3be38005e9673d044e994b1e4b123adb040179",
+      "url": "https://github.com/nvim-treesitter/nvim-treesitter-textobjects/archive/0e3be38005e9673d044e994b1e4b123adb040179.tar.gz",
+      "hash": "0y93pj3asarw7jhk4cdphhx6awxdyiwajc0n9nr4836gn48qcs85"
+    },
     "nvim-ts-autotag": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Not sure if there's a better way to make this load before mini.ai and after TS. Nothing seems to break even if mini.ai is disabled.
I also don't use any default config for the actual plugin, just the objects it provides with my mini.ai user config.