### PR TITLE
treewide: `vim.loop` -> `vim.uv`

### DIFF
--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -106,7 +106,7 @@ in {
           -- Disable slow treesitter highlight for large files
           function(lang, buf)
             local max_filesize = 1000 * 1024 -- 1MB
-            local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+            local ok, stats = pcall(vim.uv.fs_stat, vim.api.nvim_buf_get_name(buf))
             if ok and stats and stats.size > max_filesize then
                 return true
             end

--- a/modules/plugins/utility/harpoon/harpoon.nix
+++ b/modules/plugins/utility/harpoon/harpoon.nix
@@ -39,7 +39,7 @@ in {
           type = luaInline;
           default = mkLuaInline ''
             function()
-              return vim.loop.cwd()
+              return vim.uv.cwd()
             end
           '';
           description = ''


### PR DESCRIPTION
As per suggestion of `:h vim.loop`, "Use `vim.uv` instead."