### PR TITLE
languages/react: init/split off

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -108,6 +108,7 @@ isMaximal: {
       jinja.enable = false;
       svelte.enable = false;
       vue.enable = false;
+      tsx.enable = false;
       liquid.enable = false;
       tera.enable = false;
       twig.enable = false;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -118,6 +118,10 @@
   SCSS/SASS. This also changes the default LSP to `some-sass-language-server`
   for SCSS/SASS.
 
+- Split React/TSX from `languages.typescript` into `languages.tsx`. This new
+  module provides jsx/tsx support. This is a step of cleaning up the Typescript
+  module for the future.
+
 [CaueAnjos](https://github.com/caueanjos)
 
 - Renamed `roslyn_ls` to `roslyn-ls`

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -373,5 +373,10 @@ in {
         <https://strongly-typed-thoughts.net/blog/final-bye-github>
       '')
     ]
+
+    # 2026-05-16
+    [
+      (mkRenamedOptionModule ["vim" "languages" "typescript" "treesitter" "tsxPackage"] ["vim" "languages" "tsx" "treesitter" "package"])
+    ]
   ];
 }

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -7,70 +7,72 @@ in {
     ./asm.nix
     ./astro.nix
     ./bash.nix
-    ./env.nix
-    ./cue.nix
-    ./dart.nix
     ./clang.nix
     ./clojure.nix
     ./cmake.nix
+    ./csharp.nix
     ./css.nix
-    ./standard-ml.nix
-    ./scss.nix
+    ./cue.nix
+    ./dart.nix
+    ./docker.nix
     ./elixir.nix
     ./elm.nix
+    ./env.nix
     ./fish.nix
+    ./fluent.nix
     ./fsharp.nix
+    ./gettext.nix
     ./gleam.nix
     ./glsl.nix
     ./go.nix
+    ./haskell.nix
     ./hcl.nix
     ./helm.nix
-    ./kotlin.nix
     ./html.nix
-    ./tera.nix
-    ./twig.nix
-    ./liquid.nix
-    ./haskell.nix
     ./java.nix
     ./jinja.nix
+    ./jq.nix
     ./json.nix
+    ./julia.nix
+    ./just.nix
+    ./kotlin.nix
+    ./liquid.nix
     ./lua.nix
+    ./make.nix
     ./markdown.nix
-    ./tex.nix
     ./nim.nix
-    ./vala.nix
     ./nix.nix
+    ./nu.nix
     ./ocaml.nix
+    ./odin.nix
+    ./openscad.nix
     ./php.nix
     ./python.nix
     ./qml.nix
     ./r.nix
+    ./ruby.nix
     ./rust.nix
     ./scala.nix
+    ./scss.nix
+    ./scss.nix
     ./sql.nix
+    ./standard-ml.nix
     ./svelte.nix
-    ./vhdl.nix
-    ./vue.nix
+    ./tera.nix
     ./terraform.nix
+    ./tex.nix
     ./toml.nix
+    ./tsx.nix
+    ./twig.nix
     ./typescript.nix
     ./typst.nix
-    ./zig.nix
-    ./csharp.nix
-    ./julia.nix
-    ./nu.nix
-    ./odin.nix
+    ./vala.nix
+    ./vhdl.nix
+    ./vue.nix
     ./wgsl.nix
-    ./yaml.nix
-    ./ruby.nix
-    ./just.nix
-    ./make.nix
     ./xml.nix
-    ./gettext.nix
-    ./fluent.nix
-    ./openscad.nix
-    ./jq.nix
-    ./docker.nix
+    ./yaml.nix
+    ./zig.nix
 
     # This is now a hard deprecation.
     (mkRenamedOptionModule ["vim" "languages" "enableLSP"] ["vim" "lsp" "enable"])

--- a/modules/plugins/languages/tsx.nix
+++ b/modules/plugins/languages/tsx.nix
@@ -1,0 +1,159 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.options) mkEnableOption mkOption literalExpression;
+  inherit (lib.types) enum listOf;
+  inherit (lib.attrsets) attrNames genAttrs;
+  inherit (lib.meta) getExe;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.nvim.types) mkGrammarOption diagnostics;
+
+  cfg = config.vim.languages.tsx;
+
+  defaultServers = ["typescript-language-server"];
+  servers = ["typescript-language-server" "deno" "typescript-go" "emmet-ls"];
+
+  defaultFormat = ["prettier"];
+  formats = {
+    prettier = {
+      command = getExe pkgs.prettier;
+    };
+
+    prettierd = {
+      command = getExe pkgs.prettierd;
+    };
+
+    biome = {
+      command = getExe pkgs.biome;
+    };
+
+    biome-check = {
+      command = getExe pkgs.biome;
+    };
+
+    biome-organize-imports = {
+      command = getExe pkgs.biome;
+    };
+  };
+
+  defaultDiagnosticsProvider = ["biomejs"];
+  diagnosticsProviders = {
+    biomejs = let
+      pkg = pkgs.biome;
+    in {
+      package = pkg;
+      config = {
+        cmd = getExe pkg;
+      };
+    };
+  };
+in {
+  options.vim.languages.tsx = {
+    enable = mkEnableOption "Typescript XML (TSX) language support";
+
+    treesitter = {
+      enable =
+        mkEnableOption "Typescript XML (TSX) treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+          defaultText = literalExpression "config.vim.languages.enableTreesitter";
+        };
+      package = mkGrammarOption pkgs "tsx";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "Typescript XML (TSX) LSP support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
+      servers = mkOption {
+        type = listOf (enum servers);
+        default = defaultServers;
+        description = "Typescript XML (TSX) LSP server to use";
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "Typescript XML (TSX) formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
+
+      type = mkOption {
+        description = "Typescript XML (TSX) formatter to use";
+        type = listOf (enum (attrNames formats));
+        default = defaultFormat;
+      };
+    };
+
+    extraDiagnostics = {
+      enable = mkEnableOption "extra Typescript XML (TSX) diagnostics" // {default = config.vim.languages.enableExtraDiagnostics;};
+
+      types = diagnostics {
+        langDesc = "Typescript XML (TSX)";
+        inherit diagnosticsProviders;
+        inherit defaultDiagnosticsProvider;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {
+          filetypes = [
+            "typescriptreact"
+            "javascriptreact"
+          ];
+        });
+      };
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft = {
+            typescriptreact = cfg.format.type;
+            javascriptreact = cfg.format.type;
+          };
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
+    })
+
+    (mkIf cfg.extraDiagnostics.enable {
+      vim.diagnostics.nvim-lint = {
+        enable = true;
+        linters_by_ft = {
+          typescriptreact = cfg.extraDiagnostics.types;
+          javascriptreact = cfg.extraDiagnostics.types;
+        };
+        linters =
+          mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
+            cfg.extraDiagnostics.types);
+      };
+    })
+  ]);
+}

