### PR TITLE
binds/qmk: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -158,6 +158,7 @@ isMaximal: {
       whichKey.enable = true;
       cheatsheet.enable = true;
       hardtime-nvim.enable = isMaximal;
+      qmk.enable = false; # requires hardware specific options
     };
 
     telescope.enable = true;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -480,9 +480,12 @@
 [roslyn-ls]: https://github.com/dotnet/vscode-csharp
 [jsonls]: https://github.com/microsoft/vscode/tree/1.101.2/extensions/json-language-features/server
 [jsonfmt]: https://github.com/caarlos0/jsonfmt
+[qmk]: https://github.com/codethread/qmk.nvim
 
 - Add just support under `vim.languages.just` using [just-lsp].
 
 - Add [roslyn-ls] to the `vim.languages.csharp` module.
 
 - Added json support under `vim.languages.json` using [jsonls] and [jsonfmt].
+
+- Add [qmk] plugin in `vim.binds.qmk` with `enable` and `setupOpts`.

--- a/modules/plugins/utility/binds/default.nix
+++ b/modules/plugins/utility/binds/default.nix
@@ -3,5 +3,6 @@ _: {
     ./which-key
     ./cheatsheet
     ./hardtime
+    ./qmk
   ];
 }

--- a/modules/plugins/utility/binds/qmk/config.nix
+++ b/modules/plugins/utility/binds/qmk/config.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.dag) entryAfter;
+
+  cfg = config.vim.binds.qmk;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["qmk-nvim"];
+
+      pluginRC.qmk-nvim = entryAfter ["nvim-notify"] ''
+        require('qmk').setup(${toLuaObject cfg.setupOpts})
+      '';
+    };
+
+    assertions = [{
+      assertion = !(cfg.setupOpts.variant == "zmk") && !(cfg.setupOpts.comment_preview.position == "inside");
+      message = "comment_preview.position can only be set to inside when using the qmk layoyt";
+    }];
+  };
+}

--- a/modules/plugins/utility/binds/qmk/default.nix
+++ b/modules/plugins/utility/binds/qmk/default.nix
@@ -1,0 +1,6 @@
+{...}: {
+  imports = [
+    ./config.nix
+    ./qmk.nix
+  ];
+}

--- a/modules/plugins/utility/binds/qmk/qmk.nix
+++ b/modules/plugins/utility/binds/qmk/qmk.nix
@@ -1,0 +1,51 @@
+{ 
+  config, 
+  lib, 
+  ... 
+}: let
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) attrsOf enum lines str;  
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.binds.qmk = {
+    enable = mkEnableOption "QMK and ZMK keymaps in nvim";
+
+    setupOpts = mkPluginSetupOption "qmk.nvim" {
+      name = mkOption {
+        type = str;
+        description = "The name of the layout";
+      };
+
+      layout = mkOption {
+        type = lines;
+        description = ''
+          The keyboard key layout 
+          see <https://github.com/codethread/qmk.nvim?tab=readme-ov-file#Layout> for more details
+        '';
+      };
+      
+      variant = mkOption {
+        type = enum ["qmk" "zmk"];
+        default = "qmk";
+        description = "Chooses the expected hardware target";
+      };
+
+      comment_preview = {
+        position = mkOption {
+          type = enum ["top" "bottom" "inside" "none"];
+          default = "top";
+          description = "Controls the position of the preview";
+        };
+
+        keymap_overrides = mkOption {
+          type = attrsOf str;
+          default = {};
+          description = ''
+            Key codes to text replacements
+            see <https://github.com/codethread/qmk.nvim/blob/main/lua/qmk/config/key_map.lua> for more details
+          '';
+        };
+      };
+    };
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2186,6 +2186,19 @@
       "url": "https://github.com/kevinhwang91/promise-async/archive/119e8961014c9bfaf1487bf3c2a393d254f337e2.tar.gz",
       "hash": "0q4a0rmy09hka6zvydzjj2gcm2j5mlbrhbxfcdjj33ngpblkmqzm"
     },
+    "qmk-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "codethread",
+        "repo": "qmk.nvim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "3c804c1480991e4837514900b22b9358cfd64fa1",
+      "url": "https://github.com/codethread/qmk.nvim/archive/3c804c1480991e4837514900b22b9358cfd64fa1.tar.gz",
+      "hash": "03fsx6qsn8b36jp5m0fkdla6gkkzdv2j18y378y3cqpjclgq995a"
+    },
     "rainbow-delimiters-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Create the `vim.binds.qmk` module with `enable` and `setupOpts`.

If I should target a different branch let me know, I'll rebase it and move the release notes.

Fixes #1058 
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
