### PR TITLE
doc: fix appendix link in ch-configuring section

### DIFF
--- a/docs/manual/configuring.md
+++ b/docs/manual/configuring.md
@@ -8,7 +8,7 @@ your convenience. You might also be interested in the [helpful tips section] for
 more advanced or unusual configuration options supported by nvf.
 
 Note that this section does not cover module _options_. For an overview of all
-module options provided by nvf, please visit the [appendix](/options.html)
+module options provided by nvf, please visit the [appendix](/nvf/options.html)
 
 ```{=include=} chapters
 configuring/custom-package.md


### PR DESCRIPTION
previous relative link pointed to `nvf/options.html` on the repo instead of GH pages, causing 404

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.