### PR TITLE
Factor out diagnostics like LSPs

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -346,6 +346,11 @@
 
 - Added `phpantom` LSP preset and into `languages.php`.
 
+- Moved extra diagnostic modules under `diagnostics.presets.<name>` this will
+  allow for more flexibility in the future for nvf.
+
+- Added {option}`vim.diagnostics.presets.cpplint.enable`.
+
 - Added {option}`vim.treesitter.queries` to support adding custom queries.
 
 - Added injections for `query = '' ... ''` as `query` and `mkLualine '' ... ''`,

--- a/lib/types/default.nix
+++ b/lib/types/default.nix
@@ -6,11 +6,13 @@
   typesPlugin = import ./plugins.nix {inherit lib self;};
   typesLanguage = import ./languages.nix {inherit lib;};
   typesLsp = import ./lsp.nix {inherit lib;};
+  typesDiagnostics = import ./diagnostics.nix {inherit lib;};
   customTypes = import ./custom.nix {inherit lib;};
 in {
   inherit (typesDag) dagOf;
   inherit (typesPlugin) pluginsOpt extraPluginType mkPluginSetupOption luaInline pluginType borderType;
-  inherit (typesLanguage) diagnostics mkGrammarOption mkTreesitterGrammarOption;
+  inherit (typesLanguage) mkGrammarOption mkTreesitterGrammarOption;
   inherit (typesLsp) mkLspPresetEnableOption;
+  inherit (typesDiagnostics) mkDiagnosticsPresetEnableOption;
   inherit (customTypes) char hexColor mergelessListOf deprecatedSingleOrListOf enumWithRename;
 }

--- a/lib/types/diagnostics.nix
+++ b/lib/types/diagnostics.nix
@@ -1,0 +1,11 @@
+{lib}: let
+  inherit (lib.options) mkEnableOption;
+
+  mkDiagnosticsPresetEnableOption = option: display:
+    mkEnableOption ''
+      the ${display} Diagnostics Provider.
+      Use {option}`vim.diagnostics.nvim-lint.linters.${option}` for customization
+    '';
+in {
+  inherit mkDiagnosticsPresetEnableOption;
+}

--- a/lib/types/languages.nix
+++ b/lib/types/languages.nix
@@ -1,32 +1,5 @@
 {lib}: let
-  inherit (lib.options) mkOption mkPackageOption;
-  inherit (lib.attrsets) attrNames;
-  inherit (lib.types) listOf either enum submodule package;
-
-  diagnosticSubmodule = _: {
-    options = {
-      type = mkOption {
-        description = "Type of diagnostic to enable";
-        type = attrNames diagnostics;
-      };
-
-      package = mkOption {
-        type = package;
-        description = "Diagnostics package";
-      };
-    };
-  };
-
-  diagnostics = {
-    langDesc,
-    diagnosticsProviders,
-    defaultDiagnosticsProvider,
-  }:
-    mkOption {
-      type = listOf (either (enum (attrNames diagnosticsProviders)) (submodule diagnosticSubmodule));
-      default = defaultDiagnosticsProvider;
-      description = "List of ${langDesc} diagnostics to enable";
-    };
+  inherit (lib.options) mkPackageOption;
 
   mkGrammarOption = pkgs: grammar:
     mkPackageOption pkgs ["${grammar} treesitter"] {
@@ -45,5 +18,5 @@
       nullable = true;
     };
 in {
-  inherit diagnostics diagnosticSubmodule mkGrammarOption mkTreesitterGrammarOption;
+  inherit mkGrammarOption mkTreesitterGrammarOption;
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -388,5 +388,13 @@ in {
         nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
       '')
     ]
+
+    # 2026-06-12
+    [
+      (mkRemovedOptionModule ["vim" "languages" "sql" "dialect"] ''
+        This option interfered with project level configurations.
+        Linters can still be customized via `vim.diagnostics.nvim-lint.<name>.args`
+      '')
+    ]
   ];
 }

--- a/modules/plugins/diagnostics/default.nix
+++ b/modules/plugins/diagnostics/default.nix
@@ -1,3 +1,6 @@
 {
-  imports = [./nvim-lint];
+  imports = [
+    ./nvim-lint
+    ./presets
+  ];
 }

--- a/modules/plugins/diagnostics/presets/biomejs.nix
+++ b/modules/plugins/diagnostics/presets/biomejs.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.biomejs;
+in {
+  options.vim.diagnostics.presets.biomejs = {
+    enable = mkDiagnosticsPresetEnableOption "biomejs" "Biome";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.biomejs.cmd = getExe pkgs.biome;
+  };
+}

--- a/modules/plugins/diagnostics/presets/checkmake.nix
+++ b/modules/plugins/diagnostics/presets/checkmake.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.checkmake;
+in {
+  options.vim.diagnostics.presets.checkmake = {
+    enable = mkDiagnosticsPresetEnableOption "checkmake" "Checkmake";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.checkmake.cmd = getExe pkgs.checkmake;
+  };
+}

--- a/modules/plugins/diagnostics/presets/cpplint.nix
+++ b/modules/plugins/diagnostics/presets/cpplint.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.cpplint;
+in {
+  options.vim.diagnostics.presets.cpplint = {
+    enable = mkDiagnosticsPresetEnableOption "cpplint" "cpplint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.cpplint.cmd = getExe pkgs.cpplint;
+  };
+}

--- a/modules/plugins/diagnostics/presets/deadnix.nix
+++ b/modules/plugins/diagnostics/presets/deadnix.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.deadnix;
+in {
+  options.vim.diagnostics.presets.deadnix = {
+    enable = mkDiagnosticsPresetEnableOption "deadnix" "Deadnix";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.deadnix.cmd = getExe pkgs.deadnix;
+  };
+}

--- a/modules/plugins/diagnostics/presets/default.nix
+++ b/modules/plugins/diagnostics/presets/default.nix
@@ -1,0 +1,29 @@
+{
+  imports = [
+    ./biomejs.nix
+    ./checkmake.nix
+    ./cpplint.nix
+    ./deadnix.nix
+    ./djlint.nix
+    ./dotenv-linter.nix
+    ./eslint_d.nix
+    ./golangci-lint.nix
+    ./hadolint.nix
+    ./htmlhint.nix
+    ./ktlint.nix
+    ./luacheck.nix
+    ./markdownlint-cli2.nix
+    ./mypy.nix
+    ./phpstan.nix
+    ./rubocop.nix
+    ./rumdl.nix
+    ./selene.nix
+    ./shellcheck.nix
+    ./sqlfluff.nix
+    ./sqruff.nix
+    ./statix.nix
+    ./stylelint.nix
+    ./taplo.nix
+    ./tombi.nix
+  ];
+}

