### PR TITLE
filetree/nvimtree: remove deprecated `system_open` option

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -132,7 +132,8 @@
 
 [bovf](https://github.com/bovf):
 
-- Removed the deprecated `system_open` setup option from `nvim-tree.lua` to avoid startup warnings now that upstream uses `vim.ui.open()`.
+- Removed the deprecated `system_open` setup option from `nvim-tree.lua` to
+  avoid startup warnings now that upstream uses `vim.ui.open()`.
 
 [ErinaYip](https://github.com/ErinaYip):
 

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -130,6 +130,10 @@
 
 ## Changelog {#sec-release-0-9-changelog}
 
+[bovf](https://github.com/bovf):
+
+- Removed the deprecated `system_open` setup option from `nvim-tree.lua` to avoid startup warnings now that upstream uses `vim.ui.open()`.
+
 [ErinaYip](https://github.com/ErinaYip):
 
 - Fixed and updated `lualine` options:

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -378,5 +378,17 @@ in {
     [
       (mkRenamedOptionModule ["vim" "languages" "typescript" "treesitter" "tsxPackage"] ["vim" "languages" "tsx" "treesitter" "package"])
     ]
+
+    # 2026-06-02
+    [
+      (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "args"] ''
+        nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
+        See nvf issue #1621.
+      '')
+      (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "cmd"] ''
+        nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
+        See nvf issue #1621.
+      '')
+    ]
   ];
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -383,11 +383,9 @@ in {
     [
       (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "args"] ''
         nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
-        See nvf issue #1621.
       '')
       (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "cmd"] ''
         nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
-        See nvf issue #1621.
       '')
     ]
   ];

--- a/modules/plugins/filetree/nvimtree/config.nix
+++ b/modules/plugins/filetree/nvimtree/config.nix
@@ -14,16 +14,6 @@
   inherit (options.vim.filetree.nvimTree) mappings;
 in {
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = !(cfg.setupOpts ? system_open);
-        message = ''
-          vim.filetree.nvimTree.setupOpts.system_open was removed by nvim-tree.lua.
-          Use Neovim's vim.ui.open() instead. See nvf issue #1621.
-        '';
-      }
-    ];
-
     vim = {
       binds.whichKey.register = pushDownDefault {
         "<leader>t" = "+NvimTree";

--- a/modules/plugins/filetree/nvimtree/config.nix
+++ b/modules/plugins/filetree/nvimtree/config.nix
@@ -14,6 +14,16 @@
   inherit (options.vim.filetree.nvimTree) mappings;
 in {
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.setupOpts ? system_open);
+        message = ''
+          vim.filetree.nvimTree.setupOpts.system_open was removed by nvim-tree.lua.
+          Use Neovim's vim.ui.open() instead. See nvf issue #1621.
+        '';
+      }
+    ];
+
     vim = {
       binds.whichKey.register = pushDownDefault {
         "<leader>t" = "+NvimTree";

--- a/modules/plugins/filetree/nvimtree/nvimtree.nix
+++ b/modules/plugins/filetree/nvimtree/nvimtree.nix
@@ -5,7 +5,6 @@
   ...
 }: let
   inherit (lib.options) mkEnableOption mkOption literalExpression;
-  inherit (lib.modules) mkRemovedOptionModule;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.types) str bool int submodule listOf enum oneOf attrs addCheck;
   inherit (lib.nvim.types) mkPluginSetupOption;
@@ -69,18 +68,8 @@
     ["vim" "filetree" "nvimTree"]
     ["vim" "filetree" "nvimTree" "setupOpts"]
     migrationTable;
-
-  systemOpenRemovedMessage = ''
-    nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
-    See nvf issue #1621.
-  '';
 in {
-  imports =
-    renamedSetupOpts
-    ++ [
-      (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "args"] systemOpenRemovedMessage)
-      (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "cmd"] systemOpenRemovedMessage)
-    ];
+  imports = renamedSetupOpts;
   options.vim.filetree.nvimTree = {
     enable = mkEnableOption "filetree via nvim-tree.lua";
 

--- a/modules/plugins/filetree/nvimtree/nvimtree.nix
+++ b/modules/plugins/filetree/nvimtree/nvimtree.nix
@@ -5,6 +5,7 @@
   ...
 }: let
   inherit (lib.options) mkEnableOption mkOption literalExpression;
+  inherit (lib.modules) mkRemovedOptionModule;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.types) str bool int submodule listOf enum oneOf attrs addCheck;
   inherit (lib.nvim.types) mkPluginSetupOption;
@@ -28,10 +29,6 @@
     reloadOnBufEnter = "reload_on_buf_enter";
     respectBufCwd = "respect_buf_cwd";
     hijackDirectories = "hijack_directories";
-    systemOpen = {
-      args = "args";
-      cmd = "cmd";
-    };
     diagnostics = "diagnostics";
     git = {
       enable = "enable";
@@ -72,8 +69,18 @@
     ["vim" "filetree" "nvimTree"]
     ["vim" "filetree" "nvimTree" "setupOpts"]
     migrationTable;
+
+  systemOpenRemovedMessage = ''
+    nvim-tree.lua removed system_open and now uses Neovim's vim.ui.open().
+    See nvf issue #1621.
+  '';
 in {
-  imports = renamedSetupOpts;
+  imports =
+    renamedSetupOpts
+    ++ [
+      (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "args"] systemOpenRemovedMessage)
+      (mkRemovedOptionModule ["vim" "filetree" "nvimTree" "systemOpen" "cmd"] systemOpenRemovedMessage)
+    ];
   options.vim.filetree.nvimTree = {
     enable = mkEnableOption "filetree via nvim-tree.lua";
 
@@ -225,25 +232,6 @@ in {
             Opens the tree if the tree was previously closed.
           '';
           default = false;
-        };
-      };
-
-      system_open = {
-        args = mkOption {
-          default = [];
-          description = "Optional argument list.";
-          type = listOf str;
-        };
-
-        cmd = mkOption {
-          default =
-            if pkgs.stdenv.isDarwin
-            then "open"
-            else if pkgs.stdenv.isLinux
-            then "${pkgs.xdg-utils}/bin/xdg-open"
-            else throw "NvimTree: No default system open command for this platform, please set `vim.filetree.nvimTree.systemOpen.cmd`";
-          description = "The open command itself";
-          type = str;
         };
       };
 


### PR DESCRIPTION
Removes the deprecated `system_open` setup option from the nvim-tree module.

`nvim-tree.lua` now uses Neovim's `vim.ui.open()` and warns when `system_open` is
 present:

```text
NvimTree: system_open has been removed, now uses the system default handler:
vim.ui.open()
```

Fixes #1621

Sanity Checking

- [x] I have updated the changelog as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in hacking nvf
- Style and consistency
    - [x] I ran Alejandra to format my code (nix fmt)
    - [x] My code conforms to the editorconfig configuration of the project
    - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
    - [ ] My code includes comments in particularly complex areas
    - [ ] I have added a section in the manual
    - [ ] (For breaking changes) I have included a migration guide
- Package(s) built:
    - [x] .#nix (default package)
    - [ ] .#maximal
    - [ ] .#docs-html (manual, must build)
    - [ ] .#docs-linkcheck (optional, please build if adding links)
- Tested on platform(s)
    - [ ] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [x] aarch64-darwin

 Notes:

- Tested with `nix build .#nix --no-link` on `aarch64-darwin`
- nix flake check --no-build gets past the module changes, but packages.aarch64-darwin.docs currently fails because inputs.ndg.packages.aarch64-darwin is missing.