### PR TITLE
language/docker: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -79,6 +79,7 @@ isMaximal: {
       toml.enable = isMaximal;
       xml.enable = isMaximal;
       tex.enable = isMaximal;
+      docker.enable = isMaximal;
 
       # Language modules that are not as common.
       openscad.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -315,13 +315,15 @@
   more flexibility in nvf and reuse of LSPs across languages. Dropped
   `deprecatedSingleOrListOf` in favor of `listOf` for the affected LSP options.
 
+- Added {option}`vim.lsp.presets.docker-language-server.enable` for Docker
+  support.
+
 - Added {option}`vim.lsp.presets.angular-language-server.enable` for Angular
   Template support.
 
 - Added {option}`vim.lsp.presets.vtsls.enable` for Vue TypeScript support.
 
 - Added {option}`vim.lsp.presets.vue-language-server.enable` for Vue Template
-  support.
 
 - Added {option}`vim.lsp.presets.some-sass-language-server.enable`.
 

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -341,6 +341,10 @@
 - Added [Selenen](https://github.com/kampfkarren/selene) for more diagnostics in
   `languages.lua`.
 
+- Added `languages.docker` for Docker and Docker-Compose support. Thanks to
+  [poseidon-rises](https://github.com/poseidon-rises) for creating most of it in
+  [!1104](https://github.com/NotAShelf/nvf/pull/1104).
+
 - Added [`mdformat`](https://mdformat.rtfd.io/) support to `languages.markdown`
   with the extensions for [GFM](https://github.github.com/gfm/),
   [front matter](https://www.markdownlang.com/advanced/frontmatter.html) and

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -66,6 +66,7 @@ in {
     ./fluent.nix
     ./openscad.nix
     ./jq.nix
+    ./docker.nix
 
     # This is now a hard deprecation.
     (mkRenamedOptionModule ["vim" "languages" "enableLSP"] ["vim" "lsp" "enable"])

--- a/modules/plugins/languages/docker.nix
+++ b/modules/plugins/languages/docker.nix
@@ -1,0 +1,166 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (builtins) attrNames;
+  inherit (lib) genAttrs;
+  inherit (lib.meta) getExe;
+  inherit (lib.options) mkEnableOption mkOption literalExpression;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum listOf;
+  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.generators) mkLuaInline;
+
+  cfg = config.vim.languages.docker;
+
+  defaultServers = ["docker-language-server"];
+  servers = ["docker-language-server"];
+
+  defaultFormat = ["dockerfmt"];
+  formats = {
+    dockerfmt = {
+      command = getExe pkgs.dockerfmt;
+    };
+  };
+
+  defaultDiagnosticsProvider = ["hadolint"];
+  diagnosticsProviders = {
+    hadolint = {
+      config.cmd = getExe (
+        pkgs.writeShellApplication {
+          name = "hadolint";
+          runtimeInputs = [pkgs.hadolint];
+          text = "hadolint -";
+        }
+      );
+    };
+  };
+in {
+  options.vim.languages.docker = {
+    enable = mkEnableOption "Docker language support";
+    treesitter = {
+      enable =
+        mkEnableOption "Docker treesitter support"
+        // {
+          default = config.vim.languages.enableTreesitter;
+          defaultText = literalExpression "config.vim.languages.enableTreesitter";
+        };
+      package = mkGrammarOption pkgs "dockerfile";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "Docker LSP support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
+      servers = mkOption {
+        type = listOf (enum servers);
+        default = defaultServers;
+        description = "Docker LSP server to use";
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "Dockerfile formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
+
+      type = mkOption {
+        type = listOf (enum (attrNames formats));
+        default = defaultFormat;
+        description = "Dockerfile formatter to use";
+      };
+    };
+
+    extraDiagnostics = {
+      enable =
+        mkEnableOption "extra Dockerfile diagnostics"
+        // {
+          default = config.vim.languages.enableExtraDiagnostics;
+        };
+
+      types = diagnostics {
+        langDesc = "Dockerfile";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkMerge [
+    {
+      vim.autocmds = [
+        # Without this the LSP doesn't understand them correctly
+        # and there are conflicts with the YAML LSP
+        {
+          desc = "Set Docker Compose filetype";
+          event = ["BufRead" "BufNewFile"];
+          pattern = [
+            "compose.yml"
+            "compose.yaml"
+            "docker-compose.yml"
+            "docker-compose.yaml"
+          ];
+          callback = mkLuaInline ''
+            vim.bo.filetype = "dockercompose"
+          '';
+        }
+      ];
+    }
+
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {
+          filetypes = [
+            "dockerfile"
+            "dockercompose"
+          ];
+        });
+      };
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft.dockerfile = cfg.format.type;
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft.dockerfile = cfg.extraDiagnostics.types;
+        linters = mkMerge (
+          map (name: {
+            ${name} = diagnosticsProviders.${name}.config;
+          })
+          cfg.extraDiagnostics.types
+        );
+      };
+    })
+  ];
+}

--- a/modules/plugins/languages/hcl.nix
+++ b/modules/plugins/languages/hcl.nix
@@ -16,7 +16,7 @@
   cfg = config.vim.languages.hcl;
 
   defaultServers = ["tofu-ls"];
-  servers = ["terraform-ls" "tofu-ls"];
+  servers = ["terraform-ls" "tofu-ls" "docker-language-server"];
 
   defaultFormat = ["hclfmt"];
   formats = {

--- a/modules/plugins/lsp/presets/default.nix
+++ b/modules/plugins/lsp/presets/default.nix
@@ -13,6 +13,7 @@
     ./cue.nix
     ./dart.nix
     ./deno.nix
+    ./docker-language-server.nix
     ./elixir-ls.nix
     ./elm-language-server.nix
     ./emmet-ls.nix

--- a/modules/plugins/lsp/presets/docker-language-server.nix
+++ b/modules/plugins/lsp/presets/docker-language-server.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkLspPresetEnableOption;
+
+  cfg = config.vim.lsp.presets.docker-language-server;
+in {
+  options.vim.lsp.presets.docker-language-server = {
+    enable = mkLspPresetEnableOption "docker-language-server" "Docker" [];
+  };
+
+  config = mkIf cfg.enable {
+    vim.lsp.servers.docker-language-server = {
+      enable = true;
+      cmd = [(getExe pkgs.docker-language-server) "start" "--stdio"];
+      root_markers = [
+        ".git"
+        "Dockerfile"
+        "docker-compose.yaml"
+        "docker-compose.yml"
+        "compose.yaml"
+        "compose.yml"
+        "docker-bake.json"
+        "docker-bake.hcl"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Adds support for docker, docker compose and also docker in terraform.

most if it was already created in #1104.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
