### PR TITLE
languages/clang: add formatting

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -406,6 +406,8 @@
 
 - Added `asmfmt` and `nasmfmt` formatters to `languages.asm`.
 
+- Added `astyle`, `indent` and `clang-format` to `languages.clang` formatters.
+
 - Added `biome-check` and `biome-organize-imports` formatters to `languages.ts`.
 
 - Added [`biomejs`](https://biomejs.dev/) as extra diagnostics provider to

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -8,9 +8,12 @@
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.types) bool enum package listOf;
   inherit (lib) genAttrs;
+  inherit (lib.meta) getExe getExe';
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.dag) entryAfter;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.clang;
 
@@ -44,6 +47,54 @@
         dap.configurations.c = dap.configurations.cpp
       '';
     };
+  };
+
+  defaultFormat = ["clang-format"];
+  formats = {
+    astyle = {
+      command = getExe pkgs.astyle;
+      stdin = false;
+      args = mkLuaInline ''
+        function(self, ctx)
+          local args = {
+            "$FILENAME",
+          }
+
+          if not vim.bo[ctx.buf].expandtab then
+            table.insert(args, "--indent=tab=" .. ctx.shiftwidth)
+          else
+            table.insert(args, "--indent=spaces=" .. ctx.shiftwidth)
+          end
+
+          return args
+        end
+      '';
+    };
+    indent = {
+      command = getExe pkgs.indent;
+      stdin = true;
+      args = mkLuaInline ''
+        function(self, ctx)
+          local args = {
+            "--indent-level", ctx.shiftwidth,
+            "--tab-size", ctx.shiftwidth,
+          }
+
+          if not vim.bo[ctx.buf].expandtab then
+            table.insert(args, "--use-tabs")
+          else
+            table.insert(args, "--no-tabs")
+          end
+
+          return args
+        end
+      '';
+      # Default is GNU style. Nobody likes that one.
+      # This is under `append_args`, to allow easy editing of this argument,
+      # without having to redefine everything as a user.
+      append_args = ["--linux-style"];
+    };
+    clang-format.command = getExe' pkgs.clang-tools "clang-format";
   };
 in {
   options.vim.languages.clang = {
@@ -102,6 +153,21 @@ in {
         default = debuggers.${cfg.dap.debugger}.package;
       };
     };
+
+    format = {
+      enable =
+        mkEnableOption "C formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
+
+      type = mkOption {
+        type = listOf (enum (attrNames formats));
+        default = defaultFormat;
+        description = "C formatter to use";
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -126,6 +192,24 @@ in {
     (mkIf cfg.dap.enable {
       vim.debugger.nvim-dap.enable = true;
       vim.debugger.nvim-dap.sources.clang-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft = {
+            c = cfg.format.type;
+            cpp = cfg.format.type;
+          };
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
     })
   ]);
 }


### PR DESCRIPTION
Adds formatters to C.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
