### PR TITLE
add ruby lsp as ruby server option

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -375,3 +375,8 @@
 - Add missing `right_align` option for existing `renderer.icons` options.
 - Add missing `render.icons` options (`hidden_placement`,
   `diagnostics_placement`, and `bookmarks_placement`).
+
+[cramt](https://github.com/cramt):
+
+- Add `rubylsp` option in `vim.languages.ruby.lsp.server` to use shopify's
+  ruby-lsp language server

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -193,7 +193,7 @@ in {
         require("markview").setup(${toLuaObject cfg.extensions.markview-nvim.setupOpts})
       '';
     })
-    
+
     (mkIf cfg.extraDiagnostics.enable {
       vim.diagnostics.nvim-lint = {
         enable = true;

--- a/modules/plugins/languages/ruby.nix
+++ b/modules/plugins/languages/ruby.nix
@@ -9,6 +9,8 @@
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.lua) expToLua;
+  inherit (lib.lists) isList;
   inherit (lib.types) either listOf package str enum;
 
   cfg = config.vim.languages.ruby;
@@ -24,10 +26,28 @@
           flags = {
             debounce_text_changes = 150,
           },
-          cmd = { "${pkgs.solargraph}/bin/solargraph", "stdio" }
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{ "${cfg.lsp.package}/bin/solargraph", "stdio" }''
+        }
         }
       '';
     };
+    rubylsp = {
+      package = pkgs.ruby-lsp;
+      lspConfig = ''
+        lspconfig.ruby_lsp.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{ "${cfg.lsp.package}/bin/ruby-lsp" }''
+        }
+        }
+      '';
+    }
   };
 
   # testing


### PR DESCRIPTION
added shopify's new lsp for ruby called `ruby-lsp` as a server option along side solargraph

Also updated the solargraph config to match all the other, with the fact that it can either be a package or list of strings