### PR TITLE
wrapper/options: use `vim.opt` for structured options

### DIFF
--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -18,7 +18,7 @@ in {
       mapAttrsToList (name: value: "vim.g.${name} = ${toLuaObject value}") cfg.globals;
 
     optionsScript =
-      mapAttrsToList (name: value: "vim.o.${name} = ${toLuaObject value}") cfg.options;
+      mapAttrsToList (name: value: "vim.opt.${name} = ${toLuaObject value}") cfg.options;
 
     extraPluginConfigs = resolveDag {
       name = "extra plugin configs";

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -266,9 +266,9 @@ in {
         after `basic` and before `pluginConfigs` DAG entries.
 
         ::: {.note}
-        `{foo = "bar";}` will set `vim.o.foo` to "bar", where the type of `bar` in the
-        resulting Lua value will be inferred from the type of the value in the
-        `{name = value;}` pair passed to the option.
+        `{foo = "bar";}` will set `vim.opt.foo` to "bar", where the type of
+        `bar` in the resulting Lua value will be inferred from the type of the
+        value in the `{name = value;}` pair passed to the option.
         :::
       '';
     };


### PR DESCRIPTION
closes #1611 

`vim.o` only accepts string/bool/number

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
