### PR TITLE
languages/pug: init

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -117,6 +117,7 @@ isMaximal: {
       jq.enable = false;
       fish.enable = false;
       standard-ml.enable = false;
+      pug.enable = false;
 
       # Nim LSP is broken on Darwin and therefore
       # should be disabled by default. Users may still enable

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -271,6 +271,9 @@
 
 - Allow disabling nvf's vendored keymaps by toggling `vendoredKeymaps.enable`.
 
+- Add {option}`vim.languages.pug.enable`, which adds the treesitter grammar and
+  enables `emmet-ls` for pug files.
+
 [pyrox0](https://github.com/pyrox0):
 
 - Added [rumdl](https://github.com/rvben/rumdl) support to `languages.markdown`

--- a/flake/pkgs/by-name/prettier-plugin-pug/0001-fix-don-t-touch-git-state-while-building.patch
+++ b/flake/pkgs/by-name/prettier-plugin-pug/0001-fix-don-t-touch-git-state-while-building.patch
@@ -1,0 +1,25 @@
+From 85c43d3f45b6a5d301b66fe52c0c92b16ddfbc95 Mon Sep 17 00:00:00 2001
+From: alfarel <alfarelcynthesis@proton.me>
+Date: Sun, 17 May 2026 22:42:21 -0400
+Subject: [PATCH] fix: don't touch git state while building
+
+---
+ package.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/package.json b/package.json
+index 9151c4f..5508237 100644
+--- a/package.json
++++ b/package.json
+@@ -6,7 +6,7 @@
+     "clean": "git clean -fdx",
+     "build:clean": "git clean -fdx dist",
+     "build:code": "tsup-node",
+-    "build": "run-s build:clean build:code",
++    "build": "run-s build:code",
+     "docs:build": "vitepress build docs",
+     "docs:dev": "vitepress dev docs",
+     "docs:serve": "vitepress serve docs --port 5173",
+-- 
+2.53.0
+

--- a/flake/pkgs/by-name/prettier-plugin-pug/package.nix
+++ b/flake/pkgs/by-name/prettier-plugin-pug/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  nodejs,
+  gitMinimal,
+  pnpm_9,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+  pins,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}: let
+  pin = pins.prettier-plugin-pug;
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "prettier-plugin-pug";
+    version = pin.version or pin.revision;
+
+    patches = [
+      ./0001-fix-don-t-touch-git-state-while-building.patch
+    ];
+
+    src = fetchFromGitHub {
+      inherit (pin.repository) owner repo;
+      rev = finalAttrs.version;
+      sha256 = pin.hash;
+    };
+
+    pnpmDeps = fetchPnpmDeps {
+      pnpm = pnpm_9;
+      inherit (finalAttrs) pname version src;
+      hash = "sha256-NBetqPzn99W0mvv2niL9bJ3iOexOB4VAIGA7CmUn00M=";
+      fetcherVersion = 3;
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      gitMinimal
+      writableTmpDirAsHomeHook
+      (pnpmConfigHook.overrideAttrs {
+        propagatedBuildInputs = [pnpm_9];
+      })
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm run build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r dist/ $out
+      cp -r node_modules $out
+
+      runHook postInstall
+    '';
+  })

--- a/modules/plugins/languages/default.nix
+++ b/modules/plugins/languages/default.nix
@@ -47,6 +47,7 @@ in {
     ./odin.nix
     ./openscad.nix
     ./php.nix
+    ./pug.nix
     ./python.nix
     ./qml.nix
     ./r.nix

--- a/modules/plugins/languages/pug.nix
+++ b/modules/plugins/languages/pug.nix
@@ -1,0 +1,105 @@
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}: let
+  inherit (lib.attrsets) attrNames genAttrs;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.types) enum listOf;
+  inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.nvim.types) mkGrammarOption;
+
+  cfg = config.vim.languages.pug;
+
+  defaultServers = ["emmet-ls"];
+  servers = ["emmet-ls"];
+
+  defaultFormat = ["prettier"];
+  formats = {
+    prettier = {
+      command = getExe pkgs.prettier;
+      options.ft_parsers.pug = "pug";
+      prepend_args = let
+        parser = "${inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.prettier-plugin-pug}/index.js";
+      in ["--plugin=${parser}"];
+    };
+  };
+in {
+  options.vim.languages.pug = {
+    enable = mkEnableOption "Pug language support";
+
+    treesitter = {
+      enable =
+        mkEnableOption "Pug treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+          defaultText = literalExpression "config.vim.languages.enableTreesitter";
+        };
+      package = mkGrammarOption pkgs "pug";
+    };
+
+    lsp = {
+      enable =
+        mkEnableOption "Pug LSP support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
+      servers = mkOption {
+        type = listOf (enum servers);
+        default = defaultServers;
+        description = "Pug LSP server to use";
+      };
+    };
+
+    format = {
+      enable =
+        mkEnableOption "Pug formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
+
+      type = mkOption {
+        type = listOf (enum (attrNames formats));
+        default = defaultFormat;
+        description = "Pug formatter to use";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter = {
+        enable = true;
+        grammars = [cfg.treesitter.package];
+      };
+    })
+
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {filetypes = ["pug"];});
+      };
+    })
+
+    (mkIf cfg.format.enable {
+      vim.formatter.conform-nvim = {
+        enable = true;
+        setupOpts = {
+          formatters_by_ft.pug = cfg.format.type;
+          formatters =
+            mapListToAttrs (name: {
+              inherit name;
+              value = formats.${name};
+            })
+            cfg.format.type;
+        };
+      };
+    })
+  ]);
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2395,6 +2395,22 @@
       "url": "https://api.github.com/repos/withastro/prettier-plugin-astro/tarball/refs/tags/v0.14.1",
       "hash": "sha256-XGPz4D2UKOonet0tX3up5mCxw3/69XYPScxb9l7nzpE="
     },
+    "prettier-plugin-pug": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "prettier",
+        "repo": "plugin-pug"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "3.4.2",
+      "revision": "33c86341f0addf48b09968f2545efcf18331d046",
+      "url": "https://api.github.com/repos/prettier/plugin-pug/tarball/refs/tags/3.4.2",
+      "hash": "sha256-4CsKMj8Xnq+dlGzLAG2hV8jTCMYBYhaV/uoKAfztSGs="
+    },
     "prettier-plugin-svelte": {
       "type": "GitRelease",
       "repository": {


### PR DESCRIPTION
Adds a language module for `pug` (the html templating language).
Currently adds the treesitter grammar, sets up `emmet-ls`, and packages the (official) prettier plugin for pug, which isn't packaged in `nixpkgs`.

~~If y'all would prefer to recommend adding `pug` to the lsp preset's filetypes instead of adding a language module, feel free to just close this.~~

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
