### PR TITLE
meta: add flake-compat & expose flakeless interface

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+(import (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      inherit (lock.nodes.flake-compat.locked) url rev narHash;
+    in
+      builtins.fetchTarball {
+        url = "${url}/archive/${rev}.tar.gz";
+        sha256 = narHash;
+      }
+  ) {
+    src = ./.;
+    copySourceTreeToStore = false;
+    useBuiltinsFetchTree = true;
+  })
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1751685974,
+        "narHash": "sha256-NKw96t+BgHIYzHUjkTK95FqYRVKB8DHpVhefWSz/kTw=",
+        "ref": "refs/heads/main",
+        "rev": "549f2762aebeff29a2e5ece7a7dc0f955281a1d1",
+        "revCount": 92,
+        "type": "git",
+        "url": "https://git.lix.systems/lix-project/flake-compat.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://git.lix.systems/lix-project/flake-compat.git"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -73,6 +89,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "flake-utils": "flake-utils",
         "mnw": "mnw",

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+# Make the behaviour of `nix-shell` consistent with the one of `nix develop`
+# by returning the default devShell output from the flake. This is useful when
+# I do not want to work with direnv, or simply need backwards compatibility.
+{system ? builtins.currentSystem}: let
+  nvf = import ./.;
+in
+  nvf.devShells.${system}.default


### PR DESCRIPTION
This PR adds a flake-less interface for Nix2 users, consumable without using flake inputs. It uses Lix's flake-compat implementation for a slightly faster store copy (benchmarked by eyeballing the difference in speed, trust me on this :pray:) and replaces the current formattere output with a treewide wrappere for compat with newer Nix versions.

CC @horriblename and @Soliprem for testing. I'll add usage documentation before merge.

Adresses #965 