### PR TITLE
lualine: fix separator options to work with recent versions of lualine

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -439,3 +439,4 @@
 - Add [smart-splits.nvim] for navigating between Neovim windows and terminal multiplexer panes.
   Available at `vim.utility.smart-splits`.
 
+- Fix lualine separator options

--- a/modules/plugins/statusline/lualine/config.nix
+++ b/modules/plugins/statusline/lualine/config.nix
@@ -63,8 +63,8 @@ in {
           options = {
             icons_enabled = mkDefault cfg.icons.enable;
             theme = mkDefault cfg.theme;
-            component_separators = mkDefault [cfg.componentSeparator.left cfg.componentSeparator.right];
-            section_separators = mkDefault [cfg.sectionSeparator.left cfg.sectionSeparator.right];
+            component_separators = mkDefault cfg.componentSeparator;
+            section_separators = mkDefault cfg.sectionSeparator;
             globalstatus = mkDefault cfg.globalStatus;
             refresh = mkDefault cfg.refresh;
             always_divide_middle = mkDefault cfg.alwaysDivideMiddle;


### PR DESCRIPTION
The configuration generated for lualine separators used a [deprecated format](https://github.com/nvim-lualine/lualine.nvim/commit/2f801ed6221abfb00f74e34c35ccd4d1153c2b07). This change updates it.

It's already possible to override the options in `config.vim.statusline.lualine.setupOpts` which is a good workaround, but I figured the dedicated `componentSeparator` and `sectionSeparator` options don't make too much sense if they don't work.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
