### PR TITLE
docs: extend configuring section with details on the module system

### DIFF
--- a/docs/manual/configuring.md
+++ b/docs/manual/configuring.md
@@ -1,21 +1,31 @@
 # Configuring nvf {#ch-configuring}
 
+<!-- markdownlint-disable MD051 -->
+
 [helpful tips section]: ./tips.html#ch-helpful-tips
 [options reference]: ./options.html
 
-**nvf** allows for _very_ extensive configuration in Neovim through the Nix
-module interface. The below chapters describe several of the options exposed in
-nvf for your convenience. You might also be interested in the
-[helpful tips section] for more advanced or unusual configuration options
-supported by nvf.
+<!-- markdownlint-enable MD051 -->
 
-Note that this section does not cover module _options_. For an overview of all
-module options provided by nvf, please visit the [options reference]
+nvf allows for _very_ extensive configuration for your Neovim setups through a
+Nix module interface. This interface allows you to express almost everything
+using a single DSL, Nix. The below chapters describe several of the options
+exposed in nvf for your convenience. You might also be interested in the
+[helpful tips section] for more advanced or unusual configuration options
+supported by nvf such as Nix/Lua hybrid setups.
+
+::: {.note}
+
+This section does not cover module _options_. For an overview of all module
+options provided by nvf, please visit the [options reference]
+
+:::
 
 ```{=include=} chapters
 configuring/custom-package.md
 configuring/custom-plugins.md
 configuring/overriding-plugins.md
+configuring/modules.md
 configuring/languages.md
 configuring/keybinds.md
 configuring/dags.md

--- a/docs/manual/configuring.md
+++ b/docs/manual/configuring.md
@@ -32,4 +32,5 @@ configuring/dags.md
 configuring/dag-entries.md
 configuring/autocmds.md
 configuring/queries.md
+configuring/lazy.md
 ```

--- a/docs/manual/configuring/custom-plugins/lazy-method.md
+++ b/docs/manual/configuring/custom-plugins/lazy-method.md
@@ -1,5 +1,10 @@
 # Lazy Method {#sec-lazy-method}
 
+> [!NOTE]
+> This page covers the lazy-loading API for custom plugins. For a full reference
+> of trigger events and the `LazyFile` event, see the
+> [Lazy Loading](#ch-lazy-loading) chapter.
+
 As of version **0.7**, an API is exposed to allow configuring lazy-loaded
 plugins via `lz.n` and `lzn-auto-require`. Below is a comprehensive example of
 how it may be loaded to lazy-load an arbitrary plugin.

--- a/docs/manual/configuring/lazy-loading/lazyfile.md
+++ b/docs/manual/configuring/lazy-loading/lazyfile.md
@@ -1,0 +1,53 @@
+# The LazyFile Event {#sec-lazy-lazyfile}
+
+nvf re-implements the `LazyFile` user event familiar from lazy.nvim. It is a
+synthetic Neovim `User` autocommand event that fires the first time a real file
+is opened: a buffer with an actual file path, not a dashboard, an empty scratch
+buffer, or a terminal.
+
+## When LazyFile Fires {#sec-lazy-lazyfile-when}
+
+`LazyFile` is an alias for the combination of three standard Neovim events:
+
+- `BufReadPost`: an existing file was read into a buffer.
+- `BufNewFile`: a new (not yet saved) file was opened.
+- `BufWritePre`: a buffer is about to be written (catches unsaved new files
+  before the first save).
+
+This means the plugin loads when the user starts editing a file, not at startup
+or on every buffer switch.
+
+## Why Use LazyFile {#sec-lazy-lazyfile-why}
+
+Plugins that only make sense in the context of an open file (LSP clients, indent
+guides, Git signs, diagnostics) are good candidates for `LazyFile` loading.
+Using `BufReadPost` directly would miss new files; using `BufEnter` would
+include dashboard and empty buffers. `LazyFile` covers the common case.
+
+## Example {#sec-lazy-lazyfile-example}
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "gitsigns.nvim" = {
+      package = pkgs.vimPlugins.gitsigns-nvim;
+      setupModule = "gitsigns";
+      setupOpts = {
+        signs = {
+          add = { text = "+"; };
+          change = { text = "~"; };
+          delete = { text = "_"; };
+        };
+      };
+      event = [{ event = "User"; pattern = "LazyFile"; }];
+    };
+  };
+}
+```
+
+With the above configuration, `gitsigns.nvim` is not loaded at startup. It loads
+the first time a file buffer is opened, keeping startup fast for sessions that
+never open a file (e.g. `nvim` alone on the command line). This mechanism is
+regularly used in nvf modules. In case you notice plugins loading slow, it is
+worth experimenting whether the situation improves with lazy loading, and
+potentially upstreaming your optimizations to nvf.

--- a/docs/manual/configuring/lazy-loading/overview.md
+++ b/docs/manual/configuring/lazy-loading/overview.md
@@ -1,0 +1,51 @@
+# Overview {#sec-lazy-overview}
+
+Lazy loading defers plugin initialization until the plugin is actually needed.
+Rather than loading every plugin at startup, nvf (via its `lz.n` backend) loads
+plugins on demand, triggered by commands, events, filetypes, or keymaps. This
+reduces startup time, especially in configurations with many plugins.
+
+## Why Should I LazyLoad? {#sec-why-get-lazy}
+
+Neovim evaluates all sourced Lua and Vimscript at startup. Plugins that register
+autocommands, define highlight groups, or call `require()` unconditionally all
+contribute to startup latency. For frequently opened editors (terminals,
+`git commit`, quick file edits) even a few hundred milliseconds is noticeable.
+Lazy loading moves that cost to the first use of a feature instead of every
+startup.
+
+## lz.n {#sec-lazy-backend}
+
+[lz.n]: https://github.com/lumen-oss/lz.n
+
+nvf uses [lz.n] as its lazy-loading backend. `lz.n` is a minimal, declarative
+lazy loader for Neovim that integrates with Nix-managed plugin paths. Unlike
+runtime package managers, `lz.n` does not download or manage plugins; it only
+controls when they are sourced. This plays nicely with our model of using Nix to
+manage plugins.
+
+## Enabling Lazy Loading {#sec-lazy-enable}
+
+Lazy loading is configured via `vim.lazy.plugins`, which accepts an attribute
+set mapping plugin names to lazy-loading specifications:
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "my-plugin.nvim" = {
+      package = pkgs.vimPlugins.my-plugin-nvim;
+
+      # Mark the plugin as lazy. It will not load at startup.
+      lazy = true;
+
+      # Define at least one trigger to load the plugin.
+      cmd = [ "MyPluginCommand" ];
+    };
+  };
+}
+```
+
+If no trigger (`cmd`, `event`, `keys`, `ft`) is specified alongside
+`lazy =
+true`, the plugin will never be automatically loaded. You must call
+`require("lz.n").load("my-plugin.nvim")` manually or define a trigger.

