### PR TITLE
assistant/codecompanion: also add YAML tree-sitter grammar when enabled

### DIFF
--- a/modules/plugins/assistant/codecompanion/config.nix
+++ b/modules/plugins/assistant/codecompanion/config.nix
@@ -21,7 +21,17 @@ in {
         };
       };
 
-      treesitter.enable = true;
+      treesitter = {
+        enable = true;
+
+        # Codecompanion depends on the YAML grammar being added. Below is
+        # an easy way of adding an user-configurable grammar package exposed
+        # by the YAML language module *without* enabling the whole YAML language
+        # module. The package is defined even when the module is disabled.
+        grammars = [
+          config.vim.languages.yaml.treesitter.package
+        ];
+      };
 
       autocomplete.nvim-cmp = {
         sources = {codecompanion-nvim = "[codecompanion]";};


### PR DESCRIPTION
Fixes #908 