### PR TITLE
otter: remove deprecated setting

### DIFF
--- a/modules/plugins/lsp/otter/otter.nix
+++ b/modules/plugins/lsp/otter/otter.nix
@@ -25,15 +25,6 @@ in {
           };
         };
         buffers = {
-          set_filetype = mkOption {
-            type = bool;
-            default = false;
-            description = ''
-              if set to true, the filetype of the otterbuffers will be set. Other wide only
-              the autocommand of lspconfig that attaches the language server will be
-              executed without setting the filetype
-            '';
-          };
           write_to_disk = mkOption {
             type = bool;
             default = false;


### PR DESCRIPTION
otter deprecated the set_filetype setting, making `set_filetype = true` the default (and only) behavior. Right now it gives a warning, but the setting will be removed in the next release of otter

(also, the PR template totally isn't working anymore, not sure what Github did)

(not tested yet becuase it's taking ages to build maximal rn and it's super late, but there's no reason why it should break. Will check back in the morning to test)