### PR TITLE
Documentation: Fix referenes to erroneous `lib.nvim.types.luaInline`

### DIFF
--- a/docs/manual/configuring/autocmds.md
+++ b/docs/manual/configuring/autocmds.md
@@ -43,7 +43,7 @@ with the following options:
 | `enable`   | `bool`                | `true`  | Enables or disables this autocommand definition.                                                                                                                                 | `true`                                                           |
 | `event`    | `nullOr (listOf str)` | `null`  | **Required.** List of Neovim events that trigger this autocommand (e.g., `BufWritePre`, `FileType`).                                                                             | `[ "BufWritePre" ]`                                              |
 | `pattern`  | `nullOr (listOf str)` | `null`  | List of file patterns (globs) to match against (e.g., `*.py`, `*`). If `null`, matches all files for the given event.                                                            | `[ "*.lua", "*.nix" ]`                                           |
-| `callback` | `nullOr luaInline`    | `null`  | A Lua function to execute when the event triggers. Use `lib.nvim.types.luaInline` or `lib.options.literalExpression "mkLuaInline '''...'''"`. **Cannot be used with `command`.** | `lib.nvim.types.luaInline "function() print('File saved!') end"` |
+| `callback` | `nullOr luaInline`    | `null`  | A Lua function to execute when the event triggers. Use `lib.generators.mkLuaInline`. **Cannot be used with `command`.** | `lib.generators.mkLuaInline "function() print('File saved!') end"` |
 | `command`  | `nullOr str`          | `null`  | A Vimscript command to execute when the event triggers. **Cannot be used with `callback`.**                                                                                      | `"echo 'File saved!'"`                                           |
 | `group`    | `nullOr str`          | `null`  | The name of an `augroup` (defined in `vim.augroups`) to associate this autocommand with.                                                                                         | `"MyCustomAuGroup"`                                              |
 | `desc`     | `nullOr str`          | `null`  | A description for the autocommand (useful for introspection).                                                                                                                    | `"Format buffer on save"`                                        |
@@ -71,7 +71,7 @@ Vimscript) for the same autocommand. Choose one.
       pattern = [ "*.lua" ];
       group = "UserSetup";
       desc = "Notify after saving Lua file";
-      callback = lib.nvim.types.luaInline ''
+      callback = lib.generators.mkLuaInline ''
         function()
           vim.notify("Lua file saved!", vim.log.levels.INFO)
         end

--- a/modules/neovim/init/autocmds.nix
+++ b/modules/neovim/init/autocmds.nix
@@ -38,7 +38,7 @@
         type = nullOr luaInline;
         default = null;
         example = literalExpression ''
-          mkLuaInline '''
+          lib.generators.mkLuaInline '''
             function()
                 print("Saving a Lua file...")
             end


### PR DESCRIPTION
Clears up documentation using an erroneous invocation of converting a string to lua (`lib.nvim.types.luaInline` instead of `lib.generators.mkLuaInline`). This fixes the occurrences in the main docs page as well as the ambiguous reference in Appendix B. as described in #1137

Fixes #1137

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
