### PR TITLE
languages/verilog: init module

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -86,6 +86,7 @@ isMaximal: {
       haskell.enable = false;
       ruby.enable = false;
       fsharp.enable = false;
+      verilog.enable = false;
 
       tailwind.enable = false;
       svelte.enable = false;

--- a/docs/release-notes/rl-0.8.md
+++ b/docs/release-notes/rl-0.8.md
@@ -506,3 +506,11 @@
 
 - Add inline typst concealing support under `vim.languages.typst` using
   [typst-concealer].
+
+[AleksandarZhekovski](https://github.com/AleksandarZhekovski):
+
+[tree-sitter-systemverilog]: https://github.com/gmlarumbe/tree-sitter-systemverilog
+[verible]: https://github.com/chipsalliance/verible
+
+- Add Verilog support under 'vim.languages.verilog' using [verible-verilog-ls]
+  and [tree-sitter-systemverilog].

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -46,6 +46,7 @@ in {
     ./wgsl.nix
     ./yaml.nix
     ./ruby.nix
+    ./verilog.nix
 
     # This is now a hard deprecation.
     (mkRenamedOptionModule ["vim" "languages" "enableLSP"] ["vim" "lsp" "enable"])

--- a/modules/plugins/languages/verilog.nix
+++ b/modules/plugins/languages/verilog.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) package;
+  inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.verilog;
+in {
+  options.vim.languages.verilog = {
+    enable = mkEnableOption "Verilog support";
+
+    treesitter = {
+      enable =
+        mkEnableOption "Verilog treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+        };
+      package = mkGrammarOption pkgs "systemverilog";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "Verilog LSP support (verible)"
+        // {
+          default = config.vim.lsp.enable;
+        };
+
+      package = mkOption {
+        type = package;
+        default = pkgs.verible;
+        description = "verible package";
+      };
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp.lspconfig.enable = true;
+      vim.lsp.lspconfig.sources.verible = ''
+        lspconfig.verible.setup {
+          capabilities = capabilities,
+          on_attach = default_on_attach,
+          cmd = {"${cfg.lsp.package}/bin/verible-verilog-ls", "-sv", "-Wall"},
+        }
+      '';
+    })
+  ]);
+}


### PR DESCRIPTION
Add basic Verilog support using [Verible](https://github.com/chipsalliance/verible) and [tree-setter-systemverilog](https://github.com/gmlarumbe/tree-sitter-systemverilog). 
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
