### PR TITLE
lsp/harper-ls: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -31,6 +31,7 @@ isMaximal: {
       lspSignature.enable = !isMaximal; # conflicts with blink in maximal
       otter-nvim.enable = isMaximal;
       nvim-docs-view.enable = isMaximal;
+      harper-ls.enable = isMaximal;
     };
 
     debugger = {

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -524,3 +524,9 @@
 [diced](https://github.com/diced):
 
 - Fixed `typescript` treesitter grammar not being included by default.
+
+[gmvar](https://github.com/gmvar):
+
+[harper-ls]: https://github.com/Automattic/harper
+
+- Add [harper-ls] to the `vim.lsp` module.

--- a/modules/plugins/lsp/default.nix
+++ b/modules/plugins/lsp/default.nix
@@ -7,6 +7,7 @@
     ./lspconfig
     ./lspsaga
     ./null-ls
+    ./harper-ls
 
     # lsp plugins
     ./lspsaga

--- a/modules/plugins/lsp/harper-ls/config.nix
+++ b/modules/plugins/lsp/harper-ls/config.nix
@@ -1,0 +1,19 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.meta) getExe;
+
+  cfg = config.vim.lsp;
+in {
+  config = mkIf (cfg.enable && cfg.harper-ls.enable) {
+    vim.lsp.servers.harper-ls = {
+      root_markers = [".git"];
+      cmd = [(getExe pkgs.harper) "--stdio"];
+      settings = {harper-ls = cfg.harper-ls.settings;};
+    };
+  };
+}

--- a/modules/plugins/lsp/harper-ls/default.nix
+++ b/modules/plugins/lsp/harper-ls/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./harper-ls.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/lsp/harper-ls/harper-ls.nix
+++ b/modules/plugins/lsp/harper-ls/harper-ls.nix
@@ -1,0 +1,35 @@
+{lib, ...}: let
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) anything attrsOf;
+in {
+  options.vim.lsp.harper-ls = {
+    enable = mkEnableOption "Harper grammar checking LSP";
+    settings = mkOption {
+      type = attrsOf anything;
+      default = {};
+      example = {
+        userDictPath = "";
+        workspaceDictPath = "";
+        fileDictPath = "";
+        linters = {
+          BoringWords = true;
+          PossessiveNoun = true;
+          SentenceCapitalization = false;
+          SpellCheck = false;
+        };
+        codeActions = {
+          ForceStable = false;
+        };
+        markdown = {
+          IgnoreLinkTitle = false;
+        };
+        diagnosticSeverity = "hint";
+        isolateEnglish = false;
+        dialect = "American";
+        maxFileLength = 120000;
+        ignoredLintsPath = {};
+      };
+      description = "Settings to pass to harper-ls";
+    };
+  };
+}


### PR DESCRIPTION
Add [harper-ls](https://github.com/automattic/harper) to the `vim.lsp` module.

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
