### PR TITLE
languages/elixir: add HEEx and EEx treesitter grammars

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -495,5 +495,5 @@
 
 [Morsicus](https://github.com/Morsicus):
 
-- add [EEx Treesitter Grammar](https://github.com/connorlay/tree-sitter-eex) for Elixir
-- add [HEEx Treesitter Grammar](https://github.com/phoenixframework/tree-sitter-heex) for Elixir
+- Add [EEx Treesitter Grammar](https://github.com/connorlay/tree-sitter-eex) for Elixir
+- Add [HEEx Treesitter Grammar](https://github.com/phoenixframework/tree-sitter-heex) for Elixir

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -492,3 +492,8 @@
 - Fix default [blink.cmp] sources "path" and "buffer" not working when
   `autocomplete.nvim-cmp.enable` was disabled and
   `autocomplete.nvim-cmp.sources` had not been modified.
+
+[Morsicus](https://github.com/Morsicus):
+
+- add [EEx Treesitter Grammar](https://github.com/connorlay/tree-sitter-eex) for Elixir
+- add [HEEx Treesitter Grammar](https://github.com/phoenixframework/tree-sitter-heex) for Elixir

--- a/modules/plugins/languages/elixir.nix
+++ b/modules/plugins/languages/elixir.nix
@@ -50,6 +50,8 @@ in {
     treesitter = {
       enable = mkEnableOption "Elixir treesitter" // {default = config.vim.languages.enableTreesitter;};
       package = mkGrammarOption pkgs "elixir";
+      heexPackage = mkGrammarOption pkgs "heex";
+      eexPackage = mkGrammarOption pkgs "eex";
     };
 
     lsp = {
@@ -93,7 +95,11 @@ in {
   config = mkIf cfg.enable (mkMerge [
     (mkIf cfg.treesitter.enable {
       vim.treesitter.enable = true;
-      vim.treesitter.grammars = [cfg.treesitter.package];
+      vim.treesitter.grammars = [
+        cfg.treesitter.package
+        cfg.treesitter.heexPackage
+        cfg.treesitter.eexPackage
+      ];
     })
 
     (mkIf cfg.lsp.enable {


### PR DESCRIPTION
Hello,

I needed HEEx treesitter grammar for Elixir and I saw [this comment](https://github.com/NotAShelf/nvf/issues/137#issuecomment-2579360082) proposing also to add EEx.

I took the opportunity to add both of them.

I tested my PR and both grammars are installed and working.

Please do not hesitate to tell me if I forgot something.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
