### PR TITLE
Themes/solarized

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -427,3 +427,9 @@
 [theutz](https://github.com/theutz):
 
 - Added "auto" flavour for catppuccin theme
+
+[lackac](https://github.com/lackac):
+
+[solarized.nvim]: https://github.com/maxmx03/solarized.nvim
+
+- Add [solarized.nvim] theme with support for multiple variants

--- a/modules/plugins/theme/supported-themes.nix
+++ b/modules/plugins/theme/supported-themes.nix
@@ -231,9 +231,12 @@ in {
       ...
     }: let
       parts = splitString "-" style;
-      detect = list:
-        let intersection = intersectLists parts list;
-        in if intersection == [] then null else builtins.head intersection;
+      detect = list: let
+        intersection = intersectLists parts list;
+      in
+        if intersection == []
+        then null
+        else builtins.head intersection;
       background = detect backgrounds;
       palette = detect palettes;
       variant = detect variants;
@@ -251,12 +254,18 @@ in {
     '';
     styles = let
       joinWithDashes = parts: lib.concatStringsSep "-" (lib.filter (s: s != "") parts);
-      combinations = mapCartesianProduct ({bg, pal, var}: joinWithDashes [bg pal var]) {
+      combinations = mapCartesianProduct ({
+        bg,
+        pal,
+        var,
+      }:
+        joinWithDashes [bg pal var]) {
         bg = [""] ++ backgrounds;
         pal = [""] ++ palettes;
         var = [""] ++ variants;
       };
-    in lib.filter (s: s != "") combinations;
+    in
+      lib.filter (s: s != "") combinations;
   };
 
   solarized-osaka = {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2261,6 +2261,22 @@
       "url": "https://api.github.com/repos/folke/snacks.nvim/tarball/v2.22.0",
       "hash": "1hbm4fnw51qdp0nz83fcxbvnxjq2k57a37w6dp0wz6wkcx7cwxw9"
     },
+    "solarized": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "maxmx03",
+        "repo": "solarized.nvim"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v3.6.0",
+      "revision": "c0dfe1cbfabd93b546baf5f1408f5df7e02e2050",
+      "url": "https://api.github.com/repos/maxmx03/solarized.nvim/tarball/v3.6.0",
+      "hash": "1fz1wc569w26aanmj3hhsc17xrx29g6bfsjsbgssa7jq76aavp3w"
+    },
     "solarized-osaka": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
This adds the solarized colorscheme using a lua implementation that supports light and dark mode and multiple variants as well as an additional slightly modified palette. The [plugin](https://github.com/maxmx03/solarized.nvim) has support for Treesitter and a wide range of Neovim plugins.

I understand there is support for the solarized-osaka variant already, but that doesn't have light background support and is generally less configurable.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc