### PR TITLE
various: make `mkPackageOption` nullable for Treesitter grammars;  filter null grammars

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -6,6 +6,7 @@
   `vimPlugins.nvim-treesitter`. Namely, it changes from the frozen `master`
   branch to the new main branch. This change removes incremental selections, so
   it is no longer available.
+
 - [obsidian.nvim] now uses a maintained fork which has removed the `dir`
   setting. Use `workspaces` instead:
 
@@ -78,6 +79,8 @@
 [NotAShelf](https://github.com/notashelf):
 
 - Lazyload noice.nvim and nvim-web-devicons on `DeferredUIEnter`
+- Allow nulling treesitter packages for various language modules, filter `null`
+  values in `vim.treesitter.grammars`.
 
 [jfeo](https://github.com/jfeo):
 

--- a/lib/types/languages.nix
+++ b/lib/types/languages.nix
@@ -31,6 +31,7 @@
   mkGrammarOption = pkgs: grammar:
     mkPackageOption pkgs ["${grammar} treesitter"] {
       default = ["vimPlugins" "nvim-treesitter" "grammarPlugins" grammar];
+      nullable = true;
     };
 in {
   inherit diagnostics diagnosticSubmodule mkGrammarOption;

--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -24,7 +24,10 @@
     );
 
   # Build a given Treesitter grammar.
-  buildTreesitterPlug = grammars: vimPlugins.nvim-treesitter.withPlugins (_: grammars);
+  buildTreesitterPlug = grammars:
+    vimPlugins.nvim-treesitter.withPlugins (
+      _: builtins.filter (g: g != null) grammars
+    );
 
   pluginBuilders = {
     nvim-treesitter = buildTreesitterPlug config.vim.treesitter.grammars;


### PR DESCRIPTION
We now allow `null`ing grammar packages that use `mkGrammarOption` to allow toggling of misc grammars that are not critical to a language module. `null` values are filtered out before building plugins. This hopefully provides greater flexibility in language module configuration, and prevents errors from `null` grammars.