### PR TITLE
fix: lib.strings.toString does not exist in nixpkgs, replaced with bu…

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -10,7 +10,7 @@
   extraModules ? [],
   configuration ? {},
 }: let
-  inherit (lib.strings) toString;
+  inherit (builtins) toString;
   inherit (lib.lists) concatLists;
 
   # import modules.nix with `check`, `pkgs` and `lib` as arguments


### PR DESCRIPTION
Usage of non-existent func `lib.strings.toString` was causing an error when accessing `modulesPath`, such as in the below example use case, causing this codepath to be evaluated and ultimately causing an error since this no longer exists @ `nixpkgs.lib.strings.toString`. My change simply accesses the function @ `builtins.toString` instead.

## Example use case of the broken codepath:
```nix
{modulesPath, ...}: {
  disabledModules = [
    "${modulesPath}/plugins/mini/comment"
    "${modulesPath}/plugins/mini/git"
    "${modulesPath}/plugins/mini/hipatterns"
    "${modulesPath}/plugins/mini/sessions"
    "${modulesPath}/plugins/mini/statusline"
    "${modulesPath}/plugins/mini/tabline"
  ];

  imports = [
    ./blink-indent
    ./blink-pairs
    ./files
    ./highlighter
    ./mini
    ./render-markdown
    ./spider
    ./ts-textobjects
    ./usercmds
    ./nvim-ts-autotag
    ./base24-theme.nix
  ];
}
```

## The error encountered
```bash
       … while evaluating the module argument `modulesPath' in "/nix/store/9q1mr2pm7s9gyjcrnmxwjiian86l0l03-source/modules":

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'toString' missing
       at «github:jules-sommer/nvf/5b4f9c63205e5b0ef180a2b0e4cc844111f96fa6?narHash=sha256-YLVqyn6LpFa%2Bh697TmZIk0qVIbe7MxMpL8UTF4K%2BefA%3D»/modules/default.nix:13:25:
           12| }: let
           13|   inherit (lib.strings) toString;
             |                         ^
           14|   inherit (lib.lists) concatLists;
       Did you mean isString?
```

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