--- a/modules/plugins/languages/typescript.nix
+++ b/modules/plugins/languages/typescript.nix
@@ -85,7 +85,6 @@ in {
           defaultText = literalExpression "config.vim.languages.enableTreesitter";
         };
       tsPackage = mkGrammarOption pkgs "typescript";
-      tsxPackage = mkGrammarOption pkgs "tsx";
       jsPackage = mkGrammarOption pkgs "javascript";
     };
 
@@ -162,7 +161,6 @@ in {
       vim.treesitter.enable = true;
       vim.treesitter.grammars = [
         cfg.treesitter.tsPackage
-        cfg.treesitter.tsxPackage
         cfg.treesitter.jsPackage
       ];
     })
@@ -173,11 +171,6 @@ in {
         servers = genAttrs cfg.lsp.servers (_: {
           filetypes = [
             "typescript"
-            # TODO: move to a React module
-            "typescriptreact"
-            "typescript.tsx"
-            "javascriptreact"
-            "javascript.jsx"
             # TODO: move to a JavaScript module
             "javascript"
           ];
@@ -192,8 +185,6 @@ in {
           formatters_by_ft = {
             typescript = cfg.format.type;
             javascript = cfg.format.type;
-            # .tsx/.jsx files
-            typescriptreact = cfg.format.type;
           };
           formatters =
             mapListToAttrs (name: {
@@ -209,8 +200,6 @@ in {
       vim.diagnostics.nvim-lint = {
         enable = true;
         linters_by_ft.typescript = cfg.extraDiagnostics.types;
-        linters_by_ft.typescriptreact = cfg.extraDiagnostics.types;
-
         linters =
           mkMerge (map (name: {${name} = diagnosticsProviders.${name}.config;})
             cfg.extraDiagnostics.types);


### PR DESCRIPTION
The goal of this is to clean up the `typescript` module, make the naming of modules and what is a module more consistent. We got `angular`, `svelte`, `vue` and now `react`.

You could argue that it should be `tsx` and not `react` but I think users might look for a `react` module, with the other mods existing, but Im open to change it.
Though neovim already branded `tsx` and `jsx` as react, with its filetypes `typescriptreact` and `javascriptreact`.

<img width="1071" height="249" alt="image" src="https://github.com/user-attachments/assets/ef467cb8-0a78-48ec-a6f4-d69e4bea6656" />


This also doesn't add in `eslint_d` which before could have been connected on `tsx` files, as it doesn't support them without extensions, so it didn't actually ever work with nvf on `tsx`. 
If somebody needs/wants it on `tsx`, we can add it in as a new diagnostic, similar to what we did with `prettier` in the `svelte` module. Though it might be better we do that after #1586, when we also have a future plan for how to do extra diagnostics and plugins.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
