### PR TITLE
languages/beancount: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -79,6 +79,7 @@ isMaximal: {
       arduino.enable = false;
       assembly.enable = false;
       astro.enable = false;
+      beancount.enable = false;
       nu.enable = false;
       csharp.enable = false;
       julia.enable = false;

--- a/configuration.nix
+++ b/configuration.nix
@@ -89,6 +89,7 @@ isMaximal: {
       arduino.enable = false;
       assembly.enable = false;
       astro.enable = false;
+      beancount.enable = false;
       nu.enable = false;
       csharp.enable = false;
       julia.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -60,7 +60,7 @@
   following:
 
   ```shell
-  (class: "nixos") cannot be imported into a module 
+  (class: "nixos") cannot be imported into a module
   evaluation that expects class "darwin".
   ```
 
@@ -293,5 +293,13 @@ https://github.com/gorbit99/codewindow.nvim
 [alv-around](https://github.com/alv-around):
 
 - Fix `vim.assistant.codecompanion-nvim` lazy loading with [blink-cmp]
+
+[gmvar](https://github.com/gmvar):
+
+[beancount-language-server]: https://github.com/polarmutex/beancount-language-server
+[bean-format]: https://github.com/beancount/beancount
+
+- Add beancount support under `vim.languages.beancount` using
+  [beancount-language-server] and [bean-format].
 
 <!-- vim: set textwidth=80: -->

--- a/docs/manual/release-notes/rl-26.12.md
+++ b/docs/manual/release-notes/rl-26.12.md
@@ -34,3 +34,11 @@
   support.
 
 - `languages/go`: added tree-sitter injections for `sqlx` queries.
+
+[gmvar](https://github.com/gmvar):
+
+[beancount-language-server]: https://github.com/polarmutex/beancount-language-server
+[bean-format]: https://github.com/beancount/beancount
+
+- Add beancount support under `vim.languages.beancount` using
+  [beancount-language-server] and [bean-format].

--- a/modules/plugins/formatter/conform-nvim/presets/bean-format.nix
+++ b/modules/plugins/formatter/conform-nvim/presets/bean-format.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkFormatterPresetEnableOption;
+
+  cfg = config.vim.formatter.conform-nvim.presets.bean-format;
+in {
+  options.vim.formatter.conform-nvim.presets.bean-format = {
+    enable = mkFormatterPresetEnableOption {
+      option = "bean-format";
+      display = "Bean Format";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    vim.formatter.conform-nvim.setupOpts.formatters.bean-format = {
+      command = "${pkgs.beancount}/bin/bean-format";
+    };
+  };
+}

--- a/modules/plugins/formatter/conform-nvim/presets/default.nix
+++ b/modules/plugins/formatter/conform-nvim/presets/default.nix
@@ -9,6 +9,7 @@
     ./alejandra.nix
     ./asmfmt.nix
     ./astyle.nix
+    ./bean-format.nix
     ./biome.nix
     ./black.nix
     ./cabal-fmt.nix

--- a/modules/plugins/languages/beancount.nix
+++ b/modules/plugins/languages/beancount.nix
@@ -1,0 +1,126 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.meta) getExe getExe';
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum package;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+
+  cfg = config.vim.languages.beancount;
+
+  defaultServers = ["beancount-language-server"];
+  servers = {
+    beancount-language-server = {
+      rootmarkers = [".git"];
+      filetypes = [
+        "beancount"
+        "bean"
+      ];
+      cmd = [
+        # Wrap the language server to ensure 'bean-check' and 'bean-format'
+        # from 'pkgs.beancount' are in the PATH when the server runs.
+        (getExe (
+          pkgs.symlinkJoin {
+            name = "beancount-language-server-wrapped";
+            paths = [pkgs.beancount-language-server];
+            meta.mainProgram = "beancount-language-server";
+            buildInputs = [pkgs.makeBinaryWrapper];
+            postBuild = ''
+              wrapProgram $out/bin/beancount-language-server \
+                --suffix PATH : ${pkgs.beancount}/bin
+                # suffix add to path to allow users beancount in PATH to take precedence.
+            '';
+          }
+        ))
+      ];
+    };
+  };
+
+  defaultFormat = "bean-format";
+  formats = {
+    bean-format = {
+      package = pkgs.beancount;
+    };
+  };
+in {
+  options.vim.languages.beancount = {
+    enable = mkEnableOption "Beancount language support";
+
+    treesitter = {
+      enable =
+        mkEnableOption "Beancount treesitter support"
+        // {
+          default = config.vim.languages.enableTreesitter;
+        };
+      package = mkGrammarOption pkgs "beancount";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "Beancount LSP support"
+        // {
+          default = config.vim.lsp.enable;
+        };
+
+      servers = mkOption {
+        type = deprecatedSingleOrListOf "vim.languages.beancount.lsp.servers" (enum (attrNames servers));
+        default = defaultServers;
+        description = "Beancount LSP server to use.";
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "Beancount formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+        };
+
+      type = mkOption {
+        type = enum (attrNames formats);
+        default = defaultFormat;
+        description = "Beancount formatter to use";
+      };
+
+      package = mkOption {
+        type = package;
+        default = formats.${cfg.format.type}.package;
+        description = "Beancount formatter package";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.servers =
+        mapListToAttrs (n: {
+          name = n;
+          value = servers.${n};
+        })
+        cfg.lsp.servers;
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft.beancount = [cfg.format.type];
+          formatters.${cfg.format.type} = {
+            command = getExe' cfg.format.package cfg.format.type;
+          };
+        };
+      };
+    })
+  ]);
+}

--- a/modules/plugins/languages/beancount.nix
+++ b/modules/plugins/languages/beancount.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) genAttrs;
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum listOf;
+  inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.beancount;
+
+  defaultServers = ["beancount-language-server"];
+  servers = ["beancount-language-server"];
+
+  defaultFormat = ["bean-format"];
+  formats = ["bean-format"];
+in {
+  options.vim.languages.beancount = {
+    enable = mkEnableOption "Beancount language support";
+
+    treesitter = {
+      enable =
+        mkEnableOption "Beancount treesitter support"
+        // {
+          default = config.vim.languages.enableTreesitter;
+        };
+      package = mkGrammarOption pkgs "beancount";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "Beancount LSP support"
+        // {
+          default = config.vim.lsp.enable;
+        };
+
+      servers = mkOption {
+        type = listOf (enum servers);
+        default = defaultServers;
+        description = "Beancount LSP server to use";
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "Beancount formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+        };
+
+      type = mkOption {
+        type = listOf (enum formats);
+        default = defaultFormat;
+        description = "Beancount formatter to use";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      vim.filetype.extension.bean = "beancount";
+    }
+
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {
+          filetypes = ["beancount"];
+        });
+      };
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        presets = genAttrs cfg.format.type (_: {enable = true;});
+        setupOpts.formatters_by_ft.beancount = cfg.format.type;
+      };
+    })
+  ]);
+}

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -7,6 +7,7 @@ in {
     ./asm.nix
     ./astro.nix
     ./bash.nix
+    ./beancount.nix
     ./cue.nix
     ./dart.nix
     ./clang.nix

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -7,6 +7,7 @@ in {
     ./asm.nix
     ./astro.nix
     ./bash.nix
+    ./beancount.nix
     ./clang.nix
     ./clojure.nix
     ./cmake.nix

--- a/modules/plugins/lsp/presets/beancount-language-server.nix
+++ b/modules/plugins/lsp/presets/beancount-language-server.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkLspPresetEnableOption;
+
+  cfg = config.vim.lsp.presets.beancount-language-server;
+in {
+  options.vim.lsp.presets.beancount-language-server = {
+    enable = mkLspPresetEnableOption {
+      option = "beancount-language-server";
+      display = "Beancount";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    vim.lsp.servers.beancount-language-server = {
+      enable = true;
+      root_markers = [".git"];
+      cmd = [
+        # Wrap the language server to ensure 'bean-check' and 'bean-format'
+        # from 'pkgs.beancount' are in the PATH when the server runs.
+        (getExe (
+          pkgs.symlinkJoin {
+            name = "beancount-language-server-wrapped";
+            paths = [pkgs.beancount-language-server];
+            meta.mainProgram = "beancount-language-server";
+            buildInputs = [pkgs.makeBinaryWrapper];
+            postBuild = ''
+              wrapProgram $out/bin/beancount-language-server \
+                --suffix PATH : ${pkgs.beancount}/bin
+                # suffix add to path to allow users beancount in PATH to take precedence.
+            '';
+          }
+        ))
+      ];
+    };
+  };
+}

--- a/modules/plugins/lsp/presets/default.nix
+++ b/modules/plugins/lsp/presets/default.nix
@@ -6,6 +6,7 @@
     ./astro-language-server.nix
     ./basedpyright.nix
     ./bash-language-server.nix
+    ./beancount-language-server.nix
     ./ccls.nix
     ./clangd.nix
     ./clojure-lsp.nix


### PR DESCRIPTION
Create the `vim.languages.beancount` module using `bean-format` and `beancount-language-server`.

### Current Issues

1. **Formatting Behavior**:
   - ~~The `beancount-language-server` currently lacks an option to disable formatting. This results in documents being automatically formatted, even when the setting `vim.languages.beancount.format.enable` is set to `false`.~~
   - ~~I have opened an issue on the project's GitHub repository requesting the addition of a toggle for this behavior. Until this feature is implemented, users will experience automatic formatting regardless of their preferences. [GitHub Issue #650](https://github.com/polarmutex/beancount-language-server/issues/650).~~
   - `beancount-language-server` added an option to disable the automatic formatting, though it's not clear to me how to enable that option... Until then, the language server will always format the document.

## Sanity Checking
[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [x] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`