### PR TITLE
languages/verilog: init

### DIFF
--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -37,6 +37,7 @@ in {
     ./terraform.nix
     ./ts.nix
     ./typst.nix
+    ./verilog.nix
     ./zig.nix
     ./csharp.nix
     ./julia.nix

--- a/modules/plugins/languages/verilog.nix
+++ b/modules/plugins/languages/verilog.nix
@@ -1,0 +1,120 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.meta) getExe;
+  inherit (lib.lists) isList;
+  inherit (lib.types) enum either listOf package str;
+  inherit (lib.nvim.types) diagnostics mkGrammarOption;
+  inherit (lib.nvim.lua) expToLua;
+
+  cfg = config.vim.languages.verilog;
+  defaultServer = "verible";
+  servers = {
+    svls = {
+      package = pkgs.svls;
+      lspConfig = ''
+        lspconfig.verible.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${getExe cfg.lsp.package}"}''
+        },
+        }
+      '';
+    };
+    verible = {
+      package = pkgs.verible;
+      lspConfig = ''
+        lspconfig.verible.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = ${
+          if isList cfg.lsp.package
+          then expToLua cfg.lsp.package
+          else ''{"${cfg.lsp.package}/bin/verible-verilog-ls", "--rules_config_search"}''
+        },
+        }
+      '';
+    };
+  };
+  defaultDiagnosticsProvider = [ "verilator" ];
+  diagnosticsProviders = {
+    svlint = {
+      package = pkgs.svlint;
+    };
+    verible = {
+      package = pkgs.verible;
+
+    };
+    verilator = {
+      package = pkgs.verilator;
+    };
+  };
+in {
+  options.vim.languages.verilog = {
+    enable = mkEnableOption "SystemVerilog language support";
+
+    treesitter = {
+      enable = mkEnableOption "SystemVerilog treesitter" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "verilog";
+    };
+
+    lsp = {
+      enable = mkEnableOption "SystemVerilog LSP support" // {default = config.vim.lsp.enable;};
+
+      package = mkOption {
+        description = "SystemVerilog LSP server package, or the command to run as a list of strings";
+        example = ''[lib.getExe pkgs.jdt-language-server "-data" "~/.cache/jdtls/workspace"]'';
+        type = either package (listOf str);
+        default = servers.${cfg.lsp.server}.package;
+      };
+
+      server = mkOption {
+        description = "SystemVerilog LSP server to use";
+        type = enum (attrNames servers);
+        default = defaultServer;
+      };
+    };
+
+    extraDiagnostics = {
+      enable = mkEnableOption "extra SystemVerilog diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+
+      types = diagnostics {
+        langDesc = "SystemVerilog";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.verilog-lsp = servers.${cfg.lsp.server}.lspConfig;
+    })
+
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.verilog = cfg.extraDiagnostics.types;
+        linters = mkMerge (map (name: {
+            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
+          })
+          cfg.extraDiagnostics.types);
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Adds SystemVerilog language support.

Early draft for input/critique. 

### Language Servers:
- [x] [Verible](https://github.com/chipsalliance/verible/blob/master/verible/verilog/tools/ls)
- [ ] [svls](https://github.com/dalance/svls)

### Linters:
- [ ] [Verible](https://github.com/chipsalliance/verible/blob/master/verible/verilog/tools/lint)
- [ ] [svlint](https://github.com/dalance/svlint)
- [ ] [Verilator](https://github.com/verilator/verilator)

### Formatters:
- [ ] [Verible](https://github.com/chipsalliance/verible/blob/master/verible/verilog/tools/formatter)

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc