### PR TITLE
languages/qml: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -89,6 +89,7 @@ isMaximal: {
       ruby.enable = false;
       fsharp.enable = false;
       just.enable = false;
+      qml.enable = false;
 
       tailwind.enable = false;
       svelte.enable = false;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -492,4 +492,4 @@
 - Add advanced HTML support under `vim.languages.html` using [superhtml] and
   [htmlHINT].
 - Add QMK support under `vim.utility.qmk-nvim` via [qmk-nvim].
-- Add QML support under `vim.languages.just` using [qmlls] and [qmlformat]
+- Add QML support under `vim.languages.qml` using [qmlls] and [qmlformat]

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -483,6 +483,8 @@
 [superhtml]: https://github.com/kristoff-it/superhtml
 [htmlHTML]: https://github.com/htmlhint/HTMLHint
 [qmk-nvim]: https://github.com/codethread/qmk.nvim
+[qmlls]: https://doc.qt.io/qt-6/qtqml-tooling-qmlls.html
+[qmlformat]: https://doc.qt.io/qt-6/qtqml-tooling-qmlformat.html
 
 - Add just support under `vim.languages.just` using [just-lsp].
 - Add [roslyn-ls] to the `vim.languages.csharp` module.
@@ -490,3 +492,4 @@
 - Add advanced HTML support under `vim.languages.html` using [superhtml] and
   [htmlHINT].
 - Add QMK support under `vim.utility.qmk-nvim` via [qmk-nvim].
+- Add QML support under `vim.languages.just` using [qmlls] and [qmlformat]

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -30,6 +30,7 @@ in {
     ./ocaml.nix
     ./php.nix
     ./python.nix
+    ./qml.nix
     ./r.nix
     ./rust.nix
     ./scala.nix

--- a/modules/plugins/languages/qml.nix
+++ b/modules/plugins/languages/qml.nix
@@ -1,0 +1,98 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.meta) getExe getExe';
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum package;
+  inherit (lib.nvim.types) mkGrammarOption singleOrListOf;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+
+  cfg = config.vim.languages.qml;
+
+  qmlPackage = pkgs.kdePackages.qtdeclarative;
+
+  defaultServers = ["qmlls"];
+  servers = {
+    qmlls = {
+      cmd = [(getExe' qmlPackage "qmlls")];
+      filetypes = ["qml" "qmljs"];
+      rootmarkers = [".git"];
+    };
+  };
+
+  defaultFormat = "qmlformat";
+  formats = {
+    qmlformat = {
+      package = pkgs.writeShellApplication {
+        name = "qmlformat";
+        runtimeInputs = [qmlPackage];
+        text = "qmlformat -";
+      };
+    };
+  };
+in {
+  options.vim.languages.qml = {
+    enable = mkEnableOption "QML language support";
+    treesitter = {
+      enable = mkEnableOption "QML treesitter support" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "qmljs";
+    };
+
+    lsp = {
+      enable = mkEnableOption "QML LSP support" // {default = config.vim.lsp.enable;};
+      servers = mkOption {
+        type = singleOrListOf (enum (attrNames servers));
+        default = defaultServers;
+        description = "QML LSP server to use";
+      };
+    };
+
+    format = {
+      enable = mkEnableOption "QML formatting" // {default = config.vim.languages.enableFormat;};
+
+      type = mkOption {
+        type = enum (attrNames formats);
+        default = defaultFormat;
+        description = "QML formatter to use";
+      };
+
+      package = mkOption {
+        type = package;
+        default = formats.${cfg.format.type}.package;
+        description = "QML formatter package";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+    (mkIf cfg.lsp.enable {
+      vim.lsp.servers =
+        mapListToAttrs (n: {
+          name = n;
+          value = servers.${n};
+        })
+        cfg.lsp.servers;
+    })
+
+    (mkIf (cfg.format.enable && !cfg.lsp.enable) {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.qml = [cfg.format.type];
+        setupOpts.formatters.${cfg.format.type} = {
+          command = getExe cfg.format.package;
+        };
+      };
+    })
+  ]);
+}


### PR DESCRIPTION
Create the QML language module with treesitting, LSP, and formatting.

Author of #678 is no longer responding; therefore I opened this as a continuation.

- [qmlls](https://doc.qt.io/qt-6/qtqml-tooling-qmlls.html)
- [qmlformat](https://doc.qt.io/qt-6/qtqml-tooling-qmlformat.html)
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
