### PR TITLE
attach LSP keybinds + other setup work in LspAttach

### DIFF
--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -28,6 +28,10 @@
   align with the "hunks" themed mapping and avoid conflict with the new [neogit]
   group.
 
+- LSP keybinds and related plugin integrations are now attached in an LspAttach
+  autocmd event. If you were calling `default_on_attach()` in your LSP setup you
+  can remove them now.
+
 [NotAShelf](https://github.com/notashelf):
 
 [typst-preview.nvim]: https://github.com/chomosuke/typst-preview.nvim
@@ -135,6 +139,8 @@
 - Moved code setting `additionalRuntimePaths` and `enableLuaLoader` out of
   `luaConfigPre`'s default to prevent being overridden
 - Use conform over custom autocmds for LSP format on save
+- Move LSP keybinds and other related plugin integrations into an LspAttach
+  event.
 
 [diniamo](https://github.com/diniamo):
 

--- a/lib/dag.nix
+++ b/lib/dag.nix
@@ -8,7 +8,7 @@
 #  - the addition of the function `entryBefore` indicating a "wanted
 #    by" relationship.
 {lib}: let
-  inherit (builtins) isAttrs attrValues attrNames elem all head tail length toJSON isString;
+  inherit (builtins) isAttrs attrValues attrNames elem all head tail length toJSON isString removeAttrs;
   inherit (lib.attrsets) filterAttrs mapAttrs;
   inherit (lib.lists) toposort;
   inherit (lib.nvim.dag) empty isEntry entryBetween entryAfter entriesBetween entryAnywhere topoSort;
@@ -169,10 +169,11 @@ in {
       else value)
     dag;
     sortedDag = topoSort finalDag;
+    loopDetail = map (loops: removeAttrs loops ["data"]) sortedDag.loops;
     result =
       if sortedDag ? result
       then mapResult sortedDag.result
-      else abort ("Dependency cycle in ${name}: " + toJSON sortedDag);
+      else abort ("Dependency cycle in ${name}: " + toJSON loopDetail);
   in
     result;
 }

--- a/modules/neovim/init/autocmds.nix
+++ b/modules/neovim/init/autocmds.nix
@@ -9,7 +9,7 @@
   inherit (lib.types) nullOr submodule listOf str bool;
   inherit (lib.nvim.types) luaInline;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.dag) entryAfter;
