### PR TITLE
ui/nvim-highlight-colors: init

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -492,3 +492,10 @@
 - Fix default [blink.cmp] sources "path" and "buffer" not working when
   `autocomplete.nvim-cmp.enable` was disabled and
   `autocomplete.nvim-cmp.sources` had not been modified.
+
+[Jules](https://github.com/jules-sommer):
+
+[nvim-highlight-colors]: https://github.com/brenoprata10/nvim-highlight-colors
+
+- Add [nvim-highlight-colors] plugin in `vim.ui.nvim-highlight-colors` with
+  `enable` and `setupOpts`

--- a/modules/plugins/ui/default.nix
+++ b/modules/plugins/ui/default.nix
@@ -3,6 +3,7 @@
     ./borders
     ./breadcrumbs
     ./colorful-menu-nvim
+    ./nvim-highlight-colors
     ./colorizer
     ./fastaction
     ./illuminate

--- a/modules/plugins/ui/nvim-highlight-colors/config.nix
+++ b/modules/plugins/ui/nvim-highlight-colors/config.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.ui.nvim-highlight-colors;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = [
+        "nvim-highlight-colors"
+      ];
+
+      options.termguicolors = true;
+
+      pluginRC.nvim-highlight-colors = entryAnywhere ''
+        require('nvim-highlight-colors').setup(${toLuaObject cfg.setupOpts})
+      '';
+    };
+  };
+}

--- a/modules/plugins/ui/nvim-highlight-colors/config.nix
+++ b/modules/plugins/ui/nvim-highlight-colors/config.nix
@@ -15,6 +15,9 @@ in {
         "nvim-highlight-colors"
       ];
 
+      # enable display of 24-bit RGB colors in neovim
+      # via the terminal. This is required for nvim-highlight-colors
+      # to display arbitrary RGB highlights.
       options.termguicolors = true;
 
       pluginRC.nvim-highlight-colors = entryAnywhere ''

--- a/modules/plugins/ui/nvim-highlight-colors/default.nix
+++ b/modules/plugins/ui/nvim-highlight-colors/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./nvim-highlight-colors.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/ui/nvim-highlight-colors/nvim-highlight-colors.nix
+++ b/modules/plugins/ui/nvim-highlight-colors/nvim-highlight-colors.nix
@@ -1,0 +1,92 @@
+{lib, ...}: let
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) attrsOf enum nullOr submodule bool str;
+  inherit (lib.modules) mkRenamedOptionModule;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (lib.nvim.config) mkBool;
+in {
+  options.vim.ui.nvim-highlight-colors = {
+    enable = mkEnableOption "color highlighting [nvim-highlight-colors.lua]";
+
+    setupOpts = mkPluginSetupOption "nvim-highlight-colors" {
+      render = mkOption {
+        type = enum ["background" "foreground" "virtual"];
+        default = "background";
+        example = "virtual";
+        description = ''
+          Style to render color highlighting with.
+
+          ::: {.note}
+          Each render style works as follows:
+            - 'background' sets the background
+              highlight of the matched color string
+              to the RGB color it describes.
+
+            - 'foreground' sets the foreground
+              highlight of the matched color string
+              to the RGB color it describes.
+
+            - 'virtual' displays the matched color
+              with virtual text alongside the color
+              string in the buffer. Virtual text can
+              be configured to display the color in
+              various ways, i.e custom virtual symbol
+              (via `virtual_symbol`) positioning
+              relative to string, suffix/prefix, etc.
+          :::
+        '';
+      };
+
+      virtual_symbol = mkOption {
+        type = nullOr str;
+        default = "■";
+        example = "⬤";
+        description = ''
+          Symbol to display color with as virtual text.
+
+          ::: {.note}
+          Only applies when `render` is set to 'virtual'.
+          :::
+        '';
+      };
+
+      virtual_symbol_prefix = mkOption {
+        type = nullOr str;
+        default = "";
+        description = ''
+          String used as a prefix to the virtual_symbol
+          For example, to add padding between the color
+          string and the virtual symbol.
+
+          ::: {.note}
+          Only applies when `render` is set to 'virtual'.
+          :::
+        '';
+      };
+
+      virtual_symbol_suffix = mkOption {
+        type = nullOr str;
+        default = " ";
+        description = ''
+          String used as a suffix to the virtual_symbol
+          For example, to add padding between the virtual
+          symbol and other text in the buffer.
+
+          ::: {.note}
+          Only applies when `render` is set to 'virtual'.
+          :::
+        '';
+      };
+
+      enable_hex = mkBool true "Enable highlighting for hex color strings, i.e `#FFFFFF`.";
+      enable_short_hex = mkBool true "Enable highlighting for shorthand hex color format, i.e `#FFF`.";
+      enable_rgb = mkBool true "Enable highlighting for RGB color strings, i.e `rgb(0, 0, 0)` or `rgb(0 0 0)`.";
+      enable_hsl = mkBool true "Enable highlighting for HSL color strings, i.e `hsl(150deg 30% 40%)`.";
+      enable_ansi = mkBool true "Enable highlighting for HSL color strings, i.e `\033[0;34m`.";
+      enable_hsl_without_function = mkBool true "Enable highlighting for bare HSL color strings, i.e `--foreground: 0 69% 69%;`.";
+      enable_var_usage = mkBool true "Enable highlighting for CSS variables which reference colors, i.e `var(--testing-color)`.";
+      enable_named_colors = mkBool true "Enable highlighting for named colors, i.e `green`.";
+      enable_tailwind = mkBool false "Enable highlighting for tailwind color classes, i.e `bg-blue-500`.";
+    };
+  };
+}