--- a/docs/manual/configuring/lazy-loading/trigger-events.md
+++ b/docs/manual/configuring/lazy-loading/trigger-events.md
@@ -1,0 +1,107 @@
+# Trigger Events {#sec-lazy-triggers}
+
+nvf exposes four trigger mechanisms that tell `lz.n` when to load a lazy plugin.
+Multiple triggers may be combined on the same plugin entry; the plugin loads on
+whichever fires first.
+
+## cmd {#sec-lazy-trigger-cmd}
+
+Load the plugin the first time one of the listed Ex commands is invoked.
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "aerial.nvim" = {
+      package = pkgs.vimPlugins.aerial-nvim;
+      setupModule = "aerial";
+      cmd = [ "AerialOpen" "AerialToggle" "AerialNavOpen" ];
+    };
+  };
+}
+```
+
+The commands are registered as stubs at startup. When you run `:AerialOpen`, the
+plugin loads and the real command executes.
+
+## event {#sec-lazy-trigger-event}
+
+Load the plugin when a Neovim autocommand event fires. Values are strings naming
+standard Neovim events (`"BufEnter"`, `"InsertEnter"`, etc.) or structured
+records with `event` and optional `pattern` fields.
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "indent-blankline.nvim" = {
+      package = pkgs.vimPlugins.indent-blankline-nvim;
+      setupModule = "ibl";
+      event = [ "BufReadPost" "BufNewFile" ];
+    };
+  };
+}
+```
+
+Using a structured record for pattern matching:
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "my-plugin.nvim" = {
+      package = pkgs.vimPlugins.my-plugin-nvim;
+      event = [
+        { event = "BufReadPost"; pattern = "*.rs"; }
+      ];
+    };
+  };
+}
+```
+
+## keys {#sec-lazy-trigger-keys}
+
+Load the plugin the first time a defined keybinding is pressed. Each entry is a
+record with at minimum a `key` field.
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "aerial.nvim" = {
+      package = pkgs.vimPlugins.aerial-nvim;
+      setupModule = "aerial";
+      keys = [
+        {
+          key = "<leader>a";
+          action = ":AerialToggle<CR>";
+          desc = "Toggle Aerial symbol outline";
+        }
+        {
+          key = "<leader>A";
+          action = ":AerialNavOpen<CR>";
+          desc = "Open Aerial navigation";
+        }
+      ];
+    };
+  };
+}
+```
+
+The keymaps are registered as pass-through stubs at startup. The first press
+loads the plugin and re-fires the key.
+
+## ft {#sec-lazy-trigger-ft}
+
+Load the plugin when a buffer with a matching filetype is opened.
+
+```nix
+{
+  config.vim.lazy.plugins = {
+    "rust-tools.nvim" = {
+      package = pkgs.vimPlugins.rust-tools-nvim;
+      setupModule = "rust-tools";
+      ft = [ "rust" ];
+    };
+  };
+}
+```
+
+This is equivalent to listening on `FileType` events filtered by the listed
+filetype names.