+  inherit (lib.nvim.dag) entryAfter entryBetween;
 
   autocommandType = submodule {
     options = {
@@ -144,7 +144,7 @@ in {
       enabledAutogroups = filter (au: au.enable) cfg.augroups;
     in {
       luaConfigRC = {
-        augroups = entryAfter ["pluginConfigs"] (optionalString (enabledAutogroups != []) ''
+        augroups = entryBetween ["autocmds"] ["pluginConfigs"] (optionalString (enabledAutogroups != []) ''
           local nvf_autogroups = {}
           for _, group in ipairs(${toLuaObject enabledAutogroups}) do
             if group.name then

--- a/modules/neovim/init/lsp.nix
+++ b/modules/neovim/init/lsp.nix
@@ -77,7 +77,6 @@ in {
     {
       vim.lsp.servers."*" = {
         capabilities = mkDefault (mkLuaInline "capabilities");
-        on_attach = mkDefault (mkLuaInline "default_on_attach");
       };
     }
 

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -26,8 +26,6 @@
       workspace_required = true;
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr)
-
           local function switch_source_header(bufnr)
             local method_name = "textDocument/switchSourceHeader"
             local params = vim.lsp.util.make_text_document_params(bufnr)
@@ -77,8 +75,6 @@
       };
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr)
-
           local function switch_source_header(bufnr)
             local method_name = "textDocument/switchSourceHeader"
             local client = vim.lsp.get_clients({ bufnr = bufnr, name = "clangd", })[1]

--- a/modules/plugins/languages/csharp.nix
+++ b/modules/plugins/languages/csharp.nix
@@ -63,12 +63,11 @@
       };
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr)
-            local oe = require("omnisharp_extended")
-            ${mkLspBinding "goToDefinition" "oe.lsp_definition"}
-            ${mkLspBinding "goToType" "oe.lsp_type_definition"}
-            ${mkLspBinding "listReferences" "oe.lsp_references"}
-            ${mkLspBinding "listImplementations" "oe.lsp_implementation"}
+          local oe = require("omnisharp_extended")
+          ${mkLspBinding "goToDefinition" "oe.lsp_definition"}
+          ${mkLspBinding "goToType" "oe.lsp_type_definition"}
+          ${mkLspBinding "listReferences" "oe.lsp_references"}
+          ${mkLspBinding "listImplementations" "oe.lsp_implementation"}
         end
       '';
       settings = {

--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -161,7 +161,6 @@ in {
             },
 
             capabilities = capabilities,
-            on_attach = default_on_attach;
           },
           ${optionalString cfg.dap.enable ''
           debugger = {

--- a/modules/plugins/languages/haskell.nix
+++ b/modules/plugins/languages/haskell.nix
@@ -10,11 +10,10 @@
   inherit (lib.strings) optionalString;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.nvim.types) mkGrammarOption;
-  inherit (lib.nvim.dag) entryAfter entryBefore;
+  inherit (lib.nvim.dag) entryAfter;
   inherit (lib.nvim.lua) expToLua;
   inherit (lib.meta) getExe';
   inherit (lib.generators) mkLuaInline;
-  inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (pkgs) haskellPackages;
   inherit (lib.nvim.lua) toLuaObject;
 
@@ -34,7 +33,6 @@
         ''
           function(client, bufnr)
               local ht = require("haskell-tools")
-              default_on_attach(client, bufnr, ht)
               local opts = { noremap = true, silent = true, buffer = bufnr }
               vim.keymap.set('n', '<localleader>cl', vim.lsp.codelens.run, opts)
               vim.keymap.set('n', '<localleader>hs', ht.hoogle.hoogle_signature, opts)

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -42,7 +42,6 @@
       };
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr);
           vim.api.nvim_buf_create_user_command(bufnr, 'LspPyrightOrganizeImports', function()
             local params = {
               command = 'pyright.organizeimports',
@@ -89,7 +88,6 @@
       };
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr);
           vim.api.nvim_buf_create_user_command(bufnr, 'LspPyrightOrganizeImports', function()
             local params = {
               command = 'basedpyright.organizeimports',

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -160,7 +160,6 @@ in {
                 ${cfg.lsp.opts}
               },
               on_attach = function(client, bufnr)
-                default_on_attach(client, bufnr)
                 local opts = { noremap=true, silent=true, buffer = bufnr }
                 vim.keymap.set("n", "<localleader>rr", ":RustLsp runnables<CR>", opts)
                 vim.keymap.set("n", "<localleader>rp", ":RustLsp parentModule<CR>", opts)

--- a/modules/plugins/languages/ts.nix
+++ b/modules/plugins/languages/ts.nix
@@ -50,8 +50,6 @@
       };
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr);
-
           -- ts_ls provides `source.*` code actions that apply to the whole file. These only appear in
           -- `vim.lsp.buf.code_action()` if specified in `context.only`.
           vim.api.nvim_buf_create_user_command(0, 'LspTypescriptSourceAction', function()
@@ -106,7 +104,6 @@
       };
       on_attach = mkLuaInline ''
         function(client, bufnr)
-          default_on_attach(client, bufnr)
           vim.api.nvim_buf_create_user_command(0, 'LspDenolsCache', function()
             client:exec_cmd({
               command = 'deno.cache',

--- a/modules/plugins/languages/yaml.nix
+++ b/modules/plugins/languages/yaml.nix
@@ -15,18 +15,18 @@
 
   cfg = config.vim.languages.yaml;
 
-  on_attach = mkLuaInline (
+  on_attach =
     if config.vim.languages.helm.lsp.enable && config.vim.languages.helm.enable
-    then ''
-      function(client, bufnr)
-        default_on_attach()
-        local filetype = vim.bo[bufnr].filetype
-        if filetype == "helm" then
-          client.stop()
+    then
+      mkLuaInline ''
+        function(client, bufnr)
+          local filetype = vim.bo[bufnr].filetype
+          if filetype == "helm" then
+            client.stop()
+          end
         end
-      end''
-    else "default_on_attach"
-  );
+      ''
+    else null;
 
   defaultServers = ["yaml-language-server"];
   servers = {

--- a/modules/plugins/lsp/config.nix
+++ b/modules/plugins/lsp/config.nix
@@ -10,6 +10,8 @@
   inherit (lib.strings) optionalString;
   inherit (lib.trivial) boolToString;
   inherit (lib.nvim.binds) addDescriptionsToMappings;
+  inherit (lib.nvim.dag) entryBefore;
+  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.lsp;
   usingNvimCmp = config.vim.autocomplete.nvim-cmp.enable;
@@ -23,7 +25,7 @@
   mappings = addDescriptionsToMappings cfg.mappings mappingDefinitions;
   mkBinding = binding: action:
     if binding.value != null
-    then "vim.keymap.set('n', '${binding.value}', ${action}, {buffer=bufnr, noremap=true, silent=true, desc='${binding.description}'})"
+    then "vim.keymap.set('n', ${toLuaObject binding.value}, ${action}, {buffer=bufnr, noremap=true, silent=true, desc=${toLuaObject binding.description}})"
     else "";
 in {
   config = mkIf cfg.enable {
@@ -35,20 +37,26 @@ in {
 
       augroups = [{name = augroup;}];
       autocmds =
-        (optional cfg.inlayHints.enable {
-          group = augroup;
-          event = ["LspAttach"];
-          desc = "LSP on-attach enable inlay hints autocmd";
-          callback = mkLuaInline ''
-            function(event)
-              local bufnr = event.buf
-              local client = vim.lsp.get_client_by_id(event.data.client_id)
-              if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
-                vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }), { bufnr = bufnr })
+        [
+          {
+            group = augroup;
+            event = ["LspAttach"];
+            desc = "LSP on-attach add keybinds, enable inlay hints, and other plugin integrations";
+            callback = mkLuaInline ''
+              function(event)
+                local bufnr = event.buf
+                local client = vim.lsp.get_client_by_id(event.data.client_id)
+                default_on_attach(client, bufnr)
+
+                ${optionalString cfg.inlayHints.enable ''
+                if client and client.supports_method(vim.lsp.protocol.Methods.textDocument_inlayHint) then
+                  vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }), { bufnr = bufnr })
+                end
+              ''}
               end
-            end
-          '';
-        })
+            '';
+          }
+        ]
         ++ (optional (!conformFormatOnSave) {
           group = augroup;
           event = ["BufWritePre"];
@@ -87,7 +95,7 @@ in {
           '';
         });
 
-      pluginRC.lsp-setup = ''
+      pluginRC.lsp-setup = entryBefore ["autocmds"] ''
         vim.g.formatsave = ${boolToString cfg.formatOnSave};
 
         local attach_keymaps = function(client, bufnr)


### PR DESCRIPTION
currently, we use `vim.lsp.config["*"].on_attach` to call `default_on_attach()` in order to set up LSP keybinds and other plugin integrations. This is a problem because

1. in 0.8, users who want to use lspconfig (via the `vim.lsp.config` interface) may get their on_attach function overridden by lspconfig. There's not really a good way to get both `default_on_attach` and the lspconfig-provided on_attach at the same time (there are some hacky ways that I'll omit for brevity)
2. we keep forgetting to call `default_on_attach` ourselves in language modules. To save us the trouble, I think we should just move `default_on_attach` to LspAttach autocmd instead

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