--- a/modules/plugins/ui/nvim-highlight-colors/nvim-highlight-colors.nix
+++ b/modules/plugins/ui/nvim-highlight-colors/nvim-highlight-colors.nix
@@ -37,56 +37,35 @@ in {
         '';
       };
 
-      virtual_symbol = mkOption {
-        type = nullOr str;
-        default = "■";
-        example = "⬤";
+      virtual_symbol_position = mkOption {
+        type = enum ["inline" "eol" "eow"];
+        default = "inline";
+        example = "eol";
         description = ''
-          Symbol to display color with as virtual text.
+          Where to render the virtual symbol in
+          relation to the color string.
 
           ::: {.note}
-          Only applies when `render` is set to 'virtual'.
+          Each render style works as follows:
+            - 'inline' render virtual text inline,
+              similar to the style of VSCode color
+              hinting.
+
+            - 'eol' render virtual text at the end
+              of the line which the color string
+              occurs (last column). Recommended to
+              set `virtual_symbol_suffix` to an
+              empty string when used.
+
+            - 'eow' render virtual text at the end
+              of the word where the color string
+              occurs. Recommended to set
+              `virtual_symbol_prefix` to a single
+              space for padding and the suffix to
+              an empty string for no padding.
           :::
         '';
       };
-
-      virtual_symbol_prefix = mkOption {
-        type = nullOr str;
-        default = "";
-        description = ''
-          String used as a prefix to the virtual_symbol
-          For example, to add padding between the color
-          string and the virtual symbol.
-
-          ::: {.note}
-          Only applies when `render` is set to 'virtual'.
-          :::
-        '';
-      };
-
-      virtual_symbol_suffix = mkOption {
-        type = nullOr str;
-        default = " ";
-        description = ''
-          String used as a suffix to the virtual_symbol
-          For example, to add padding between the virtual
-          symbol and other text in the buffer.
-
-          ::: {.note}
-          Only applies when `render` is set to 'virtual'.
-          :::
-        '';
-      };
-
-      enable_hex = mkBool true "Enable highlighting for hex color strings, i.e `#FFFFFF`.";
-      enable_short_hex = mkBool true "Enable highlighting for shorthand hex color format, i.e `#FFF`.";
-      enable_rgb = mkBool true "Enable highlighting for RGB color strings, i.e `rgb(0, 0, 0)` or `rgb(0 0 0)`.";
-      enable_hsl = mkBool true "Enable highlighting for HSL color strings, i.e `hsl(150deg 30% 40%)`.";
-      enable_ansi = mkBool true "Enable highlighting for HSL color strings, i.e `\033[0;34m`.";
-      enable_hsl_without_function = mkBool true "Enable highlighting for bare HSL color strings, i.e `--foreground: 0 69% 69%;`.";
-      enable_var_usage = mkBool true "Enable highlighting for CSS variables which reference colors, i.e `var(--testing-color)`.";
-      enable_named_colors = mkBool true "Enable highlighting for named colors, i.e `green`.";
-      enable_tailwind = mkBool false "Enable highlighting for tailwind color classes, i.e `bg-blue-500`.";
     };
   };
 }

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1838,6 +1838,19 @@
       "url": "https://github.com/amrbashir/nvim-docs-view/archive/f674ba57349849bce894efdd54096483c88e810b.tar.gz",
       "hash": "0ifbfhifly5sdsbxv1p71wvl644jz505ln9j1yr6qwvyk6a2krm1"
     },
