### PR TITLE
Added logic to configure nil_ls via the same options parameter used for nixd.

### DIFF
--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -4,8 +4,7 @@
   lib,
   inputs,
   ...
-}:
-let
+}: let
   inherit (builtins) attrNames;
   inherit (lib) concatStringsSep;
   inherit (lib.meta) getExe;
@@ -13,7 +12,8 @@ let
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.strings) optionalString;
-  inherit (lib.types)
+  inherit
+    (lib.types)
     anything
     attrsOf
     enum
@@ -32,9 +32,10 @@ let
   noFormat = "on_attach = attach_keymaps";
 
   defaultServer = "nil";
-  packageToCmd =
-    package: defaultCmd:
-    if isList package then expToLua package else ''{"${package}/bin/${defaultCmd}"}'';
+  packageToCmd = package: defaultCmd:
+    if isList package
+    then expToLua package
+    else ''{"${package}/bin/${defaultCmd}"}'';
   servers = {
     nil = {
       package = inputs.nil.packages.${pkgs.stdenv.system}.nil;
@@ -42,7 +43,11 @@ let
       lspConfig = ''
         lspconfig.nil_ls.setup{
           capabilities = capabilities,
-        ${if cfg.format.enable then useFormat else noFormat},
+        ${
+          if cfg.format.enable
+          then useFormat
+          else noFormat
+        },
           cmd = ${packageToCmd cfg.lsp.package "nil"},
         ${optionalString cfg.format.enable ''
           settings = {
@@ -71,7 +76,11 @@ let
       lspConfig = ''
         lspconfig.nixd.setup{
           capabilities = capabilities,
-        ${if cfg.format.enable then useFormat else noFormat},
+        ${
+          if cfg.format.enable
+          then useFormat
+          else noFormat
+        },
           cmd = ${packageToCmd cfg.lsp.package "nixd"},
         ${optionalString cfg.format.enable ''
           settings = {
@@ -135,22 +144,25 @@ let
       '';
     };
   };
-in
-{
+in {
   options.vim.languages.nix = {
     enable = mkEnableOption "Nix language support";
 
     treesitter = {
-      enable = mkEnableOption "Nix treesitter" // {
-        default = config.vim.languages.enableTreesitter;
-      };
+      enable =
+        mkEnableOption "Nix treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+        };
       package = mkGrammarOption pkgs "nix";
     };
 
     lsp = {
-      enable = mkEnableOption "Nix LSP support" // {
-        default = config.vim.lsp.enable;
-      };
+      enable =
+        mkEnableOption "Nix LSP support"
+        // {
+          default = config.vim.lsp.enable;
+        };
       server = mkOption {
         description = "Nix LSP server to use";
         type = enum (attrNames servers);
@@ -172,9 +184,11 @@ in
     };
 
     format = {
-      enable = mkEnableOption "Nix formatting" // {
-        default = config.vim.languages.enableFormat;
-      };
+      enable =
+        mkEnableOption "Nix formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+        };
 
       type = mkOption {
         description = "Nix formatter to use";
@@ -190,9 +204,11 @@ in
     };
 
     extraDiagnostics = {
-      enable = mkEnableOption "extra Nix diagnostics" // {
-        default = config.vim.languages.enableExtraDiagnostics;
-      };
+      enable =
+        mkEnableOption "extra Nix diagnostics"
+        // {
+          default = config.vim.languages.enableExtraDiagnostics;
+        };
 
       types = diagnostics {
         langDesc = "Nix";
@@ -224,7 +240,7 @@ in
 
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
-      vim.treesitter.grammars = [ cfg.treesitter.package ];
+      vim.treesitter.grammars = [cfg.treesitter.package];
     })
 
     (mkIf cfg.lsp.enable {
@@ -235,7 +251,7 @@ in
     (mkIf (cfg.format.enable && (!cfg.lsp.enable || !servers.${cfg.lsp.server}.internalFormatter)) {
       vim.formatter.conform-nvim = {
         enable = true;
-        setupOpts.formatters_by_ft.nix = [ cfg.format.type ];
+        setupOpts.formatters_by_ft.nix = [cfg.format.type];
         setupOpts.formatters.${cfg.format.type} = {
           command = getExe cfg.format.package;
         };
@@ -249,7 +265,8 @@ in
         linters = mkMerge (
           map (name: {
             ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          }) cfg.extraDiagnostics.types
+          })
+          cfg.extraDiagnostics.types
         );
       };
     })

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -47,7 +47,7 @@
               if cfg.format.enable
               then mkLuaInline "default_on_attach"
               else "attach_keymaps";
-            cmd = [(packageToCmd cfg.lsp.package "nil")];
+            cmd = mkLuaInline (packageToCmd cfg.lsp.package "nil");
             settings.nil =
               {
                 formatting.command =

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -44,8 +44,8 @@ let
           capabilities = mkLuaInline "capabilities";
           on_attach = if cfg.format.enable then mkLuaInline "default_on_attach" else "attach_keymaps";
           cmd = packageToCmd cfg.lsp.package "nil";
-          settings = {
-            nil.formatting.command =
+          settings.nil = {
+            formatting.command =
               if cfg.format.enable then
                 if cfg.format.type == "alejandra" then
                   ''{"${cfg.format.package}/bin/alejandra", "--quiet"}''
@@ -55,7 +55,7 @@ let
                   null
               else
                 null;
-          } // config.lsp.options;
+          } // cfg.lsp.options;
         }
       }'';
       # lspConfig = ''

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -4,16 +4,16 @@
   lib,
   inputs,
   ...
-}: let
+}:
+let
   inherit (builtins) attrNames;
-  inherit (lib) concatStringsSep;
+  inherit (lib) concatStringsSep mkLuaInline;
   inherit (lib.meta) getExe;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.strings) optionalString;
-  inherit
-    (lib.types)
+  inherit (lib.types)
     anything
     attrsOf
     enum
@@ -32,42 +32,60 @@
   noFormat = "on_attach = attach_keymaps";
 
   defaultServer = "nil";
-  packageToCmd = package: defaultCmd:
-    if isList package
-    then expToLua package
-    else ''{"${package}/bin/${defaultCmd}"}'';
+  packageToCmd =
+    package: defaultCmd:
+    if isList package then expToLua package else ''{"${package}/bin/${defaultCmd}"}'';
   servers = {
     nil = {
       package = inputs.nil.packages.${pkgs.stdenv.system}.nil;
       internalFormatter = true;
-      lspConfig = ''
-        lspconfig.nil_ls.setup{
-          capabilities = capabilities,
-        ${
-          if cfg.format.enable
-          then useFormat
-          else noFormat
-        },
-          cmd = ${packageToCmd cfg.lsp.package "nil"},
-        ${optionalString cfg.format.enable ''
+      lspConfig = ''lspconfig.nil_ls.setup ${
+        toLuaObject {
+          capabilities = mkLuaInline "capabilities";
+          on_attach = if cfg.format.enable then mkLuaInline "default_on_attach" else "attach_keymaps";
+          cmd = packageToCmd cfg.lsp.package "nil";
           settings = {
-            ["nil"] = {
-          ${optionalString (cfg.format.type == "alejandra") ''
-            formatting = {
-              command = {"${cfg.format.package}/bin/alejandra", "--quiet"},
-            },
-          ''}
-          ${optionalString (cfg.format.type == "nixfmt") ''
-            formatting = {
-              command = {"${cfg.format.package}/bin/nixfmt"},
-            },
-          ''}
-            nix = ${toLuaObject cfg.lsp.options},
-            },
-          },
-        ''}
+            nil.formatting.command =
+              if cfg.format.enable then
+                if cfg.format.type == "alejandra" then
+                  ''{"${cfg.format.package}/bin/alejandra", "--quiet"}''
+                else if cfg.format.type == "nixfmt" then
+                  ''{"${cfg.format.package}/bin/nixfmt"}''
+                else
+                  null
+              else
+                null;
+          } // config.lsp.options;
         }
-      '';
+      }'';
+      # lspConfig = ''
+      #   lspconfig.nil_ls.setup{
+      #     capabilities = capabilities,
+      #   ${
+      #     if cfg.format.enable
+      #     then useFormat
+      #     else noFormat
+      #   },
+      #     cmd = ${packageToCmd cfg.lsp.package "nil"},
+      #   ${optionalString cfg.format.enable ''
+      #     settings = {
+      #       ["nil"] = {
+      #     ${optionalString (cfg.format.type == "alejandra") ''
+      #       formatting = {
+      #         command = {"${cfg.format.package}/bin/alejandra", "--quiet"},
+      #       },
+      #     ''}
+      #     ${optionalString (cfg.format.type == "nixfmt") ''
+      #       formatting = {
+      #         command = {"${cfg.format.package}/bin/nixfmt"},
+      #       },
+      #     ''}
+      #       nix = ${toLuaObject cfg.lsp.options},
+      #       },
+      #     },
+      #   ''}
+      #   }
+      # '';
     };
 
     nixd = {
@@ -76,11 +94,7 @@
       lspConfig = ''
         lspconfig.nixd.setup{
           capabilities = capabilities,
-        ${
-          if cfg.format.enable
-          then useFormat
-          else noFormat
-        },
+        ${if cfg.format.enable then useFormat else noFormat},
           cmd = ${packageToCmd cfg.lsp.package "nixd"},
         ${optionalString cfg.format.enable ''
           settings = {
@@ -144,25 +158,22 @@
       '';
     };
   };
-in {
+in
+{
   options.vim.languages.nix = {
     enable = mkEnableOption "Nix language support";
 
     treesitter = {
-      enable =
-        mkEnableOption "Nix treesitter"
-        // {
-          default = config.vim.languages.enableTreesitter;
-        };
+      enable = mkEnableOption "Nix treesitter" // {
+        default = config.vim.languages.enableTreesitter;
+      };
       package = mkGrammarOption pkgs "nix";
     };
 
     lsp = {
-      enable =
-        mkEnableOption "Nix LSP support"
-        // {
-          default = config.vim.lsp.enable;
-        };
+      enable = mkEnableOption "Nix LSP support" // {
+        default = config.vim.lsp.enable;
+      };
       server = mkOption {
         description = "Nix LSP server to use";
         type = enum (attrNames servers);
@@ -184,11 +195,9 @@ in {
     };
 
     format = {
-      enable =
-        mkEnableOption "Nix formatting"
-        // {
-          default = config.vim.languages.enableFormat;
-        };
+      enable = mkEnableOption "Nix formatting" // {
+        default = config.vim.languages.enableFormat;
+      };
 
       type = mkOption {
         description = "Nix formatter to use";
@@ -204,11 +213,9 @@ in {
     };
 
     extraDiagnostics = {
-      enable =
-        mkEnableOption "extra Nix diagnostics"
-        // {
-          default = config.vim.languages.enableExtraDiagnostics;
-        };
+      enable = mkEnableOption "extra Nix diagnostics" // {
+        default = config.vim.languages.enableExtraDiagnostics;
+      };
 
       types = diagnostics {
         langDesc = "Nix";
@@ -240,7 +247,7 @@ in {
 
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
-      vim.treesitter.grammars = [cfg.treesitter.package];
+      vim.treesitter.grammars = [ cfg.treesitter.package ];
     })
 
     (mkIf cfg.lsp.enable {
@@ -251,7 +258,7 @@ in {
     (mkIf (cfg.format.enable && (!cfg.lsp.enable || !servers.${cfg.lsp.server}.internalFormatter)) {
       vim.formatter.conform-nvim = {
         enable = true;
-        setupOpts.formatters_by_ft.nix = [cfg.format.type];
+        setupOpts.formatters_by_ft.nix = [ cfg.format.type ];
         setupOpts.formatters.${cfg.format.type} = {
           command = getExe cfg.format.package;
         };
@@ -265,8 +272,7 @@ in {
         linters = mkMerge (
           map (name: {
             ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types
+          }) cfg.extraDiagnostics.types
         );
       };
     })

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -4,7 +4,8 @@
   lib,
   inputs,
   ...
-}: let
+}:
+let
   inherit (builtins) attrNames;
   inherit (lib) concatStringsSep mkLuaInline;
   inherit (lib.meta) getExe;
@@ -12,8 +13,7 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.strings) optionalString;
-  inherit
-    (lib.types)
+  inherit (lib.types)
     anything
     attrsOf
     enum
@@ -32,37 +32,32 @@
   noFormat = "on_attach = attach_keymaps";
 
   defaultServer = "nil";
-  packageToCmd = package: defaultCmd:
-    if isList package
-    then expToLua package
-    else ''{"${package}/bin/${defaultCmd}"}'';
+  packageToCmd =
+    package: defaultCmd:
+    if isList package then expToLua package else ''{"${package}/bin/${defaultCmd}"}'';
   servers = {
     nil = {
       package = inputs.nil.packages.${pkgs.stdenv.system}.nil;
       internalFormatter = true;
       lspConfig = ''lspconfig.nil_ls.setup ${
-          toLuaObject {
-            capabilities = mkLuaInline "capabilities";
-            on_attach =
-              if cfg.format.enable
-              then mkLuaInline "default_on_attach"
-              else "attach_keymaps";
-            cmd = mkLuaInline (packageToCmd cfg.lsp.package "nil");
-            settings.nil =
-              {
-                formatting.command =
-                  if cfg.format.enable
-                  then
-                    if cfg.format.type == "alejandra"
-                    then ''{"${cfg.format.package}/bin/alejandra", "--quiet"}''
-                    else if cfg.format.type == "nixfmt"
-                    then ''{"${cfg.format.package}/bin/nixfmt"}''
-                    else null
-                  else null;
-              }
-              // cfg.lsp.options;
-          }
-        }'';
+        toLuaObject {
+          capabilities = mkLuaInline "capabilities";
+          on_attach = if cfg.format.enable then mkLuaInline "default_on_attach" else "attach_keymaps";
+          cmd = mkLuaInline (packageToCmd cfg.lsp.package "nil");
+          settings.nil = {
+            formatting.command =
+              if cfg.format.enable then
+                if cfg.format.type == "alejandra" then
+                  mkLuaInline ''{"${cfg.format.package}/bin/alejandra", "--quiet"}''
+                else if cfg.format.type == "nixfmt" then
+                  mkLuaInline ''{"${cfg.format.package}/bin/nixfmt"}''
+                else
+                  null
+              else
+                null;
+          } // cfg.lsp.options;
+        }
+      }'';
       # lspConfig = ''
       #   lspconfig.nil_ls.setup{
       #     capabilities = capabilities,
@@ -99,11 +94,7 @@
       lspConfig = ''
         lspconfig.nixd.setup{
           capabilities = capabilities,
-        ${
-          if cfg.format.enable
-          then useFormat
-          else noFormat
-        },
+        ${if cfg.format.enable then useFormat else noFormat},
           cmd = ${packageToCmd cfg.lsp.package "nixd"},
         ${optionalString cfg.format.enable ''
           settings = {
@@ -167,25 +158,22 @@
       '';
     };
   };
-in {
+in
+{
   options.vim.languages.nix = {
     enable = mkEnableOption "Nix language support";
 
     treesitter = {
-      enable =
-        mkEnableOption "Nix treesitter"
-        // {
-          default = config.vim.languages.enableTreesitter;
-        };
+      enable = mkEnableOption "Nix treesitter" // {
+        default = config.vim.languages.enableTreesitter;
+      };
       package = mkGrammarOption pkgs "nix";
     };
 
     lsp = {
-      enable =
-        mkEnableOption "Nix LSP support"
-        // {
-          default = config.vim.lsp.enable;
-        };
+      enable = mkEnableOption "Nix LSP support" // {
+        default = config.vim.lsp.enable;
+      };
       server = mkOption {
         description = "Nix LSP server to use";
         type = enum (attrNames servers);
@@ -207,11 +195,9 @@ in {
     };
 
     format = {
-      enable =
-        mkEnableOption "Nix formatting"
-        // {
-          default = config.vim.languages.enableFormat;
-        };
+      enable = mkEnableOption "Nix formatting" // {
+        default = config.vim.languages.enableFormat;
+      };
 
       type = mkOption {
         description = "Nix formatter to use";
@@ -227,11 +213,9 @@ in {
     };
 
     extraDiagnostics = {
-      enable =
-        mkEnableOption "extra Nix diagnostics"
-        // {
-          default = config.vim.languages.enableExtraDiagnostics;
-        };
+      enable = mkEnableOption "extra Nix diagnostics" // {
+        default = config.vim.languages.enableExtraDiagnostics;
+      };
 
       types = diagnostics {
         langDesc = "Nix";
@@ -263,7 +247,7 @@ in {
 
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
-      vim.treesitter.grammars = [cfg.treesitter.package];
+      vim.treesitter.grammars = [ cfg.treesitter.package ];
     })
 
     (mkIf cfg.lsp.enable {
@@ -274,7 +258,7 @@ in {
     (mkIf (cfg.format.enable && (!cfg.lsp.enable || !servers.${cfg.lsp.server}.internalFormatter)) {
       vim.formatter.conform-nvim = {
         enable = true;
-        setupOpts.formatters_by_ft.nix = [cfg.format.type];
+        setupOpts.formatters_by_ft.nix = [ cfg.format.type ];
         setupOpts.formatters.${cfg.format.type} = {
           command = getExe cfg.format.package;
         };
@@ -288,8 +272,7 @@ in {
         linters = mkMerge (
           map (name: {
             ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types
+          }) cfg.extraDiagnostics.types
         );
       };
     })

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -4,8 +4,7 @@
   lib,
   inputs,
   ...
-}:
-let
+}: let
   inherit (builtins) attrNames;
   inherit (lib) concatStringsSep mkLuaInline;
   inherit (lib.meta) getExe;
@@ -13,7 +12,8 @@ let
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.lists) isList;
   inherit (lib.strings) optionalString;
-  inherit (lib.types)
+  inherit
+    (lib.types)
     anything
     attrsOf
     enum
@@ -32,60 +32,37 @@ let
   noFormat = "on_attach = attach_keymaps";
 
   defaultServer = "nil";
-  packageToCmd =
-    package: defaultCmd:
-    if isList package then expToLua package else ''{"${package}/bin/${defaultCmd}"}'';
+  packageToCmd = package: defaultCmd:
+    if isList package
+    then expToLua package
+    else ''{"${package}/bin/${defaultCmd}"}'';
   servers = {
     nil = {
       package = inputs.nil.packages.${pkgs.stdenv.system}.nil;
       internalFormatter = true;
       lspConfig = ''lspconfig.nil_ls.setup ${
-        toLuaObject {
-          capabilities = mkLuaInline "capabilities";
-          on_attach = if cfg.format.enable then mkLuaInline "default_on_attach" else "attach_keymaps";
-          cmd = mkLuaInline (packageToCmd cfg.lsp.package "nil");
-          settings.nil = {
-            formatting.command =
-              if cfg.format.enable then
-                if cfg.format.type == "alejandra" then
-                  mkLuaInline ''{"${cfg.format.package}/bin/alejandra", "--quiet"}''
-                else if cfg.format.type == "nixfmt" then
-                  mkLuaInline ''{"${cfg.format.package}/bin/nixfmt"}''
-                else
-                  null
-              else
-                null;
-          } // cfg.lsp.options;
-        }
-      }'';
-      # lspConfig = ''
-      #   lspconfig.nil_ls.setup{
-      #     capabilities = capabilities,
-      #   ${
-      #     if cfg.format.enable
-      #     then useFormat
-      #     else noFormat
-      #   },
-      #     cmd = ${packageToCmd cfg.lsp.package "nil"},
-      #   ${optionalString cfg.format.enable ''
-      #     settings = {
-      #       ["nil"] = {
-      #     ${optionalString (cfg.format.type == "alejandra") ''
-      #       formatting = {
-      #         command = {"${cfg.format.package}/bin/alejandra", "--quiet"},
-      #       },
-      #     ''}
-      #     ${optionalString (cfg.format.type == "nixfmt") ''
-      #       formatting = {
-      #         command = {"${cfg.format.package}/bin/nixfmt"},
-      #       },
-      #     ''}
-      #       nix = ${toLuaObject cfg.lsp.options},
-      #       },
-      #     },
-      #   ''}
-      #   }
-      # '';
+          toLuaObject {
+            capabilities = mkLuaInline "capabilities";
+            on_attach =
+              if cfg.format.enable
+              then mkLuaInline "default_on_attach"
+              else "attach_keymaps";
+            cmd = mkLuaInline (packageToCmd cfg.lsp.package "nil");
+            settings.nil =
+              {
+                formatting.command =
+                  if cfg.format.enable
+                  then
+                    if cfg.format.type == "alejandra"
+                    then mkLuaInline ''{"${cfg.format.package}/bin/alejandra", "--quiet"}''
+                    else if cfg.format.type == "nixfmt"
+                    then mkLuaInline ''{"${cfg.format.package}/bin/nixfmt"}''
+                    else null
+                  else null;
+              }
+              // cfg.lsp.options;
+          }
+        }'';
     };
 
     nixd = {
@@ -94,7 +71,11 @@ let
       lspConfig = ''
         lspconfig.nixd.setup{
           capabilities = capabilities,
-        ${if cfg.format.enable then useFormat else noFormat},
+        ${
+          if cfg.format.enable
+          then useFormat
+          else noFormat
+        },
           cmd = ${packageToCmd cfg.lsp.package "nixd"},
         ${optionalString cfg.format.enable ''
           settings = {
@@ -158,22 +139,25 @@ let
       '';
     };
   };
-in
-{
+in {
   options.vim.languages.nix = {
     enable = mkEnableOption "Nix language support";
 
     treesitter = {
-      enable = mkEnableOption "Nix treesitter" // {
-        default = config.vim.languages.enableTreesitter;
-      };
+      enable =
+        mkEnableOption "Nix treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+        };
       package = mkGrammarOption pkgs "nix";
     };
 
     lsp = {
-      enable = mkEnableOption "Nix LSP support" // {
-        default = config.vim.lsp.enable;
-      };
+      enable =
+        mkEnableOption "Nix LSP support"
+        // {
+          default = config.vim.lsp.enable;
+        };
       server = mkOption {
         description = "Nix LSP server to use";
         type = enum (attrNames servers);
@@ -195,9 +179,11 @@ in
     };
 
     format = {
-      enable = mkEnableOption "Nix formatting" // {
-        default = config.vim.languages.enableFormat;
-      };
+      enable =
+        mkEnableOption "Nix formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+        };
 
       type = mkOption {
         description = "Nix formatter to use";
@@ -213,9 +199,11 @@ in
     };
 
     extraDiagnostics = {
-      enable = mkEnableOption "extra Nix diagnostics" // {
-        default = config.vim.languages.enableExtraDiagnostics;
-      };
+      enable =
+        mkEnableOption "extra Nix diagnostics"
+        // {
+          default = config.vim.languages.enableExtraDiagnostics;
+        };
 
       types = diagnostics {
         langDesc = "Nix";
@@ -247,7 +235,7 @@ in
 
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
-      vim.treesitter.grammars = [ cfg.treesitter.package ];
+      vim.treesitter.grammars = [cfg.treesitter.package];
     })
 
     (mkIf cfg.lsp.enable {
@@ -258,7 +246,7 @@ in
     (mkIf (cfg.format.enable && (!cfg.lsp.enable || !servers.${cfg.lsp.server}.internalFormatter)) {
       vim.formatter.conform-nvim = {
         enable = true;
-        setupOpts.formatters_by_ft.nix = [ cfg.format.type ];
+        setupOpts.formatters_by_ft.nix = [cfg.format.type];
         setupOpts.formatters.${cfg.format.type} = {
           command = getExe cfg.format.package;
         };
@@ -272,7 +260,8 @@ in
         linters = mkMerge (
           map (name: {
             ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          }) cfg.extraDiagnostics.types
+          })
+          cfg.extraDiagnostics.types
         );
       };
     })


### PR DESCRIPTION
I got fed up with being asked whether I want to "fetch inputs" every time I open a nix file so I added the logic to configure nil_ls via `languages.nix.lsp.options` the same way that nixd is configured. I'm somewhat new to nix so if the code doesn't have the quality you'd like it to have tell me so I can try fixing it myself. You might see some more changes than needed because I have my nvf set up in a way to auto format files on save and I use nixfmt so it might have gotten messed up in some of the commits. I made sure to check that it's formatted with alejandra in the last commit tho.

I hope this helps! Thanks for reading!