--- a/modules/plugins/diagnostics/presets/djlint.nix
+++ b/modules/plugins/diagnostics/presets/djlint.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.djlint;
+in {
+  options.vim.diagnostics.presets.djlint = {
+    enable = mkDiagnosticsPresetEnableOption "djlint" "djLint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.djlint.cmd = getExe pkgs.djlint;
+  };
+}

--- a/modules/plugins/diagnostics/presets/dotenv-linter.nix
+++ b/modules/plugins/diagnostics/presets/dotenv-linter.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.dotenv-linter;
+in {
+  options.vim.diagnostics.presets.dotenv-linter = {
+    enable = mkDiagnosticsPresetEnableOption "dotenv-linter" "Dotenv Linter";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.dotenv-linter.cmd = getExe pkgs.dotenv-linter;
+  };
+}

--- a/modules/plugins/diagnostics/presets/eslint_d.nix
+++ b/modules/plugins/diagnostics/presets/eslint_d.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.eslint_d;
+in {
+  options.vim.diagnostics.presets.eslint_d = {
+    enable = mkDiagnosticsPresetEnableOption "eslint_d" "Eslint Daemon";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.eslint_d = {
+      cmd = getExe pkgs.eslint_d;
+      required_files = [
+        "eslint.config.js"
+        "eslint.config.mjs"
+        ".eslintrc"
+        ".eslintrc.json"
+        ".eslintrc.js"
+        ".eslintrc.yml"
+      ];
+    };
+  };
+}

--- a/modules/plugins/diagnostics/presets/golangci-lint.nix
+++ b/modules/plugins/diagnostics/presets/golangci-lint.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.golangci-lint;
+in {
+  options.vim.diagnostics.presets.golangci-lint = {
+    enable = mkDiagnosticsPresetEnableOption "golangci-lint" "GolangCI Lint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.golangci-lint = {
+      cmd = getExe pkgs.golangci-lint;
+      args = [
+        "run"
+        "--output.json.path=stdout"
+        "--issues-exit-code=0"
+        "--show-stats=false"
+        "--fix=false"
+        "--path-mode=abs"
+        # Overwrite values that could be configured and result in unwanted writes
+        "--output.text.path="
+        "--output.tab.path="
+        "--output.html.path="
+        "--output.checkstyle.path="
+        "--output.code-climate.path="
+        "--output.junit-xml.path="
+        "--output.teamcity.path="
+        "--output.sarif.path="
+        (mkLuaInline ''
+          -- Run on current file only if go.mod is missing
+          function()
+            local fnmod = ":p";
+            local cmd = {"${getExe pkgs.go}", "env", "GOMOD"};
+            local ok, gomod = pcall(vim.fn.system, cmd);
+            gomod = gomod:gsub("%s+", "")
+            if ok and gomod ~= "" and gomod ~= "/dev/null" then
+              fnmod = ":h";
+            end
+            return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), fnmod)
+          end
+        '')
+      ];
+      append_fname = false;
+      parser = mkLuaInline ''
+        function(output, bufnr)
+          local SOURCE = "golangci-lint";
+
+          local function display_tool_error(msg)
+            return{
+              {
+                bufnr = bufnr,
+                lnum = 0,
+                col = 0,
+                message = string.format("[%s] %s", SOURCE, msg),
+                severity = vim.diagnostic.severity.ERROR,
+                source = SOURCE,
+              },
+            }
+          end
+
+          if output == "" then
+            return display_tool_error("no output provided")
+          end
+
+          local ok, decoded = pcall(vim.json.decode, output)
+          if not ok then
+            return display_tool_error("failed to parse JSON output")
+          end
+
+          if not decoded or not decoded.Issues then
+            return display_tool_error("unexpected output format")
+          end
+
+          local severity_map = {
+            error   = vim.diagnostic.severity.ERROR,
+            warning = vim.diagnostic.severity.WARN,
+            info    = vim.diagnostic.severity.INFO,
+            hint    = vim.diagnostic.severity.HINT,
+          }
+          local diagnostics = {}
+          for _, issue in ipairs(decoded.Issues) do
+            local sev = vim.diagnostic.severity.ERROR
+            if issue.Severity and issue.Severity ~= "" then
+              local normalized = issue.Severity:lower()
+              sev = severity_map[normalized] or vim.diagnostic.severity.ERROR
+            end
+
+            local buffer = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
+            if vim.fs.normalize(buffer) == vim.fs.normalize(issue.Pos.Filename) then
+              table.insert(diagnostics, {
+                bufnr = bufnr,
+                lnum = issue.Pos.Line - 1,
+                col = issue.Pos.Column - 1,
+                message = issue.Text,
+                code = issue.FromLinter,
+                severity = sev,
+                source = SOURCE,
+              })
+            end
+          end
+          return diagnostics
+        end
+      '';
+    };
+  };
+}

--- a/modules/plugins/diagnostics/presets/hadolint.nix
+++ b/modules/plugins/diagnostics/presets/hadolint.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.hadolint;
+in {
+  options.vim.diagnostics.presets.hadolint = {
+    enable = mkDiagnosticsPresetEnableOption "hadolint" "Hadolint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.hadolint.cmd = getExe pkgs.hadolint;
+  };
+}

--- a/modules/plugins/diagnostics/presets/htmlhint.nix
+++ b/modules/plugins/diagnostics/presets/htmlhint.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.htmlhint;
+in {
+  options.vim.diagnostics.presets.htmlhint = {
+    enable = mkDiagnosticsPresetEnableOption "htmlhint" "HTMLHint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.htmlhint.cmd = getExe pkgs.htmlhint;
+  };
+}

--- a/modules/plugins/diagnostics/presets/ktlint.nix
+++ b/modules/plugins/diagnostics/presets/ktlint.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.ktlint;
+in {
+  options.vim.diagnostics.presets.ktlint = {
+    enable = mkDiagnosticsPresetEnableOption "ktlint" "ktlint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.ktlint.cmd = getExe pkgs.ktlint;
+  };
+}

