### PR TITLE
snippets/luasnip: add the ability to add custom snippets

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -352,6 +352,7 @@
 
 [rrvsh](https://github.com/rrvsh):
 
+- Add custom snippet support to `vim.snippets.luasnip`
 - Fix namespace of python-lsp-server by changing it to python3Packages
 
 [Noah765](https://github.com/Noah765):

--- a/modules/plugins/snippets/luasnip/config.nix
+++ b/modules/plugins/snippets/luasnip/config.nix
@@ -1,11 +1,48 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }: let
   inherit (lib.modules) mkIf;
 
+  inherit (lib.lists) replicate;
+  inherit
+    (lib.strings)
+    optionalString
+    removeSuffix
+    concatStrings
+    stringAsChars
+    concatMapStringsSep
+    ;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (pkgs) writeTextFile;
   cfg = config.vim.snippets.luasnip;
+  # LuaSnip freaks out if the indentation is wrong in snippets
+  indent = n: s: let
+    indentString = concatStrings (replicate n " ");
+    sep = "\n" + indentString;
+  in
+    indentString
+    + stringAsChars (c:
+      if c == "\n"
+      then sep
+      else c) (removeSuffix "\n" s);
+  customSnipmateSnippetFiles =
+    mapAttrsToList (
+      name: value:
+        writeTextFile {
+          name = "${name}.snippets";
+          text =
+            concatMapStringsSep "\n" (x: ''
+              snippet ${x.trigger} ${x.description}
+              ${indent 2 x.body}
+            '')
+            value;
+          destination = "/snippets/${name}.snippets";
+        }
+    )
+    cfg.customSnippets.snipmate;
 in {
   config = mkIf cfg.enable {
     vim = {
@@ -19,11 +56,16 @@ in {
 
         after = cfg.loaders;
       };
-      startPlugins = cfg.providers;
+      startPlugins = cfg.providers ++ customSnipmateSnippetFiles;
       autocomplete.nvim-cmp = mkIf config.vim.autocomplete.nvim-cmp.enable {
         sources = {luasnip = "[LuaSnip]";};
         sourcePlugins = ["cmp-luasnip"];
       };
+      snippets.luasnip.loaders = ''
+        ${optionalString (
+          cfg.customSnippets.snipmate != {}
+        ) "require('luasnip.loaders.from_snipmate').lazy_load()"}
+      '';
     };
   };
 }

--- a/modules/plugins/snippets/luasnip/luasnip.nix
+++ b/modules/plugins/snippets/luasnip/luasnip.nix
@@ -1,6 +1,6 @@
 {lib, ...}: let
   inherit (lib.options) mkEnableOption mkOption literalExpression literalMD;
-  inherit (lib.types) listOf lines;
+  inherit (lib.types) listOf lines submodule str attrsOf;
   inherit (lib.nvim.types) pluginType mkPluginSetupOption;
 in {
   options.vim.snippets.luasnip = {
@@ -35,6 +35,62 @@ in {
 
     setupOpts = mkPluginSetupOption "LuaSnip" {
       enable_autosnippets = mkEnableOption "autosnippets";
+    };
+
+    customSnippets.snipmate = mkOption {
+      type = attrsOf (
+        listOf (submodule {
+          options = {
+            trigger = mkOption {
+              type = str;
+              description = ''
+                The trigger used to activate this snippet.
+              '';
+            };
+            description = mkOption {
+              type = str;
+              default = "";
+              description = ''
+                The description shown for this snippet.
+              '';
+            };
+            body = mkOption {
+              type = str;
+              description = ''
+                [LuaSnip Documentation]: https://github.com/L3MON4D3/LuaSnip#add-snippets
+                The body of the snippet in SnipMate format (see [LuaSnip Documentation]).
+              '';
+            };
+          };
+        })
+      );
+      default = {};
+      example = ''
+        {
+          all = [
+            {
+              trigger = "if";
+              body = "if $1 else $2";
+            }
+          ];
+          nix = [
+            {
+              trigger = "mkOption";
+              body = '''
+                mkOption {
+                  type = $1;
+                  default = $2;
+                  description = $3;
+                  example = $4;
+                }
+              ''';
+            }
+          ];
+        }
+      '';
+      description = ''
+        A list containing custom snippets in the SnipMate format to be loaded by LuaSnip.
+      '';
     };
   };
 }


### PR DESCRIPTION
This adds `vim.snippets.luasnip.customSnippets.snipmate` as an option, allowing custom snippets to be added to the runtime dir.

Only snipmate is added as of now, but VSCode snippets should be easy enough to patch in.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc