### PR TITLE
lsp/presets/qml-language-server: init

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -275,6 +275,9 @@
 
 - Added support for neovim 0.12's `ui2` feature via `vim.ui.ui2`
 
+- Added support for the `qml-language-server` package in `languages.qml` and the
+  new LSP preset for it
+
 [Machshev](https://github.com/machshev):
 
 - Added `ruff` and `ty` LSP support for Python under `programs.python`.

--- a/modules/plugins/languages/qml.nix
+++ b/modules/plugins/languages/qml.nix
@@ -17,7 +17,10 @@
   qmlPackage = pkgs.kdePackages.qtdeclarative;
 
   defaultServers = ["qmlls"];
-  servers = ["qmlls"];
+  servers = [
+    "qml-language-server"
+    "qmlls"
+  ];
 
   defaultFormat = ["qmlformat"];
   formats = {

--- a/modules/plugins/lsp/presets/default.nix
+++ b/modules/plugins/lsp/presets/default.nix
@@ -47,6 +47,7 @@
     ./pyrefly.nix
     ./pyright.nix
     ./python-lsp-server.nix
+    ./qml-language-server.nix
     ./qmlls.nix
     ./r-languageserver.nix
     ./roslyn-ls.nix

--- a/modules/plugins/lsp/presets/qml-language-server.nix
+++ b/modules/plugins/lsp/presets/qml-language-server.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkLspPresetEnableOption;
+
+  cfg = config.vim.lsp.presets.qmlls;
+in {
+  options.vim.lsp.presets.qml-language-server = {
+    enable = mkLspPresetEnableOption "qml-language-server" "QML" [];
+  };
+
+  config = mkIf cfg.enable {
+    vim.lsp.servers.qml-language-server = {
+      enable = true;
+      cmd = [(getExe pkgs.qml-language-server)];
+      root_markers = [
+        ".git"
+        "qmldir"
+        "shell.qml"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Opened as draft because this depends on https://github.com/NixOS/nixpkgs/pull/515608, which is not merged at time of PR.

Adds a QML language server that doesn't depend on qtdeclarative because i hate needing qtdeclarative for my nvim installation

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