--- a/modules/plugins/diagnostics/presets/luacheck.nix
+++ b/modules/plugins/diagnostics/presets/luacheck.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.luacheck;
+in {
+  options.vim.diagnostics.presets.luacheck = {
+    enable = mkDiagnosticsPresetEnableOption "luacheck" "Luacheck";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.luacheck.cmd = getExe pkgs.luajitPackages.luacheck;
+  };
+}

--- a/modules/plugins/diagnostics/presets/markdownlint-cli2.nix
+++ b/modules/plugins/diagnostics/presets/markdownlint-cli2.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.markdownlint-cli2;
+in {
+  options.vim.diagnostics.presets.markdownlint-cli2 = {
+    enable = mkDiagnosticsPresetEnableOption "markdownlint-cli2" "Markdownlint CLI 2";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.markdownlint-cli2.cmd = getExe pkgs.markdownlint-cli2;
+  };
+}

--- a/modules/plugins/diagnostics/presets/mypy.nix
+++ b/modules/plugins/diagnostics/presets/mypy.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe';
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.mypy;
+in {
+  options.vim.diagnostics.presets.mypy = {
+    enable = mkDiagnosticsPresetEnableOption "mypy" "Mypy";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.mypy.cmd = getExe' pkgs.mypy "mypy";
+  };
+}

--- a/modules/plugins/diagnostics/presets/phpstan.nix
+++ b/modules/plugins/diagnostics/presets/phpstan.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.phpstan;
+in {
+  options.vim.diagnostics.presets.phpstan = {
+    enable = mkDiagnosticsPresetEnableOption "phpstan" "PHPStan";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.phpstan.cmd = getExe pkgs.phpstan;
+  };
+}

--- a/modules/plugins/diagnostics/presets/rubocop.nix
+++ b/modules/plugins/diagnostics/presets/rubocop.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.rubocop;
+in {
+  options.vim.diagnostics.presets.rubocop = {
+    enable = mkDiagnosticsPresetEnableOption "rubocop" "RuboCop";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.rubocop.cmd = getExe pkgs.rubyPackages.rubocop;
+  };
+}

--- a/modules/plugins/diagnostics/presets/rumdl.nix
+++ b/modules/plugins/diagnostics/presets/rumdl.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.rumdl;
+in {
+  options.vim.diagnostics.presets.rumdl = {
+    enable = mkDiagnosticsPresetEnableOption "rumdl" "Rumdl";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.rumdl.cmd = getExe pkgs.rumdl;
+  };
+}

--- a/modules/plugins/diagnostics/presets/selene.nix
+++ b/modules/plugins/diagnostics/presets/selene.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.selene;
+in {
+  options.vim.diagnostics.presets.selene = {
+    enable = mkDiagnosticsPresetEnableOption "selene" "Selene";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.selene.cmd = getExe pkgs.selene;
+  };
+}

--- a/modules/plugins/diagnostics/presets/shellcheck.nix
+++ b/modules/plugins/diagnostics/presets/shellcheck.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.shellcheck;
+in {
+  options.vim.diagnostics.presets.shellcheck = {
+    enable = mkDiagnosticsPresetEnableOption "shellcheck" "Shellcheck";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.shellcheck.cmd = getExe pkgs.shellcheck;
+  };
+}

--- a/modules/plugins/diagnostics/presets/sqlfluff.nix
+++ b/modules/plugins/diagnostics/presets/sqlfluff.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.sqlfluff;
+in {
+  options.vim.diagnostics.presets.sqlfluff = {
+    enable = mkDiagnosticsPresetEnableOption "sqlfluff" "SQLFluff";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.sqlfluff = {
+      cmd = getExe pkgs.sqlfluff;
+      args = ["lint" "--format=json"];
+    };
+  };
+}

--- a/modules/plugins/diagnostics/presets/sqruff.nix
+++ b/modules/plugins/diagnostics/presets/sqruff.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.sqruff;
+in {
+  options.vim.diagnostics.presets.sqruff = {
+    enable = mkDiagnosticsPresetEnableOption "sqruff" "Sqruff";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.sqruff = {
+      cmd = getExe pkgs.sqruff;
+      args = ["lint" "--format=json" "-"];
+    };
+  };
+}

--- a/modules/plugins/diagnostics/presets/statix.nix
+++ b/modules/plugins/diagnostics/presets/statix.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.statix;
+in {
+  options.vim.diagnostics.presets.statix = {
+    enable = mkDiagnosticsPresetEnableOption "statix" "Statix";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.statix.cmd = getExe pkgs.statix;
+  };
+}

--- a/modules/plugins/diagnostics/presets/stylelint.nix
+++ b/modules/plugins/diagnostics/presets/stylelint.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.stylelint;
+in {
+  options.vim.diagnostics.presets.stylelint = {
+    enable = mkDiagnosticsPresetEnableOption "stylelint" "Stylelint";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.stylelint.cmd = getExe pkgs.stylelint;
+  };
+}

--- a/modules/plugins/diagnostics/presets/taplo.nix
+++ b/modules/plugins/diagnostics/presets/taplo.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.taplo;
+in {
+  options.vim.diagnostics.presets.taplo = {
+    enable = mkDiagnosticsPresetEnableOption "taplo" "Taplo";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.taplo = {
+      cmd = getExe pkgs.taplo;
+      args = ["lint"];
+    };
+  };
+}

--- a/modules/plugins/diagnostics/presets/tombi.nix
+++ b/modules/plugins/diagnostics/presets/tombi.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.tombi;
+in {
+  options.vim.diagnostics.presets.tombi = {
+    enable = mkDiagnosticsPresetEnableOption "tombi" "Tombi";
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.tombi = {
+      cmd = getExe pkgs.tombi;
+      args = ["lint"];
+    };
+  };
+}

--- a/modules/plugins/languages/astro.nix
+++ b/modules/plugins/languages/astro.nix
@@ -11,7 +11,7 @@
   inherit (lib.meta) getExe;
   inherit (lib.types) enum coercedTo listOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf enumWithRename;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf enumWithRename;
   inherit (lib) genAttrs;
 
   cfg = config.vim.languages.astro;
@@ -35,24 +35,7 @@
   };
 
   defaultDiagnosticsProvider = ["eslint_d"];
