### PR TITLE
fix(blink-cmp): Fix broken default sources

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -486,3 +486,9 @@
 
 - Add [nvim-biscuits] to show block context. Available at
   `vim.utility.nvim-biscuits`.
+
+[JManch](https://github.com/JManch):
+
+- Fix default [blink.cmp] sources "path" and "buffer" not working when
+  `autocomplete.nvim-cmp.enable` was disabled and
+  `autocomplete.nvim-cmp.sources` had not been modified.

--- a/modules/plugins/completion/blink-cmp/config.nix
+++ b/modules/plugins/completion/blink-cmp/config.nix
@@ -5,11 +5,12 @@
 }: let
   inherit (lib.modules) mkIf;
   inherit (lib.strings) optionalString;
+  inherit (lib.attrsets) optionalAttrs;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.attrsets) attrValues filterAttrs mapAttrsToList;
-  inherit (lib.lists) map optional elem;
+  inherit (lib.lists) map optional optionals elem;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (builtins) concatStringsSep typeOf tryEval attrNames mapAttrs;
+  inherit (builtins) concatStringsSep typeOf tryEval attrNames mapAttrs removeAttrs;
 
   cfg = config.vim.autocomplete.blink-cmp;
   cmpCfg = config.vim.autocomplete.nvim-cmp;
@@ -55,7 +56,7 @@ in {
         after =
           # lua
           ''
-            ${optionalString config.vim.lazy.enable
+            ${optionalString (config.vim.lazy.enable && cmpCfg.enable)
               (concatStringsSep "\n" (map
                 (package: "require('lz.n').trigger_load(${toLuaObject (getPluginName package)})")
                 cmpCfg.sourcePlugins))}
@@ -66,7 +67,10 @@ in {
     autocomplete = {
       enableSharedCmpSources = true;
       blink-cmp.setupOpts = {
-        sources = {
+        sources = let
+          # We do not want nvim-cmp compat sources overriding built-in blink sources
+          filteredCmpSources = removeAttrs cmpCfg.sources blinkBuiltins;
+        in {
           default =
             [
               "lsp"
@@ -74,14 +78,16 @@ in {
               "snippets"
               "buffer"
             ]
-            ++ (attrNames cmpCfg.sources)
+            ++ optionals cmpCfg.enable (attrNames filteredCmpSources)
             ++ (attrNames enabledBlinkSources);
           providers =
-            mapAttrs (name: _: {
-              inherit name;
-              module = "blink.compat.source";
-            })
-            cmpCfg.sources
+            optionalAttrs cmpCfg.enable (
+              mapAttrs (name: _: {
+                inherit name;
+                module = "blink.compat.source";
+              })
+              filteredCmpSources
+            )
             // (mapAttrs (name: definition: {
                 inherit name;
                 inherit (definition) module;


### PR DESCRIPTION
Currently, regardless of whether nvim-cmp is enabled, nvim-cmp's sources are added as providers. If the nvim-cmp sources "buffer" or "path" are enabled they will override and break blink.cmp's default "path" and "buffer" sources.

This fixes the issue by only configuring nvim-cmp sources and providers when nvim-cmp is enabled and, if nvim-cmp is enabled, only configuring nvim-cmp compat providers that are not in the blink.cmp default sources.

The maximal config was not affected because both `languages.rust.crates.enable = true` and `snippets.luasnip.enable = true` set `autocomplete.nvim-cmp.sources`, overriding the default value of `{ nvim-cmp = null; buffer = "[Buffer]"; path = "[Path]"; }`.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
