### PR TITLE
fix: disable Conform for Rust

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -346,6 +346,8 @@
 - Fix default telescope ignore list entry for '.git/' to properly match
 - Add [gitlinker.nvim] plugin to `vim.git.gitlinker-nvim`
 - Add [nvim-treesitter-textobjects] plugin to `vim.treesitter.textobjects`
+- Default to disabling Conform for Rust if rust-analyzer is used
+  - To force using Conform, set `languages.rust.format.enable = true`.
 
 [rrvsh](https://github.com/rrvsh):
 

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -7,7 +7,7 @@
   inherit (builtins) attrNames;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.options) mkOption mkEnableOption literalMD;
   inherit (lib.strings) optionalString;
   inherit (lib.trivial) boolToString;
   inherit (lib.lists) isList;
@@ -68,7 +68,14 @@ in {
     };
 
     format = {
-      enable = mkEnableOption "Rust formatting" // {default = config.vim.languages.enableFormat;};
+      enable =
+        mkEnableOption "Rust formatting"
+        // {
+          default = !cfg.lsp.enable && config.vim.languages.enableFormat;
+          defaultText = literalMD ''
+            Disabled if Rust LSP is enabled, otherwise follows {option}`vim.languages.enableFormat`
+          '';
+        };
 
       type = mkOption {
         description = "Rust formatter to use";


### PR DESCRIPTION
I don't think we want Conform to also do autoformatting. I am running into issues where it doesn't respect the `rustfmt.toml` file and will happily format according to the 2015 edition. The builtin `RustFmt` command also works and can be set up to autosave, but `rustaceanvim` includes `rust-analyzer` which will run `rustfmt` as well. 

All this to say, autoformatting still works without Conform and also doesn't break stuff. 