-  diagnosticsProviders = {
-    eslint_d = let
-      pkg = pkgs.eslint_d;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-        required_files = [
-          "eslint.config.js"
-          "eslint.config.mjs"
-          ".eslintrc"
-          ".eslintrc.json"
-          ".eslintrc.js"
-          ".eslintrc.yml"
-        ];
-      };
-    };
-  };
+  diagnosticsProviders = ["eslint_d"];
 
   formatType =
     deprecatedSingleOrListOf
@@ -113,16 +96,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Astro diagnostics"
+        mkEnableOption "extra Astro diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "Astro";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Astro diagnostics providers";
       };
     };
   };
@@ -158,12 +141,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.astro = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.astro = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/bash.nix
+++ b/modules/plugins/languages/bash.nix
@@ -10,7 +10,7 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum bool listOf;
   inherit (lib) genAttrs;
-  inherit (lib.nvim.types) diagnostics mkGrammarOption deprecatedSingleOrListOf enumWithRename;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf enumWithRename;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.bash;
@@ -26,11 +26,7 @@
   };
 
   defaultDiagnosticsProvider = ["shellcheck"];
-  diagnosticsProviders = {
-    shellcheck = {
-      package = pkgs.shellcheck;
-    };
-  };
+  diagnosticsProviders = ["shellcheck"];
 in {
   options.vim.languages.bash = {
     enable = mkEnableOption "Bash language support";
@@ -80,15 +76,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Bash diagnostics"
+        mkEnableOption "extra Shell diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "Bash";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Shell diagnostics providers";
       };
     };
   };
@@ -128,13 +125,16 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.sh = cfg.extraDiagnostics.types;
-        linters = mkMerge (map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft = {
+            sh = cfg.extraDiagnostics.types;
+            bash = cfg.extraDiagnostics.types;
+            zsh = cfg.extraDiagnostics.types;
+          };
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -96,6 +96,9 @@
     };
     clang-format.command = getExe' pkgs.clang-tools "clang-format";
   };
+
+  defaultDiagnosticsProvider = ["cpplint"];
+  diagnosticsProviders = ["cpplint"];
 in {
   options.vim.languages.clang = {
     enable = mkEnableOption "C/C++ language support";
@@ -168,6 +171,21 @@ in {
         description = "C formatter to use";
       };
     };
+
+    extraDiagnostics = {
+      enable =
+        mkEnableOption "extra C/C++ diagnostics via nvim-lint"
+        // {
+          default = config.vim.languages.enableExtraDiagnostics;
+          defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
+        };
+
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra C/C++ diagnostics providers";
+      };
+    };
   };
 
   config = mkIf cfg.enable (mkMerge [
@@ -208,6 +226,19 @@ in {
               value = formats.${name};
             })
             cfg.format.type;
+        };
+      };
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft = {
+            c = cfg.extraDiagnostics.types;
+            cpp = cfg.extraDiagnostics.types;
+          };
         };
       };
     })

--- a/modules/plugins/languages/docker.nix
+++ b/modules/plugins/languages/docker.nix
@@ -4,13 +4,12 @@
   lib,
   ...
 }: let
-  inherit (builtins) attrNames;
-  inherit (lib) genAttrs;
+  inherit (lib.attrsets) attrNames genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.docker;
@@ -26,17 +25,7 @@
   };
 
   defaultDiagnosticsProvider = ["hadolint"];
-  diagnosticsProviders = {
-    hadolint = {
-      config.cmd = getExe (
-        pkgs.writeShellApplication {
-          name = "hadolint";
-          runtimeInputs = [pkgs.hadolint];
-          text = "hadolint -";
-        }
-      );
-    };
-  };
+  diagnosticsProviders = ["hadolint"];
 in {
   options.vim.languages.docker = {
     enable = mkEnableOption "Docker language support";
@@ -81,15 +70,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Dockerfile diagnostics"
+        mkEnableOption "extra Docker diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
+          defaultText = literalExpression "config.vim.languages.enableExtraDiagnostic";
         };
 
-      types = diagnostics {
-        langDesc = "Dockerfile";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Docker diagnostics providers";
       };
     };
   };
@@ -151,15 +141,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.dockerfile = cfg.extraDiagnostics.types;
-        linters = mkMerge (
-          map (name: {
-            ${name} = diagnosticsProviders.${name}.config;
-          })
-          cfg.extraDiagnostics.types
-        );
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.dockerfile = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/env.nix
+++ b/modules/plugins/languages/env.nix
@@ -1,42 +1,33 @@
 {
   config,
-  pkgs,
   lib,
   ...
 }: let
-  inherit (lib.options) mkEnableOption literalExpression;
-  inherit (lib.meta) getExe;
+  inherit (lib.options) mkEnableOption literalExpression mkOption;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.types) diagnostics;
+  inherit (lib.attrsets) genAttrs;
+  inherit (lib.types) enum listOf;
 
   cfg = config.vim.languages.env;
 
   defaultDiagnosticsProvider = ["dotenv-linter"];
-  diagnosticsProviders = {
-    dotenv-linter = let
-      pkg = pkgs.dotenv-linter;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-      };
-    };
-  };
+  diagnosticsProviders = ["dotenv-linter"];
 in {
   options.vim.languages.env = {
     enable = mkEnableOption "Env language support";
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Env diagnostics"
+        mkEnableOption "extra Env diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
-          defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
+          defaultText = literalExpression "config.vim.languages.enableExtraDiagnostic";
         };
-      types = diagnostics {
-        langDesc = "Env";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Env diagnostics providers";
       };
     };
   };
@@ -58,12 +49,12 @@ in {
     }
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.env = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.env = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/go.nix
+++ b/modules/plugins/languages/go.nix
@@ -10,9 +10,8 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.meta) getExe;
   inherit (lib) genAttrs;
-  inherit (lib.generators) mkLuaInline;
   inherit (lib.types) enum package str listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf mkPluginSetupOption;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf mkPluginSetupOption;
   inherit (lib.nvim.dag) entryAfter;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
@@ -44,107 +43,7 @@
   };
 
   defaultDiagnosticsProvider = ["golangci-lint"];
