### PR TITLE
treesitter: add compatibility layer for master

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -39,4 +39,5 @@
 
 [jtliang24](https://github.com/jtliang24):
 
-- Updated nix language plugin to use pkgs.nixfmt instead of pkgs.nixfmt-rfc-style
+- Updated nix language plugin to use pkgs.nixfmt instead of
+  pkgs.nixfmt-rfc-style

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -24,27 +24,33 @@ in {
       pluginRC.treesitter-autocommands = entryAfter ["basic"] ''
         vim.api.nvim_create_augroup("nvf_treesitter", { clear = true })
 
-        ${lib.optionalString cfg.highlight.enable ''
-          -- Enable treesitter highlighting for all filetypes
-          vim.api.nvim_create_autocmd("FileType", {
-            group = "nvf_treesitter",
-            pattern = "*",
-            callback = function()
-              pcall(vim.treesitter.start)
-            end,
-          })
-        ''}
+        local has_configs_module = pcall(require, 'nvim-treesitter.configs')
 
-        ${lib.optionalString cfg.indent.enable ''
-          -- Enable treesitter highlighting for all filetypes
-          vim.api.nvim_create_autocmd("FileType", {
-            group = "nvf_treesitter",
-            pattern = "*",
-            callback = function()
-              vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
-            end,
+        if has_configs_module then
+          -- nvim-treesitter master branch
+          require('nvim-treesitter.configs').setup({
+            ${lib.optionalString cfg.highlight.enable ''
+              highlight = { enable = true },
+            ''}${lib.optionalString cfg.indent.enable ''
+              indent = { enable = true },
+            ''}
           })
-        ''}
+        else
+          -- nvim-treesitter main branch
+          ${lib.optionalString (cfg.highlight.enable || cfg.indent.enable) ''
+            vim.api.nvim_create_autocmd("FileType", {
+              group = "nvf_treesitter",
+              pattern = "*",
+              callback = function()
+                ${lib.optionalString cfg.highlight.enable ''
+                  pcall(vim.treesitter.start)
+                ''}${lib.optionalString cfg.indent.enable ''
+                  vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+                ''}
+              end,
+            })
+          ''}
+        end
 
         ${lib.optionalString cfg.fold ''
           -- Enable treesitter folding for all filetypes

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -28,28 +28,31 @@ in {
 
         if has_configs_module then
           -- nvim-treesitter master branch
-          require('nvim-treesitter.configs').setup({
+          require('nvim-treesitter.configs').setup(vim.tbl_deep_extend("force", {
             ${lib.optionalString cfg.highlight.enable ''
-              highlight = { enable = true },
-            ''}${lib.optionalString cfg.indent.enable ''
-              indent = { enable = true },
-            ''}
-          })
+          highlight = { enable = true },
+        ''}${lib.optionalString cfg.indent.enable ''
+          indent = { enable = true },
+        ''}
+          }, ${lib.nvim.lua.toLuaObject cfg.setupOpts}))
         else
           -- nvim-treesitter main branch
+          ${lib.optionalString (cfg.setupOpts != {}) ''
+          require('nvim-treesitter').setup(${lib.nvim.lua.toLuaObject cfg.setupOpts})
+        ''}
           ${lib.optionalString (cfg.highlight.enable || cfg.indent.enable) ''
-            vim.api.nvim_create_autocmd("FileType", {
-              group = "nvf_treesitter",
-              pattern = "*",
-              callback = function()
-                ${lib.optionalString cfg.highlight.enable ''
-                  pcall(vim.treesitter.start)
-                ''}${lib.optionalString cfg.indent.enable ''
-                  vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
-                ''}
-              end,
-            })
+          vim.api.nvim_create_autocmd("FileType", {
+            group = "nvf_treesitter",
+            pattern = "*",
+            callback = function()
+              ${lib.optionalString cfg.highlight.enable ''
+            pcall(vim.treesitter.start)
+          ''}${lib.optionalString cfg.indent.enable ''
+            vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
           ''}
+            end,
+          })
+        ''}
         end
 
         ${lib.optionalString cfg.fold ''

--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -5,6 +5,7 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption literalExpression;
   inherit (lib.types) listOf package bool;
+  inherit (lib.nvim.types) mkPluginSetupOption;
 in {
   options.vim.treesitter = {
     enable = mkEnableOption "treesitter, also enabled automatically through language options";
@@ -66,5 +67,7 @@ in {
 
     indent = {enable = mkEnableOption "indentation with treesitter" // {default = true;};};
     highlight = {enable = mkEnableOption "highlighting with treesitter" // {default = true;};};
+
+    setupOpts = mkPluginSetupOption "nvim-treesitter" {};
   };
 }


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->


Add a compatibility layer for master branch, both for 25.11 users and unstable which want to keep using `nvim-treesitter-legacy` package

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/release-notes
[hacking nvf]: https://notashelf.github.io/nvf/index.xhtml#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
