### PR TITLE
prettier-plugin-svelte: skip npm prune step; remove redundant build deps

### DIFF
--- a/flake/pkgs/by-name/prettier-plugin-svelte/package.nix
+++ b/flake/pkgs/by-name/prettier-plugin-svelte/package.nix
@@ -17,11 +17,12 @@ in
 
     npmDepsHash = "sha256-XVyLW0XDCvZCZxu8g1fP7fRfeU3Hz81o5FCi/i4BKQw=";
 
-    # FIXME: this probably also copies over build dependencies.
-    # Look at how other prettier plugins in nixpkgs do things. I couldn't get it to work
-    # and am out of time so good luck :)
-    preInstall = ''
-      mkdir -p $out/lib
-      cp -r node_modules $out
+    dontNpmPrune = true;
+
+    # Fixes error: Cannot find module 'prettier'
+    postInstall = ''
+      pushd "$nodeModulesPath"
+      find -mindepth 1 -maxdepth 1 -type d -print0 | grep --null-data -Exv "\./(ulid|prettier)" | xargs -0 rm -rfv
+      popd
     '';
   })


### PR DESCRIPTION
Supersedes #1517 