-  diagnosticsProviders = {
-    golangci-lint = let
-      pkg = pkgs.golangci-lint;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-        args = [
-          "run"
-          "--output.json.path=stdout"
-          "--issues-exit-code=0"
-          "--show-stats=false"
-          "--fix=false"
-          "--path-mode=abs"
-          # Overwrite values that could be configured and result in unwanted writes
-          "--output.text.path="
-          "--output.tab.path="
-          "--output.html.path="
-          "--output.checkstyle.path="
-          "--output.code-climate.path="
-          "--output.junit-xml.path="
-          "--output.teamcity.path="
-          "--output.sarif.path="
-          (mkLuaInline ''
-            -- Run on current file only if go.mod is missing
-            function()
-              local fnmod = ":p";
-              local cmd = {"${getExe pkgs.go}", "env", "GOMOD"};
-              local ok, gomod = pcall(vim.fn.system, cmd);
-              gomod = gomod:gsub("%s+", "")
-              if ok and gomod ~= "" and gomod ~= "/dev/null" then
-                fnmod = ":h";
-              end
-              return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), fnmod)
-            end
-          '')
-        ];
-        append_fname = false;
-        parser = mkLuaInline ''
-          function(output, bufnr)
-            local SOURCE = "golangci-lint";
-
-            local function display_tool_error(msg)
-              return{
-                {
-                  bufnr = bufnr,
-                  lnum = 0,
-                  col = 0,
-                  message = string.format("[%s] %s", SOURCE, msg),
-                  severity = vim.diagnostic.severity.ERROR,
-                  source = SOURCE,
-                },
-              }
-            end
-
-            if output == "" then
-              return display_tool_error("no output provided")
-            end
-
-            local ok, decoded = pcall(vim.json.decode, output)
-            if not ok then
-              return display_tool_error("failed to parse JSON output")
-            end
-
-            if not decoded or not decoded.Issues then
-              return display_tool_error("unexpected output format")
-            end
-
-            local severity_map = {
-              error   = vim.diagnostic.severity.ERROR,
-              warning = vim.diagnostic.severity.WARN,
-              info    = vim.diagnostic.severity.INFO,
-              hint    = vim.diagnostic.severity.HINT,
-            }
-            local diagnostics = {}
-            for _, issue in ipairs(decoded.Issues) do
-              local sev = vim.diagnostic.severity.ERROR
-              if issue.Severity and issue.Severity ~= "" then
-                local normalized = issue.Severity:lower()
-                sev = severity_map[normalized] or vim.diagnostic.severity.ERROR
-              end
-
-              local buffer = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
-              if vim.fs.normalize(buffer) == vim.fs.normalize(issue.Pos.Filename) then
-                table.insert(diagnostics, {
-                  bufnr = bufnr,
-                  lnum = issue.Pos.Line - 1,
-                  col = issue.Pos.Column - 1,
-                  message = issue.Text,
-                  code = issue.FromLinter,
-                  severity = sev,
-                  source = SOURCE,
-                })
-              end
-            end
-            return diagnostics
-          end
-        '';
-      };
-    };
-  };
+  diagnosticsProviders = ["golangci-lint"];
 in {
   options.vim.languages.go = {
     enable = mkEnableOption "Go language support";
@@ -226,16 +125,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Go diagnostics"
+        mkEnableOption "extra Go diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostic";
         };
 
-      types = diagnostics {
-        langDesc = "Go";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Go diagnostics providers";
       };
     };
 
@@ -357,12 +256,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.go = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.go = cfg.extraDiagnostics.types;
+        };
       };
     })
 

--- a/modules/plugins/languages/html.nix
+++ b/modules/plugins/languages/html.nix
@@ -5,13 +5,12 @@
   ...
 }: let
   inherit (builtins) attrNames;
-  inherit (lib.meta) getExe;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) bool enum listOf;
   inherit (lib) genAttrs;
   inherit (lib.lists) optional;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
@@ -29,11 +28,7 @@
   };
 
   defaultDiagnosticsProvider = ["htmlhint"];
-  diagnosticsProviders = {
-    htmlhint = {
-      config.cmd = getExe pkgs.htmlhint;
-    };
-  };
+  diagnosticsProviders = ["htmlhint"];
 in {
   options.vim.languages.html = {
     enable = mkEnableOption "HTML language support";
@@ -83,16 +78,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra HTML diagnostics"
+        mkEnableOption "extra HTML diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "HTML";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra HTML diagnostics providers";
       };
     };
   };
@@ -138,13 +133,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.html = cfg.extraDiagnostics.types;
-        linters = mkMerge (map (name: {
-            ${name} = diagnosticsProviders.${name}.config;
-          })
-          cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.html = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/kotlin.nix
+++ b/modules/plugins/languages/kotlin.nix
@@ -6,11 +6,9 @@
 }: let
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.meta) getExe;
   inherit (lib) genAttrs;
   inherit (lib.types) enum listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
-  inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.nvim.types) mkGrammarOption;
 
   cfg = config.vim.languages.kotlin;
 
@@ -18,11 +16,7 @@
   servers = ["kotlin-language-server"];
 
   defaultDiagnosticsProvider = ["ktlint"];
-  diagnosticsProviders = {
-    ktlint = {
-      package = pkgs.ktlint;
-    };
-  };
+  diagnosticsProviders = ["ktlint"];
 in {
   options.vim.languages.kotlin = {
     enable = mkEnableOption "Kotlin/HCL support";
@@ -53,16 +47,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Kotlin diagnostics"
+        mkEnableOption "extra Kotlin diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "Kotlin";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Kotlin diagnostics providers";
       };
     };
   };
@@ -73,13 +67,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.kotlin = cfg.extraDiagnostics.types;
-        linters = mkMerge (map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.kotlin = cfg.extraDiagnostics.types;
+        };
       };
     })
 

--- a/modules/plugins/languages/lua.nix
+++ b/modules/plugins/languages/lua.nix
@@ -10,7 +10,7 @@
   inherit (lib.meta) getExe;
   inherit (lib) genAttrs;
   inherit (lib.types) bool enum listOf;
-  inherit (lib.nvim.types) diagnostics mkGrammarOption;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.dag) entryBefore;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
@@ -27,14 +27,7 @@
   };
 
   defaultDiagnosticsProvider = ["luacheck"];
