### PR TITLE
languages/python: add formatter that combines `ruff format` with `ruff check --fix`

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -522,15 +522,6 @@
 
 - Fixed `typescript` treesitter grammar not being included by default.
 
-- Add [nvim-biscuits] to show block context. Available at
-  `vim.utility.nvim-biscuits`.
-
-[JManch](https://github.com/JManch):
-
-- Fix default [blink.cmp] sources "path" and "buffer" not working when
-  `autocomplete.nvim-cmp.enable` was disabled and
-  `autocomplete.nvim-cmp.sources` had not been modified.
-
 [valterschutz](https://github.com/valterschutz):
 
 [ruff]: (https://github.com/astral-sh/ruff)

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -522,3 +522,17 @@
 
 - Fixed `typescript` treesitter grammar not being included by default.
 
+- Add [nvim-biscuits] to show block context. Available at
+  `vim.utility.nvim-biscuits`.
+
+[JManch](https://github.com/JManch):
+
+- Fix default [blink.cmp] sources "path" and "buffer" not working when
+  `autocomplete.nvim-cmp.enable` was disabled and
+  `autocomplete.nvim-cmp.sources` had not been modified.
+
+[valterschutz](https://github.com/valterschutz):
+
+[ruff]: (https://github.com/astral-sh/ruff)
+
+- Add [ruff-fix] as a formatter option in `vim.languages.python.format.type`.

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -149,6 +149,16 @@
         '';
       };
     };
+
+    ruff-check = {
+      package = pkgs.writeShellApplication {
+        name = "ruff-check";
+        runtimeInputs = [pkgs.ruff];
+        text = ''
+          ruff check --fix --exit-zero -
+        '';
+      };
+    };
   };
 
   defaultDebugger = "debugpy";


### PR DESCRIPTION
`ruff check --fix` also formats python files, removing unused imports for example. I want an option that uses both `ruff format` and `ruff check --fix`.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
- [X] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [X] I ran **Alejandra** to format my code (`nix fmt`)
  - [X] My code conforms to the [editorconfig] configuration of the project
  - [X] My changes are consistent with the rest of the codebase
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [X] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc