### PR TITLE
language/{astro,svelte}: fix missing self arg

### DIFF
--- a/modules/plugins/languages/astro.nix
+++ b/modules/plugins/languages/astro.nix
@@ -1,5 +1,5 @@
 {
-  self,
+  inputs,
   config,
   pkgs,
   lib,
@@ -43,7 +43,7 @@
 
   defaultFormat = ["prettier"];
   formats = let
-    parser = "${self.packages.${pkgs.stdenv.hostPlatform.system}.prettier-plugin-astro}/index.js";
+    parser = "${inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.prettier-plugin-astro}/index.js";
   in {
     prettier = {
       command = getExe pkgs.prettier;

--- a/modules/plugins/languages/svelte.nix
+++ b/modules/plugins/languages/svelte.nix
@@ -1,5 +1,5 @@
 {
-  self,
+  inputs,
   config,
   pkgs,
   lib,
@@ -56,7 +56,7 @@
 
   defaultFormat = ["prettier"];
   formats = let
-    prettierPlugin = self.packages.${pkgs.stdenv.system}.prettier-plugin-svelte;
+    prettierPlugin = inputs.self.packages.${pkgs.stdenv.system}.prettier-plugin-svelte;
     prettierPluginPath = "${prettierPlugin}/lib/node_modules/prettier-plugin-svelte/plugin.js";
   in {
     prettier = {


### PR DESCRIPTION
supersedes #1280 

fixes #1272 

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