-  diagnosticsProviders = {
-    luacheck = {
-      package = pkgs.luajitPackages.luacheck;
-    };
-    selene = {
-      package = pkgs.selene;
-    };
-  };
+  diagnosticsProviders = ["luacheck" "selene"];
 in {
   imports = [
     (lib.mkRemovedOptionModule ["vim" "languages" "lua" "lsp" "neodev"] ''
@@ -86,15 +79,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Lua diagnostics"
+        mkEnableOption "extra Lua diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "Lua";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Lua diagnostics providers";
       };
     };
   };
@@ -143,13 +136,12 @@ in {
       })
 
       (mkIf cfg.extraDiagnostics.enable {
-        vim.diagnostics.nvim-lint = {
-          enable = true;
-          linters_by_ft.lua = cfg.extraDiagnostics.types;
-          linters = mkMerge (map (name: {
-              ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-            })
-            cfg.extraDiagnostics.types);
+        vim.diagnostics = {
+          presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+          nvim-lint = {
+            enable = true;
+            linters_by_ft.lua = cfg.extraDiagnostics.types;
+          };
         };
       })
     ]))

--- a/modules/plugins/languages/make.nix
+++ b/modules/plugins/languages/make.nix
@@ -6,10 +6,10 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.meta) getExe;
   inherit (lib.types) listOf enum;
+  inherit (lib) genAttrs;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.make;
@@ -22,13 +22,7 @@
   };
 
   defaultDiagnosticsProvider = ["checkmake"];
-  diagnosticsProviders = {
-    checkmake = {
-      config = {
-        cmd = getExe pkgs.checkmake;
-      };
-    };
-  };
+  diagnosticsProviders = ["checkmake"];
 in {
   options.vim.languages.make = {
     enable = mkEnableOption "Make support";
@@ -59,15 +53,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Make diagnostics"
+        mkEnableOption "extra Make diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "Make";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Make diagnostics providers";
       };
     };
   };
@@ -96,12 +90,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.make = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.make = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -11,7 +11,7 @@
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.types) bool enum listOf str nullOr;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.types) diagnostics mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf;
+  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf;
   inherit (lib.nvim.dag) entryAnywhere;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.trivial) warn;
@@ -46,14 +46,7 @@
     };
   };
   defaultDiagnosticsProvider = ["markdownlint-cli2"];
-  diagnosticsProviders = {
-    markdownlint-cli2 = {
-      package = pkgs.markdownlint-cli2;
-    };
-    rumdl = {
-      package = pkgs.rumdl;
-    };
-  };
+  diagnosticsProviders = ["markdownlint-cli2" "rumdl"];
 in {
   options.vim.languages.markdown = {
     enable = mkEnableOption "Markdown markup language support";
@@ -146,15 +139,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Markdown diagnostics"
+        mkEnableOption "extra Markdown diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "Markdown";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Markdown diagnostics providers";
       };
     };
   };
@@ -214,13 +207,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.markdown = cfg.extraDiagnostics.types;
-        linters = mkMerge (map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.markdown = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -10,7 +10,7 @@
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.nix;
@@ -30,31 +30,7 @@
   };
 
   defaultDiagnosticsProvider = ["statix" "deadnix"];
-  diagnosticsProviders = {
-    statix = {
-      package = pkgs.statix;
-      nullConfig = pkg: ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.diagnostics.statix.with({
-            command = "${pkg}/bin/statix",
-          })
-        )
-      '';
-    };
-
-    deadnix = {
-      package = pkgs.deadnix;
-      nullConfig = pkg: ''
-        table.insert(
-          ls_sources,
-          null_ls.builtins.diagnostics.deadnix.with({
-            command = "${pkg}/bin/deadnix",
-          })
-        )
-      '';
-    };
-  };
+  diagnosticsProviders = ["statix" "deadnix"];
 in {
   options.vim.languages.nix = {
     enable = mkEnableOption "Nix language support";
@@ -100,16 +76,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Nix diagnostics"
+        mkEnableOption "extra Nix diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "Nix";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Nix diagnostics providers";
       };
     };
   };
@@ -220,13 +196,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.nix = cfg.extraDiagnostics.types;
-        linters = mkMerge (map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.nix = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/php.nix
+++ b/modules/plugins/languages/php.nix
@@ -4,14 +4,14 @@
   lib,
   ...
 }: let
-  inherit (builtins) attrNames toString;
+  inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum int attrs listOf;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.php;
@@ -35,12 +35,7 @@
   };
 
   defaultDiagnosticsProvider = ["phpstan"];
-
-  diagnosticsProviders = {
-    phpstan = {
-      config.cmd = getExe pkgs.phpstan;
-    };
-  };
+  diagnosticsProviders = ["phpstan"];
 in {
   options.vim.languages.php = {
     enable = mkEnableOption "PHP language support";
@@ -114,16 +109,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra PHP diagnostics"
+        mkEnableOption "extra PHP diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
-          defaultText = literalExpression "config.vim.languages.enableExtraDiagnostic";
+          defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-
-      types = diagnostics {
-        langDesc = "PHP";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra PHP diagnostics providers";
       };
     };
   };
@@ -179,12 +173,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.php = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.php = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -8,11 +8,11 @@
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.lists) flatten;
   inherit (lib) genAttrs;
-  inherit (lib.meta) getExe getExe';
+  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum package bool listOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
-  inherit (lib.nvim.types) deprecatedSingleOrListOf diagnostics;
+  inherit (lib.nvim.types) deprecatedSingleOrListOf;
   inherit (lib.trivial) warn;
 
   cfg = config.vim.languages.python;
@@ -112,13 +112,7 @@
     };
   };
   defaultDiagnosticsProvider = ["mypy"];
-  diagnosticsProviders = {
-    mypy = {
-      config = {
-        cmd = getExe' pkgs.mypy "mypy";
-      };
-    };
-  };
+  diagnosticsProviders = ["mypy"];
 in {
   options.vim.languages.python = {
     enable = mkEnableOption "Python language support";
@@ -195,15 +189,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Python diagnostics"
+        mkEnableOption "extra Python diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "Python";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Python diagnostics providers";
       };
     };
   };
@@ -261,12 +255,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.python = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.python = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/ruby.nix
+++ b/modules/plugins/languages/ruby.nix
@@ -9,7 +9,7 @@
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf enumWithRename;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf enumWithRename;
   inherit (lib.types) enum listOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
