### PR TITLE
doc: fix un-buildable example code in pure-lua-config section

### DIFF
--- a/docs/manual/tips/pure-lua-config.md
+++ b/docs/manual/tips/pure-lua-config.md
@@ -23,7 +23,7 @@ manner.
   # flake.nix. For the sake of the argument, we will assume that the Neovim lua
   # configuration is in a nvim/ directory relative to flake.nix.
   vim = {
-    additionalRuntimeDirectories = [
+    additionalRuntimePaths = [
       # This will be added to Neovim's runtime paths. Conceptually, this behaves
       # very similarly to ~/.config/nvim but you may not place a top-level
       # init.lua to be able to require it directly.
@@ -41,7 +41,7 @@ directory, and call it with [](#opt-vim.luaConfigRC).
 ```nix
 {pkgs, ...}: {
   vim = {
-    additionalRuntimeDirectories = [
+    additionalRuntimePaths = [
       # You can list more than one file here.
       ./nvim-custom-1
 


### PR DESCRIPTION
The example code in the [Pure Lua Configuration](https://notashelf.github.io/nvf/index.xhtml#sec-pure-lua-config)/[Pure Runtime Directory](https://notashelf.github.io/nvf/index.xhtml#sec-pure-nvf-runtime) section references the `vim.additionalRuntimeDirectories` option, which does not exist. The correct option is `vim.additionalRuntimePaths` (as seen in the [source](https://github.com/NotAShelf/nvf/blob/5bad5dd94ce5ea3b40b08d9e6802e69d02198d21/modules/wrapper/rc/options.nix#L31) and [docs](https://notashelf.github.io/nvf/options.html#opt-vim.additionalRuntimePaths)).

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc