### PR TITLE
Update vim.clipboard.registers type to str

### DIFF
--- a/modules/neovim/init/clipboard.nix
+++ b/modules/neovim/init/clipboard.nix
@@ -20,7 +20,7 @@ in {
         '';
 
         registers = mkOption {
-          type = either str (listOf str);
+          type = str;
           default = "";
           example = "unnamedplus";
           description = ''
@@ -33,8 +33,8 @@ in {
             `"+"` ({command}`:h quoteplus`) instead of register `"*"` for all yank, delete,
             change and put operations which would normally go to the unnamed register.
 
-            When `unnamed` and `unnamedplus` is included simultaneously yank and delete
-            operations (but not put) will additionally copy the text into register `"*"`.
+            When `unnamed` and `unnamedplus` is included simultaneously as `"unnamed,unnamedplus"`,
+            yank and delete operations (but not put) will additionally copy the text into register `"*"`.
 
             Please see  {command}`:h clipboard` for more details.
 


### PR DESCRIPTION
nvf.settings.vim.clipboard.registers allows for either a string or a list of strings, but Neovim only accepts a string value. When a NVF user follows the options Appendix and passes a string, this results in an invalid Neovim config. Solved by updating the type to allow strings only.