@@ -28,11 +28,7 @@
   };
 
   defaultDiagnosticsProvider = ["rubocop"];
-  diagnosticsProviders = {
-    rubocop = {
-      package = pkgs.rubyPackages.rubocop;
-    };
-  };
+  diagnosticsProviders = ["rubocop"];
 in {
   options.vim.languages.ruby = {
     enable = mkEnableOption "Ruby language support";
@@ -79,13 +75,13 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "Ruby extra diagnostics support"
+        mkEnableOption "Ruby extra diagnostics via nvim-lint"
         // {default = config.vim.languages.enableExtraDiagnostics;};
 
-      types = diagnostics {
-        langDesc = "Ruby";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Ruby diagnostics providers";
       };
     };
   };
@@ -121,13 +117,15 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.ruby = cfg.extraDiagnostics.types;
-        linters = mkMerge (map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft = {
+            ruby = cfg.extraDiagnostics.types;
+            eruby = cfg.extraDiagnostics.types;
+          };
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/scss.nix
+++ b/modules/plugins/languages/scss.nix
@@ -10,7 +10,7 @@
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.scss;
@@ -30,13 +30,7 @@
   };
 
   defaultDiagnosticsProvider = ["stylelint"];
-  diagnosticsProviders = {
-    stylelint = {
-      config = {
-        cmd = getExe pkgs.stylelint;
-      };
-    };
-  };
+  diagnosticsProviders = ["stylelint"];
 in {
   options.vim.languages.scss = {
     enable = mkEnableOption "SCSS/SASS language support";
@@ -82,15 +76,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra SCSS/SASS diagnostics"
+        mkEnableOption "extra SCSS/SASS diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "SCSS";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra SCSS/SASS diagnostics providers";
       };
     };
   };
@@ -130,13 +124,15 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.scss = cfg.extraDiagnostics.types;
-        linters_by_ft.sass = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft = {
+            scss = cfg.extraDiagnostics.types;
+            sass = cfg.extraDiagnostics.types;
+          };
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/sql.nix
+++ b/modules/plugins/languages/sql.nix
@@ -9,8 +9,8 @@
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.types) enum package str listOf;
-  inherit (lib.nvim.types) diagnostics deprecatedSingleOrListOf;
+  inherit (lib.types) enum package listOf;
+  inherit (lib.nvim.types) deprecatedSingleOrListOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.sql;
@@ -24,40 +24,17 @@
   formats = {
     sqlfluff = {
       command = getExe sqlfluffDefault;
-      append_args = ["--dialect=${cfg.dialect}"];
     };
     sqruff = {
       command = getExe sqruffDefault;
-      append_args = ["--dialect=${cfg.dialect}"];
     };
   };
 
   defaultDiagnosticsProvider = ["sqlfluff"];
-  diagnosticsProviders = {
-    sqlfluff = {
-      package = sqlfluffDefault;
-      config = {
-        cmd = getExe sqlfluffDefault;
-        args = ["lint" "--format=json" "--dialect=${cfg.dialect}"];
-      };
-    };
-    sqruff = {
-      package = sqruffDefault;
-      config = {
-        cmd = getExe sqruffDefault;
-        args = ["lint" "--format=json" "--dialect=${cfg.dialect}" "-"];
-      };
-    };
-  };
+  diagnosticsProviders = ["sqlfluff" "sqruff"];
 in {
   options.vim.languages.sql = {
     enable = mkEnableOption "SQL language support";
-
-    dialect = mkOption {
-      type = str;
-      default = "ansi";
-      description = "SQL dialect for formatters and diagnostics (if used)";
-    };
 
     treesitter = {
       enable =
@@ -106,16 +83,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra SQL diagnostics"
+        mkEnableOption "extra SQL diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "SQL";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra SQL diagnostics providers";
       };
     };
   };
@@ -153,12 +130,14 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.sql = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {
+          enable = true;
+        });
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.sql = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/svelte.nix
+++ b/modules/plugins/languages/svelte.nix
@@ -11,7 +11,7 @@
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.types) enum coercedTo listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics deprecatedSingleOrListOf;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.svelte;
@@ -35,26 +35,8 @@
     };
   };
 
-  # TODO: specify packages
   defaultDiagnosticsProvider = ["eslint_d"];
-  diagnosticsProviders = {
-    eslint_d = let
-      pkg = pkgs.eslint_d;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-        required_files = [
-          "eslint.config.js"
-          "eslint.config.mjs"
-          ".eslintrc"
-          ".eslintrc.json"
-          ".eslintrc.js"
-          ".eslintrc.yml"
-        ];
-      };
-    };
-  };
+  diagnosticsProviders = ["eslint_d"];
 
   formatType =
     deprecatedSingleOrListOf
@@ -111,16 +93,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Svelte diagnostics"
+        mkEnableOption "extra Svelte diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "Svelte";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Svelte diagnostics providers";
       };
     };
   };
@@ -156,12 +138,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.svelte = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.svelte = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/toml.nix
+++ b/modules/plugins/languages/toml.nix
@@ -10,7 +10,7 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.types) enum listOf;
-  inherit (lib.nvim.types) diagnostics mkGrammarOption deprecatedSingleOrListOf;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.toml;
@@ -39,12 +39,7 @@
     };
   };
   defaultDiagnosticsProvider = ["tombi"];
-  diagnosticsProviders = {
-    tombi = {
-      package = pkgs.tombi;
-      args = ["lint"];
-    };
-  };
+  diagnosticsProviders = ["tombi" "taplo"];
 in {
   options.vim.languages.toml = {
     enable = mkEnableOption "TOML configuration language support";
@@ -91,15 +86,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra TOML diagnostics"
+        mkEnableOption "extra TOML diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "TOML";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra TOML diagnostics providers";
       };
     };
   };
@@ -137,15 +132,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.toml = cfg.extraDiagnostics.types;
-        linters = mkMerge (
-          map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types
-        );
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.toml = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/tsx.nix
+++ b/modules/plugins/languages/tsx.nix
@@ -10,7 +10,7 @@
   inherit (lib.attrsets) attrNames genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.nvim.attrsets) mapListToAttrs;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
 
   cfg = config.vim.languages.tsx;
 
@@ -41,16 +41,7 @@
   };
 
   defaultDiagnosticsProvider = ["biomejs"];
