### PR TITLE
completion/blink-cmp: added keymap "inherit" preset

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -499,3 +499,6 @@
 
 - Add [nvim-highlight-colors] plugin in `vim.ui.nvim-highlight-colors` with
   `enable` and `setupOpts`
+- Fix [blink.cmp] keymap preset types to allow alternate cmdline, terminal, 
+  etc modes to `inherit` the default mode keymaps. This is an option as per
+  the [blink.cmp] docs and is now supported in  docs and is now supported in nvf.nvf.

--- a/modules/plugins/completion/blink-cmp/blink-cmp.nix
+++ b/modules/plugins/completion/blink-cmp/blink-cmp.nix
@@ -9,7 +9,7 @@
     freeformType = attrsOf (listOf (either str luaInline));
     options = {
       preset = mkOption {
-        type = enum ["default" "none" "super-tab" "enter" "cmdline"];
+        type = enum ["inherit" "default" "none" "super-tab" "enter" "cmdline"];
         default = "none";
         description = "keymap presets";
       };


### PR DESCRIPTION
`inherit` as a value for the option `vim.autocomplete.blink-cmp.setupOpts.cmdline.keymap.preset` is valid as per [blink-cmp's documentation](https://cmp.saghen.dev/modes/cmdline.html). This is only true for alternate completion modes (mainly `cmdline`, but also potentially `terminal` AFAIK), allowing that mode to inherit the keymaps set for the default completion mode in blink-cmp. This is within `setupOpts` and is not related to the nvf-specific option `vim.autocomplete.blink-cmp.mappings` but it was still typed in nvf's blink-cmp module so this PR is updating that type. An excerpt from their docs details when to use this option:

>   If you want cmdline's behavior to match the default mode, try the following config:
>   
>   ```lua
>   cmdline = {
>     keymap = { preset = 'inherit' },
>     completion = { menu = { auto_show = true } },
>   },
>   ```

This was previously an invalid value for nvf's `keymapType.preset` option. But with this PR it would be valid.
```nix
-        type = enum ["default" "none" "super-tab" "enter" "cmdline"];
+        type = enum ["inherit" "default" "none" "super-tab" "enter" "cmdline"];
```

Now this does open up the possibility of creating separate `preset` enum's for alternate modes, i.e cmdline, terminal, etc, different from the enum for the default mode. Which, since it is the parent being inherited from, cannot be set to `inherit` itself.

If you do this, blink-cmp will give you an error since it wasn't expecting "inherit" for the default mode's keymaps. I am very much willing to create a separate type for that to clarify these semantics, but I thought I'd discuss it here first.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
