### PR TITLE
flake: follow flake-parts and flake-utils inputs

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -446,3 +446,13 @@
 - Fix lualine separator options
 - Add [neogit], an interactive and powerful Git interface for Neovim, inspired by Magit
 - Allow deregistering which-key binds or groups by setting them to `null`
+
+[trueNAHO](https://github.com/trueNAHO):
+
+- `flake-parts`'s `nixpkgs-lib` input follows nvf's `nixpkgs` input to reduce
+  download size.
+
+- `flake-utils`'s `systems` inputs follows nvf's `systems` input to transitively
+  leverage the pattern introduced in commit [fc8206e7a61d ("flake: utilize
+  nix-systems for overridable flake systems")](
+  https://github.com/NotAShelf/nvf/commit/fc8206e7a61d7eb02006f9010e62ebdb3336d0d2).

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1749398372,
@@ -20,7 +22,9 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -67,46 +71,16 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "mnw": "mnw",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_2"
+        "systems": "systems"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -76,8 +76,17 @@
   inputs = {
     ## Basic Inputs
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.systems.follows = "systems";
+    };
+
     systems.url = "github:nix-systems/default";
 
     # Alternate neovim-wrapper


### PR DESCRIPTION
```
flake-parts's nixpkgs-lib input follows nvf's nixpkgs input to reduce
download size, and flake-utils's systems inputs follows nvf's systems
input to transitively leverage the pattern introduced in commit
fc8206e7a61d ("flake: utilize nix-systems for overridable flake
systems").
```

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
    - **As a non-nvf user, my testing does not go beyond running `nix build .#{docs-html,docs-linkcheck,maximal,nix}` with the following temporary patch to avoid compiling `deno` from source:**

    ```diff
    diff --git a/modules/plugins/languages/markdown.nix b/modules/plugins/languages/markdown.nix
    index 23848835..e6337b5b 100644
    --- a/modules/plugins/languages/markdown.nix
    +++ b/modules/plugins/languages/markdown.nix
    @@ -37,10 +37,10 @@
       formats = {
         # for backwards compatibility
         denofmt = {
    -      package = pkgs.deno;
    +      package = pkgs.hello;
         };
         deno_fmt = {
    -      package = pkgs.deno;
    +      package = pkgs.hello;
         };
         prettierd = {
           package = pkgs.prettierd;
    diff --git a/modules/plugins/languages/ts.nix b/modules/plugins/languages/ts.nix
    index 6064da98..95af56b1 100644
    --- a/modules/plugins/languages/ts.nix
    +++ b/modules/plugins/languages/ts.nix
    @@ -37,7 +37,7 @@
         };

         denols = {
    -      package = pkgs.deno;
    +      package = pkgs.hello;
           lspConfig = ''
             vim.g.markdown_fenced_languages = { "ts=typescript" }
             lspconfig.denols.setup {
    ```
- [X] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`)
  - [X] My code conforms to the [editorconfig] configuration of the project
  - [X] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [X] `.#nix` _(default package)_
  - [X] `.#maximal`
  - [X] `.#docs-html` _(manual, must build)_
  - [X] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
