### PR TITLE
doc: add textwidth modeline in release-note

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -150,3 +150,5 @@
 
 - Added [Selenen](https://github.com/kampfkarren/selene) for more diagnostics in
   `languages.lua`.
+
+<!-- vim: set textwidth=80: -->


### PR DESCRIPTION
I'm not giving up on #1351...

this time using vim modeline so CI doesn't choke