### PR TITLE
languages/go: fix scope of golangci-lint

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -551,4 +551,8 @@ https://github.com/gorbit99/codewindow.nvim
 - Allow `vim.treesitter.context.setupOpts.max_lines` to also be given as a
   string in order to allow percentage values like `"20%"`
 
+[RoastedCheese](https://github.com/roastedcheese):
+
+- Fix `golangci-lint` to lint at the package level.
+
 <!-- vim: set textwidth=80: -->

--- a/modules/plugins/languages/go.nix
+++ b/modules/plugins/languages/go.nix
@@ -67,7 +67,21 @@
           "--output.junit-xml.path="
           "--output.teamcity.path="
           "--output.sarif.path="
+          (mkLuaInline ''
+            -- Run on current file only if go.mod is missing
+            function()
+              local fnmod = ":p";
+              local cmd = {"${getExe pkgs.go}", "env", "GOMOD"};
+              local ok, gomod = pcall(vim.fn.system, cmd);
+              gomod = gomod:gsub("%s+", "")
+              if ok and gomod ~= "" and gomod ~= "/dev/null" then
+                fnmod = ":h";
+              end
+              return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), fnmod)
+            end
+          '')
         ];
+        append_fname = false;
         parser = mkLuaInline ''
           function(output, bufnr)
             local SOURCE = "golangci-lint";
@@ -111,15 +125,19 @@
                 local normalized = issue.Severity:lower()
                 sev = severity_map[normalized] or vim.diagnostic.severity.ERROR
               end
-              table.insert(diagnostics, {
-                bufnr = bufnr,
-                lnum = issue.Pos.Line - 1,
-                col = issue.Pos.Column - 1,
-                message = issue.Text,
-                code = issue.FromLinter,
-                severity = sev,
-                source = SOURCE,
-              })
+
+              local buffer = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
+              if vim.fs.normalize(buffer) == vim.fs.normalize(issue.Pos.Filename) then
+                table.insert(diagnostics, {
+                  bufnr = bufnr,
+                  lnum = issue.Pos.Line - 1,
+                  col = issue.Pos.Column - 1,
+                  message = issue.Text,
+                  code = issue.FromLinter,
+                  severity = sev,
+                  source = SOURCE,
+                })
+              end
             end
             return diagnostics
           end


### PR DESCRIPTION
Fix `golangci-lint` to run on the package directory as opposed to single files, falling back to single file mode if no go.mod is found.
The default `nvim-lint` configuration provides the same behavior.
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->
Fixes #1602 

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