-  diagnosticsProviders = {
-    biomejs = let
-      pkg = pkgs.biome;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-      };
-    };
-  };
+  diagnosticsProviders = ["biomejs"];
 in {
   options.vim.languages.tsx = {
     enable = mkEnableOption "Typescript XML (TSX) language support";
@@ -95,12 +86,12 @@ in {
     };
 
     extraDiagnostics = {
-      enable = mkEnableOption "extra Typescript XML (TSX) diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+      enable = mkEnableOption "extra Typescript XML (TSX) diagnostics via nvim-lint" // {default = config.vim.languages.enableExtraDiagnostics;};
 
-      types = diagnostics {
-        langDesc = "Typescript XML (TSX)";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Typescript XML (TSX) diagnostics providers";
       };
     };
   };
@@ -144,15 +135,15 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft = {
-          typescriptreact = cfg.extraDiagnostics.types;
-          javascriptreact = cfg.extraDiagnostics.types;
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft = {
+            typescriptreact = cfg.extraDiagnostics.types;
+            javascriptreact = cfg.extraDiagnostics.types;
+          };
         };
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
       };
     })
   ]);

--- a/modules/plugins/languages/twig.nix
+++ b/modules/plugins/languages/twig.nix
@@ -10,7 +10,7 @@
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.types) listOf enum;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.twig;
@@ -26,14 +26,8 @@
     # TODO: if twig-cs-fixer gets packaged for nix, add it and default to it.
   };
   defaultDiagnosticsProvider = ["djlint"];
-  diagnosticsProviders = {
-    djlint = {
-      config = {
-        cmd = getExe pkgs.djlint;
-      };
-    };
-    # TODO: if curlylint gets packaged for nix, add it.
-  };
+  # TODO: if curlylint gets packaged for nix, add it.
+  diagnosticsProviders = ["djlint"];
 in {
   options.vim.languages.twig = {
     enable = mkEnableOption "Twig templating language support";
@@ -78,15 +72,15 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Twig diagnostics"
+        mkEnableOption "extra Twig diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
-      types = diagnostics {
-        langDesc = "Twig";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Twig diagnostics providers";
       };
     };
   };
@@ -122,12 +116,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.twig = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.twig = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);

--- a/modules/plugins/languages/typescript.nix
+++ b/modules/plugins/languages/typescript.nix
@@ -12,7 +12,7 @@
   inherit (lib.types) enum bool listOf;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics mkPluginSetupOption enumWithRename;
+  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption enumWithRename;
   inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.languages.typescript;
@@ -44,35 +44,8 @@
     };
   };
 
-  # TODO: specify packages
   defaultDiagnosticsProvider = ["eslint_d"];
-  diagnosticsProviders = {
-    eslint_d = let
-      pkg = pkgs.eslint_d;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-        required_files = [
-          "eslint.config.js"
-          "eslint.config.mjs"
-          ".eslintrc"
-          ".eslintrc.cjs"
-          ".eslintrc.json"
-          ".eslintrc.js"
-          ".eslintrc.yml"
-        ];
-      };
-    };
-    biomejs = let
-      pkg = pkgs.biome;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-      };
-    };
-  };
+  diagnosticsProviders = ["eslint_d" "biomejs"];
 in {
   options.vim.languages.typescript = {
     enable = mkEnableOption "Typescript/Javascript language support";
@@ -128,10 +101,10 @@ in {
     extraDiagnostics = {
       enable = mkEnableOption "extra Typescript/Javascript diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
 
-      types = diagnostics {
-        langDesc = "Typescript/Javascript";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Typescript/Javascript diagnostics providers";
       };
     };
 
@@ -197,12 +170,14 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.typescript = cfg.extraDiagnostics.types;
-        linters =
-          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
-            cfg.extraDiagnostics.types);
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft = {
+            typescript = cfg.extraDiagnostics.types;
+          };
+        };
       };
     })
 

--- a/modules/plugins/languages/vue.nix
+++ b/modules/plugins/languages/vue.nix
@@ -10,7 +10,7 @@
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.types) enum listOf;
-  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
   cfg = config.vim.languages.vue;
@@ -34,16 +34,7 @@
   };
 
   defaultDiagnosticsProvider = ["biomejs"];
-  diagnosticsProviders = {
-    biomejs = let
-      pkg = pkgs.biome;
-    in {
-      package = pkg;
-      config = {
-        cmd = getExe pkg;
-      };
-    };
-  };
+  diagnosticsProviders = ["biomejs"];
 in {
   options.vim.languages.vue = {
     enable = mkEnableOption "Vue.js language support";
@@ -91,16 +82,16 @@ in {
 
     extraDiagnostics = {
       enable =
-        mkEnableOption "extra Vue.js diagnostics"
+        mkEnableOption "extra Vue.js diagnostics via nvim-lint"
         // {
           default = config.vim.languages.enableExtraDiagnostics;
           defaultText = literalExpression "config.vim.languages.enableExtraDiagnostics";
         };
 
-      types = diagnostics {
-        langDesc = "Vue.js";
-        inherit diagnosticsProviders;
-        inherit defaultDiagnosticsProvider;
+      types = mkOption {
+        type = listOf (enum diagnosticsProviders);
+        default = defaultDiagnosticsProvider;
+        description = "extra Vue.js diagnostics providers";
       };
     };
   };
@@ -136,15 +127,12 @@ in {
     })
 
     (mkIf cfg.extraDiagnostics.enable {
-      vim.diagnostics.nvim-lint = {
-        enable = true;
-        linters_by_ft.vue = cfg.extraDiagnostics.types;
-        linters = mkMerge (
-          map (name: {
-            ${name}.cmd = getExe diagnosticsProviders.${name}.package;
-          })
-          cfg.extraDiagnostics.types
-        );
+      vim.diagnostics = {
+        presets = genAttrs cfg.extraDiagnostics.types (_: {enable = true;});
+        nvim-lint = {
+          enable = true;
+          linters_by_ft.vue = cfg.extraDiagnostics.types;
+        };
       };
     })
   ]);


### PR DESCRIPTION
The Idea that @horriblename and I had was to factor out diagnostics and formatters as well into presets. The advantage is that the language modules all will be simpler, and some modules, we didn't want to split because of duplication can be split up into multiple, which actually makes sense. This is just for the Diagnostics, the formatters will need to be done another day.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