--- a/docs/manual/configuring/lazy.md
+++ b/docs/manual/configuring/lazy.md
@@ -1,0 +1,7 @@
+# Lazy Loading {#ch-lazy-loading}
+
+```{=include=} chapters
+lazy-loading/overview.md
+lazy-loading/trigger-events.md
+lazy-loading/lazyfile.md
+```

--- a/docs/manual/configuring/modules.md
+++ b/docs/manual/configuring/modules.md
@@ -1,0 +1,58 @@
+## Using the Module Interface {#ch-module-interface}
+
+Before describing the module interface, it is worth noting that NVF is a hybrid
+wrapper. It does not lock you into one of Lua or Nix, and both languages are
+considered first-class citizens for configuring your editor. However, Nix is the
+primarily supported language for NVF. While [DAGs](#ch-using-dags) allow for the
+surgical insertion of Lua code into your configuration, in most cases you will
+be more interested in using or extending the Nix-based module system.
+
+### {#ch-using-modules}
+
+Up until v0.6, most modules exposed all supported plugin options as individual
+module options. With the release of v0.6, almost every module has been converted
+to a new `setupOpts` format that provides complete user freedom over a plugin's
+`setup({})` function.
+
+The anatomy of a typical **plugin** module consists of two primary options:
+
+`vim.<category>.<plugin>.enable` and `vim.<category>.<plugin>.setupOpts`. The
+first option is disabled by default, and dictates whether the plugin is enabled.
+If set to `true`, the plugin will be enabled and added to your Neovim's runtime
+path. The second is an attribute set (`{}`) that will be converted to the
+plugin's setup table. From Lua-based setups you may be used to something like
+this:
+
+```lua
+require("nvim-autopairs").setup({
+  check_ts = true,
+  disable_filetype = { "TelescopePrompt", "vim" }
+})
+```
+
+This is the typical setup table. It is sometimes expressed slightly differently
+(e.g., the table might be stored as a variable) but the gist is that you pass a
+table to the `setup()` function. The principle of `setupOpts` is the same. It
+converts a Nix attribute set to a Lua table using the `toLuaObject` function
+located in nvf's extended library. The same configuration would be expressed in
+Nix as follows:
+
+```nix
+{
+  setupOpts = {
+    check_ts = true; # boolean
+    disable_filetype = ["TelescopePrompt" "vim"]; # Lua table
+  };
+}
+```
+
+<!-- markdownlint-disable MD051 MD059 -->
+
+The `setupOpts` option is freeform, so anything you put in it will be converted
+to its Lua equivalent and will appear in your built `init.lua`. You can find
+details about `toLuaObject` [here](#sec-details-of-toluaobject). The top-level
+DAG entries in **nvf** are documented in the [DAG entries](#ch-dag-entries)
+section. You can read more about DAGs in the [using DAGs](#ch-using-dags)
+section.
+
+<!-- markdownlint-enable MD051 MD059 -->

--- a/docs/manual/hacking.md
+++ b/docs/manual/hacking.md
@@ -622,15 +622,33 @@ own fields!
 
 ### Details of `toLuaObject` {#sec-details-of-toluaobject}
 
-As you've seen above, `toLuaObject` is used to convert our nix attrSet
-`cfg.setupOpts`, into a lua table. Here are some rules of the conversion:
+As you've seen above, `toLuaObject` is used to convert our `cfg.setupOpts`, a
+Nix attribute set, into Lua tables across the codebase. Here are some rules of
+the conversion:
 
-1. Nix `null` converts to lua `nil`
-2. Number and strings convert to their lua counterparts
+1. Nix `null` converts to Lua `nil`
+   - `foo = null;` -> `foo = nil`
+2. Number and strings convert to their Lua counterparts
 3. Nix attribute sets (`{}`) and lists (`[]`) convert into Lua dictionaries and
    tables respectively. Here is an example of Nix -> Lua conversion.
    - `{foo = "bar"}` -> `{["foo"] = "bar"}`
    - `["foo" "bar"]` -> `{"foo", "bar"}`
+   - You may also write **mixed tables** using `toLuaObject`, using a special
+     syntax to describe a key's position in the table. Let's say you want to get
+     something like `{"foo", bar = "baz"}` expressed in Lua using Nix. The
+     appropriate Nix syntax to express mixed tables is as follows:
+
+     ```nix
+     # Notice the position indicator, "@1"
+     { "@1" = "foo"; bar = "baz"; };
+     ```
+
+     This will result in a mixed Lua table that is as follows:
+
+     ```lua
+     {"foo", bar = "baz"}
+     ```
+
 4. You can write raw Lua code using `lib.generators.mkLuaInline`. This function
    is part of nixpkgs, and is accessible without relying on **nvf**'s extended
    library.

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -113,3 +113,7 @@ appropriate modules for NixOS and Home Manager as described in the
 installation/custom-configuration.md
 installation/modules.md
 ```
+
+```{=include=} chapters
+lib.md
+```

--- a/docs/manual/lib.md
+++ b/docs/manual/lib.md
@@ -1,0 +1,80 @@
+# Extended Library {#ch-lib}
+
+nvf exposes utility functions under `inputs.nvf.lib` that are used internally
+and available for use in your own flake modules.
+
+## Accessing the Library {#sec-lib-access}
+
+Two entry points are available:
+
+- **`inputs.nvf.lib.nvim`**: the nvf utility library, containing all
+  sub-namespaces described below.
+- **`inputs.nvf.lib.neovimConfiguration`**: the main function for building a
+  standalone Neovim derivation from a set of nvf modules (see
+  [installation](#ch-installation)).
+
+Example usage in a flake:
+
+```nix
+{
+  inputs.nvf.url = "github:notashelf/nvf";
+
+  outputs = { nvf, ... }: {
+    packages.x86_64-linux.neovim =
+      (nvf.lib.neovimConfiguration {
+        pkgs = import nixpkgs { system = "x86_64-linux"; };
+        modules = [ ./nvf-config.nix ];
+      }).neovim;
+  };
+}
+```
+
+## Sub-namespaces {#sec-lib-namespaces}
+
+### `lib.nvim.dag` {#sec-lib-dag}
+
+DAG utilities for ordering configuration sections. Provides `entryAnywhere`,
+`entryAfter`, `entryBefore`, `entryBetween`, and `topoSort`. Used internally to
+order Lua configuration chunks and exposed for custom DAG entries via
+`vim.luaConfigRC`.
+
+### `lib.nvim.binds` {#sec-lib-binds}
+
+Keybinding construction helpers. Provides `mkBinding`, `mkLuaBinding`,
+`mkExprBinding`, `mkMappingOption`, `addDescriptionsToMappings`, `mkSetBinding`,
+`mkSetLuaBinding`, `mkSetExprBinding`, `pushDownDefault`, and `mkKeymap`.
+
+### `lib.nvim.lua` {#sec-lib-lua}
+
+Nix-to-Lua conversion utilities. Provides `toLuaObject` for converting Nix
+values to Lua literal strings, `isLuaInline` for detecting raw-Lua passthrough
+values, and `luaTable` for building Lua table strings from lists of Lua
+expressions.
+
+### `lib.nvim.languages` {#sec-lib-languages}
+
+Helpers for language module definitions. Provides `mkEnable` for boolean
+language-feature options, `lspOptions` as a reusable submodule type for LSP
+server configuration, and `diagnosticsToLua` for converting diagnostic provider
+lists to DAG entries.
+
+### `lib.nvim.lists` {#sec-lib-lists}
+
+List utilities. Provides `listContainsValues` for checking that all values in
+one list are present in another.
+
+### `lib.nvim.attrsets` {#sec-lib-attrsets}
+
+Attribute set utilities. Provides `mapListToAttrs` for mapping a list to an
+attribute set via a `{ name; value }` mapping function.
+
+<!--
+
+TODO: do this with ndg, properly
+
+## API Reference {#sec-lib-api-reference}
+
+Type signatures and examples for all library functions are auto-generated from
+source docstrings and available in the lib section of the HTML manual.
+
+-->


### PR DESCRIPTION
This is an initial draft of a new `modules` section describing how we use the Nix module system within nvf. While it **does not** cover every module, I think it is worth covering the *basics* of a module to give the users and idea and to potentially answer questions from those New to the Nix ecosystem.

I also think we stand to gain from adding some examples in the DAG section, but I reckon it may be more confusing for the users than it is helpful. CC @horriblename and @Soliprem for reviews and feedback. This *can* be merged as is, but worth discussing beforehand.

Closes #1067