### PR TITLE
git/neogit: module init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -162,6 +162,7 @@ isMaximal: {
       enable = true;
       gitsigns.enable = true;
       gitsigns.codeActions.enable = false; # throws an annoying debug message
+      neogit.enable = isMaximal;
     };
 
     minimap = {

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -433,9 +433,9 @@
 
 [solarized.nvim]: https://github.com/maxmx03/solarized.nvim
 [smart-splits.nvim]: https://github.com/mrjones2014/smart-splits.nvim
+[neogit]: https://github.com/NeogitOrg/neogit
 
 - Add [solarized.nvim] theme with support for multiple variants
-
 - Add [smart-splits.nvim] for navigating between Neovim windows and terminal multiplexer panes.
   Available at `vim.utility.smart-splits`.
-
+- Add [neogit], an interactive and powerful Git interface for Neovim, inspired by Magit

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -24,6 +24,10 @@
   module interface. You may set [](#opt-vim.clipboard.registers) appropriately
   to configure Neovim to use the system clipboard.
 
+- Changed which-key group used for gitsigns from `<leader>g` to `<leader>h` to
+  align with the "hunks" themed mapping and avoid conflict with the new [neogit]
+  group.
+
 [NotAShelf](https://github.com/notashelf):
 
 [typst-preview.nvim]: https://github.com/chomosuke/typst-preview.nvim

--- a/modules/plugins/git/default.nix
+++ b/modules/plugins/git/default.nix
@@ -6,6 +6,7 @@ in {
     ./vim-fugitive
     ./git-conflict
     ./gitlinker-nvim
+    ./neogit
   ];
 
   options.vim.git = {

--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -69,7 +69,7 @@ in {
         };
 
         binds.whichKey.register = pushDownDefault {
-          "<leader>g" = "+Gitsigns";
+          "<leader>h" = "+Gitsigns";
         };
 
         pluginRC.gitsigns = entryAnywhere ''

--- a/modules/plugins/git/neogit/config.nix
+++ b/modules/plugins/git/neogit/config.nix
@@ -1,0 +1,39 @@
+{
+  options,
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.binds) pushDownDefault mkKeymap;
+
+  cfg = config.vim.git.neogit;
+
+  keys = cfg.mappings;
+  inherit (options.vim.git.neogit) mappings;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["plenary-nvim"];
+
+      lazy.plugins.neogit = {
+        package = "neogit";
+        setupModule = "neogit";
+        inherit (cfg) setupOpts;
+
+        cmd = ["Neogit"];
+
+        keys = [
+          (mkKeymap "n" keys.open "<Cmd>Neogit<CR>" {desc = mappings.open.description;})
+          (mkKeymap "n" keys.commit "<Cmd>Neogit commit<CR>" {desc = mappings.commit.description;})
+          (mkKeymap "n" keys.pull "<Cmd>Neogit pull<CR>" {desc = mappings.pull.description;})
+          (mkKeymap "n" keys.push "<Cmd>Neogit push<CR>" {desc = mappings.push.description;})
+        ];
+      };
+
+      binds.whichKey.register = pushDownDefault {
+        "<leader>g" = "+Git";
+      };
+    };
+  };
+}

--- a/modules/plugins/git/neogit/default.nix
+++ b/modules/plugins/git/neogit/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./neogit.nix
+  ];
+}

--- a/modules/plugins/git/neogit/neogit.nix
+++ b/modules/plugins/git/neogit/neogit.nix
@@ -1,0 +1,17 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.binds) mkMappingOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.git.neogit = {
+    enable = mkEnableOption "An Interactive and powerful Git interface [Neogit]";
+    setupOpts = mkPluginSetupOption "neogit" {};
+
+    mappings = {
+      open = mkMappingOption "Git Status [Neogit]" "<leader>gs";
+      commit = mkMappingOption "Git Commit [Neogit]" "<leader>gc";
+      pull = mkMappingOption "Git pull [Neogit]" "<leader>gp";
+      push = mkMappingOption "Git push [Neogit]" "<leader>gP";
+    };
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1530,6 +1530,22 @@
       "url": "https://github.com/IogaMaster/neocord/archive/2ebf3792a8100376bb65fd66d5dbf60f50af7529.tar.gz",
       "hash": "1ycx26ppfb5djxji1mwamr7ra29z8sm0fs9a6hhwn0l69x06x353"
     },
+    "neogit": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "NeogitOrg",
+        "repo": "neogit"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v2.0.0",
+      "revision": "7f97dbfc5af3b898c6660d927c23e3a96a5bd069",
+      "url": "https://api.github.com/repos/NeogitOrg/neogit/tarball/v2.0.0",
+      "hash": "0nyv64ai3765if7bdfyx01a0xmsmhm8cjvxyvh2s40bzvkx8xy17"
+    },
     "neorg": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
This adds [Neogit](https://github.com/NeogitOrg/neogit), an interactive and powerful Git interface for Neovim, inspired by Magit.

It also changes the which-key group for gitsigns to `<leader>h` since its mappings were mostly under that prefix anyway and `<leader>g` makes sense to use for Neogit.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [x] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
