### PR TITLE
languages/fish: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -92,6 +92,7 @@ isMaximal: {
       fsharp.enable = false;
       just.enable = false;
       qml.enable = false;
+      fish.enable = false;
 
       tailwind.enable = false;
       svelte.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -150,5 +150,5 @@
 [fish-lsp]: https://www.fish-lsp.dev/
 [fish_indent]: https://fishshell.com/docs/current/cmds/fish_indent.html
 
-- Add Fish support vai {option}`languages.fish` using [fish-lsp] and
+- Add Fish support via {option}`languages.fish` using [fish-lsp] and
   [fish_indent].

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -144,3 +144,11 @@
 [Machshev](https://github.com/machshev):
 
 - Added `ruff` and `ty` LSP support for Python under `programs.python`.
+
+[Poseidon](https://github.com/poseidon-rises):
+
+[fish-lsp]: https://www.fish-lsp.dev/
+[fish_indent]: https://fishshell.com/docs/current/cmds/fish_indent.html
+
+- Add Fish support vai {option}`languages.fish` using [fish-lsp] and
+  [fish_indent].

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -12,6 +12,7 @@ in {
     ./clojure.nix
     ./css.nix
     ./elixir.nix
+    ./fish.nix
     ./fsharp.nix
     ./gleam.nix
     ./go.nix

--- a/modules/plugins/languages/fish.nix
+++ b/modules/plugins/languages/fish.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib.meta) getExe;
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum package listOf;
+  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+
+  cfg = config.vim.languages.fish;
+
+  defaultServers = ["fish-lsp"];
+  servers = {
+    fish-lsp = {
+      cmd = [(getExe pkgs.fish-lsp) "start"];
+      filetypes = ["fish"];
+      root_markers = ["config.fish" ".git"];
+    };
+  };
+
+  defaultFormat = ["fish_indent"];
+  formats = {
+    fish_indent = {
+      package = pkgs.fish;
+      config.command = "${cfg.format.package}/bin/fish_indent";
+    };
+  };
+in {
+  options.vim.languages.fish = {
+    enable = mkEnableOption "Fish language support";
+    treesitter = {
+      enable = mkEnableOption "Fish treesitter support" // {default = config.vim.languages.enableTreesitter;};
+      package = mkGrammarOption pkgs "fish";
+    };
+
+    lsp = {
+      enable = mkEnableOption "Fish LSP support" // {default = config.vim.lsp.enable;};
+      servers = mkOption {
+        type = listOf (enum (attrNames servers));
+        default = defaultServers;
+        description = "Fish LSP server to use";
+      };
+    };
+
+    format = {
+      enable = mkEnableOption "Fish formatting" // {default = config.vim.languages.enableFormat;};
+
+      type = mkOption {
+        type = listOf enum (attrNames formats);
+        default = defaultFormat;
+        description = "Fish formatter to use";
+      };
+
+      package = mkOption {
+        type = package;
+        default = formats.${cfg.format.type}.package;
+        description = "Fish formatter package";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.servers =
+        mapListToAttrs (n: {
+          name = n;
+          value = servers.${n};
+        })
+        cfg.lsp.servers;
+    })
+
+    (mkIf (cfg.format.enable && !cfg.lsp.enable) {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts.formatters_by_ft.fish = cfg.format.type;
+        setupOpts.formatters =
+          mapListToAttrs (name: {
+            inherit name;
+            value = formats.${name};
+          })
+          cfg.format.type;
+      };
+    })
+  ]);
+}

--- a/modules/plugins/languages/fish.nix
+++ b/modules/plugins/languages/fish.nix
@@ -51,7 +51,7 @@ in {
       enable = mkEnableOption "Fish formatting" // {default = config.vim.languages.enableFormat;};
 
       type = mkOption {
-        type = listOf enum (attrNames formats);
+        type = listOf (enum (attrNames formats));
         default = defaultFormat;
         description = "Fish formatter to use";
       };


### PR DESCRIPTION
[fish-lsp]: https://www.fish-lsp.dev/
[fish_indent]: https://fishshell.com/docs/current/cmds/fish_indent.html

Add fish support with [fish-lsp] and [fish_indent].

Rewrite of #807 using the new API as the original creator has stopped responding.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
