### PR TITLE
editorconfig: remove rule conflicting with deno fmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,6 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = false
-max_line_length = 80
 
 [*.{js,json,nix,yml,yaml,toml}]
 indent_style = space


### PR DESCRIPTION
reverts #1351 

so deno fmt actually allows lines longer than 80...:

https://github.com/NotAShelf/nvf/blob/18c55d3bebf2c704970b4ea6fd0261808bec8d94/docs/manual/release-notes/rl-0.9.md?plain=1#L83