### PR TITLE
docs: fixup release notes from main -> v0.8 merge

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -484,13 +484,6 @@
 - fix broken `neorg` grammars
 - remove obsolete warning in the `otter` module
 
-[Cool-Game-Dev](https://github.com/Cool-Game-Dev):
-
-[nvim-biscuits]: https://github.com/code-biscuits/nvim-biscuits
-
-- Add [nvim-biscuits] to show block context. Available at
-  `vim.utility.nvim-biscuits`.
-
 [JManch](https://github.com/JManch):
 
 - Fix default [blink.cmp] sources "path" and "buffer" not working when
@@ -499,6 +492,7 @@
 
 [Cool-Game-Dev](https://github.com/Cool-Game-Dev):
 
+[nvim-biscuits]: https://github.com/code-biscuits/nvim-biscuits
 [just-lsp]: https://github.com/terror/just-lsp
 [roslyn-ls]: https://github.com/dotnet/vscode-csharp
 [jsonls]: https://github.com/microsoft/vscode/tree/1.101.2/extensions/json-language-features/server
@@ -509,6 +503,7 @@
 [qmlls]: https://doc.qt.io/qt-6/qtqml-tooling-qmlls.html
 [qmlformat]: https://doc.qt.io/qt-6/qtqml-tooling-qmlformat.html
 
+- Add [nvim-biscuits] support under `vim.utility.nvim-biscuits`.
 - Add just support under `vim.languages.just` using [just-lsp].
 - Add [roslyn-ls] to the `vim.languages.csharp` module.
 - Add JSON support under `vim.languages.json` using [jsonls] and [jsonfmt].

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -490,7 +490,7 @@
   `autocomplete.nvim-cmp.enable` was disabled and
   `autocomplete.nvim-cmp.sources` had not been modified.
 
-[Cool-Game-Dev](https://github.com/Cool-Game-Dev):
+[Poseidon](https://github.com/poseidon-rises):
 
 [nvim-biscuits]: https://github.com/code-biscuits/nvim-biscuits
 [just-lsp]: https://github.com/terror/just-lsp


### PR DESCRIPTION
Clean up the release notes by merging entries separated when main was pulled into v0.8 and fixing my username link and display text.
 
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