+    "nvim-highlight-colors": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "brenoprata10",
+        "repo": "nvim-highlight-colors"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "1ce0a09bfc28c7274e649d20927cea51e440b65c",
+      "url": "https://github.com/brenoprata10/nvim-highlight-colors/archive/1ce0a09bfc28c7274e649d20927cea51e440b65c.tar.gz",
+      "hash": "1wsscm2mycd7zalxv8paa3fk0qy46bbhq4yfr73sl71wvkdh6yjn"
+    },
     "nvim-lightbulb": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
This PR adds support for [nvim-highlight-colors](https://github.com/brenoprata10/nvim-highlight-colors), a plugin that uses highlight groups and/or virtual text to visually display the color being encoded as a string in various formats (i.e rgb(0 0 0), #fff, #ffffff, hsl(150deg 30% 40%), etc) in open buffers.

My personal motivation behind using this plugin and also writing this module is the ease with which it integrates with blink-cmp to display color highlighting in completion windows as well as it's virtual text which is super easy to configure to your desired style preferences. I am aware of the existing `nvim-colorizer` plugin which nvf already has a module for. I understand if the maintainers here don't think it's necessary to add and support another color highlighting plugin within the project. I would love to hear your thoughts on that, but since I wrote it already I figured I may as well make a PR and see what folks thought <3 I just love using nvf in my own neovim config and think it's a great project and I wanted to get familiar with contributing here so I can hopefully work on other things within nvf. And if this module is useful to anyone or gets merged then that's just an added bonus!!

This plugin also provides lua code to integrate with nvim-cmp, lspkind, or blink-cmp and highlight color in completions. I was thinking about adding a module options for easily toggling the various completion integrations that this plugin provides (nvim-cmp, blink-cmp, lspkind). But I wanted to get some thoughts on how to go about that, if at all. An issue arises of how to contend with conflicts between a user's existing blink-cmp or nvim-cmp setupOpts which might also call a function to modify completion items to, for example, display custom icons, rename or otherwise format the items via lua, creating a difficult to resolve conflict between setupOpts. So that was my worry with implementing that without asking for some thoughts first. It's possible it's just not feasible for those reasons. 

In the interest of keeping this PR concise, if you do want to reference the integration lua examples for context on what I am talking about re: conflicting inline lua in setupOpts, they can be found here in the plugin repo: 
[nvim-highlight-colors repo](https://github.com/brenoprata10/nvim-highlight-colors) specifically in the readme near the bottom,

__or alternatively, this gist__: [example lua code demonstrating the completion integrations nvim-highlight-colors provides](https://gist.github.com/jules-sommer/9c30cf68d9a5a425917a3fa289724972)

![image showing the nvim-cmp integration with nvim-hightlight-colors](https://private-user-images.githubusercontent.com/26099427/344429318-0f6858fe-f7e2-4710-a22f-c3b3a455f74b.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTY1NzEyOTQsIm5iZiI6MTc1NjU3MDk5NCwicGF0aCI6Ii8yNjA5OTQyNy8zNDQ0MjkzMTgtMGY2ODU4ZmUtZjdlMi00NzEwLWEyMmYtYzNiM2E0NTVmNzRiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA4MzAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwODMwVDE2MjMxNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWRiZTQ2OGQ3M2QzMzZjZWE2NzI0N2NlYzU5NTYwZWE4M2JhNDVkYjhiZDI2ZmVlNTY1NGQ4NTg2OTdmZmFkNGQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.3GulLdPfU7CPioHLsTivYnwD32etk3cUsXp8iCpt56E) 
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

