### PR TITLE
languages/rust: move rustaceanvim to extensions submodule

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -74,6 +74,8 @@ isMaximal: {
       typst.enable = isMaximal;
       rust = {
         enable = isMaximal;
+        # Can only be enabled if lsp.enable = false
+        extensions.rustaceanvim.enable = false;
         extensions.crates-nvim.enable = isMaximal;
       };
       toml.enable = isMaximal;

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -151,6 +151,11 @@
 - Turned `omnisharp-extended-lsp-nvim` into an extension disabled by default
 - Turned `csharpls-extended-lsp-nvim` into an extension disabled by default
 
+[sjcobb2022](https://github.com/caueanjos)
+
+- Rust module is now no longer dependant on `rustaceanvim` by default. Use
+  `vim.languages.rust.extensions.rustaceanvim.enable` if needed.
+
 ## Changelog {#sec-release-0-9-changelog}
 
 [bovf](https://github.com/bovf):
@@ -670,6 +675,12 @@ https://github.com/gorbit99/codewindow.nvim
 - Add [PHPStan] as a formatter for `vim.languages.php`.
 - Add `prettier` and `prettierd` as supported formatters to
   `vim.languages.json`.
+
+[sjcobb2022](https://github.com/sjcobb2022)
+
+- Modernize rust toolchain by defaulting to a `rustaceanvim` free default
+  configuration. Enabled via configuration
+  `vim.languages.rust.extensions.rustaceanvim.enable`.
 
 [BrockoliniMorgan](https://github.com/BrockoliniMorgan)
 

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -407,6 +407,12 @@ in {
       '')
     ]
 
+    # 2026-06-05
+    [
+      (mkRemovedLspPackage "rust")
+      (mkRemovedLspOpt "rust")
+    ]
+
     # 2026-06-12
     [
       (mkRemovedOptionModule ["vim" "languages" "sql" "dialect"] ''
@@ -456,6 +462,12 @@ in {
         Filetype association is now handled automatically by the conform-nvim presets.
         Use `vim.formatter.conform-nvim.setupOpts.formatters_by_ft.<ft> = ["<formatter>", ...]` to register extra formatters per filetype.
       '')
+    ]
+
+    # 2026-06-25
+    [
+      (mkRenamedOptionModule ["vim" "languages" "rust" "dap" "adapter"] ["vim" "languages" "rust" "dap" "debugger"])
+      (mkRenamedOptionModule ["vim" "languages" "rust" "dap" "package"] ["vim" "languages" "rust" "dap" "debugger"])
     ]
 
     # 2026-07-03

--- a/modules/plugins/debugger/nvim-dap/presets/codelldb.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/codelldb.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption;
+
+  cfg = config.vim.debugger.nvim-dap.presets.codelldb;
+  codelldb = pkgs.vscode-extensions.vadimcn.vscode-lldb.adapter;
+in {
+  options.vim.debugger.nvim-dap.presets.codelldb = {
+    enable = mkEnableOption ''
+      adapter configuration for CodeLLDB using the vadimcn.vscode-lldb extension.
+      Use {option}`vim.debugger.nvim-dap.adapters.codelldb` for customization.
+
+      A configuration is also needed for your filetype in
+      {option}`vim.debugger.nvim-dap.configurations`
+    '';
+  };
+
+  config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {
+    codelldb = {
+      type = "server";
+      port = "\${port}";
+      executable = {
+        command = "${codelldb}/bin/codelldb";
+        args = ["--liblldb" "${codelldb}/share/lldb/lib/liblldb.so" "--port" "\${port}"];
+      };
+    };
+  };
+}

--- a/modules/plugins/debugger/nvim-dap/presets/default.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./codelldb.nix
     ./debugpy.nix
     ./jls.nix
     ./lldb.nix

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -6,18 +6,64 @@
 }: let
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkOption mkEnableOption literalMD literalExpression;
+  inherit (lib) attrNames genAttrs;
+  inherit (lib.lists) flatten getExe;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.strings) optionalString;
-  inherit (lib.lists) isList;
-  inherit (lib) genAttrs;
-  inherit (lib.types) bool package str listOf either enum int;
-  inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf;
+  inherit (lib.types) bool listOf enum int;
   inherit (lib.nvim.dag) entryAfter;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf enumWithRename;
 
   cfg = config.vim.languages.rust;
 
+  servers = ["rust-analyzer"];
+  defaultServers = ["rust-analyzer"];
+
   defaultFormat = ["rustfmt"];
   formats = ["rustfmt"];
+
+  defaultDebugger = ["codelldb"];
+  dapConfigurations = {
+    lldb = [
+      {
+        name = "Launch file (lldb)";
+        type = "lldb";
+        request = "launch";
+        program = mkLuaInline ''
+          function()
+            return nvf_dap_cached_input(
+              'rust_lldb_launch_exe',
+              "Path to executable: ",
+              vim.fn.getcwd() .. "/target/debug/",
+              "file")
+          end
+        '';
+        cwd = "\${workspaceFolder}";
+        stopOnEntry = false;
+        args = [];
+      }
+    ];
+    codelldb = [
+      {
+        name = "Launch file (codelldb)";
+        type = "codelldb";
+        request = "launch";
+        program = mkLuaInline ''
+          function()
+            return nvf_dap_cached_input(
+              'rust_codelldb_launch_exe',
+              "Path to executable: ",
+              vim.fn.getcwd() .. "/target/debug/",
+              "file")
+          end
+        '';
+        cwd = "\${workspaceFolder}";
+        stopOnEntry = false;
+        args = [];
+      }
+    ];
+  };
 in {
   options.vim.languages.rust = {
     enable = mkEnableOption "Rust language support";
@@ -34,31 +80,16 @@ in {
 
     lsp = {
       enable =
-        mkEnableOption "Rust LSP support (rust-analyzer with extra tools)"
+        mkEnableOption "Rust LSP support"
         // {
           default = config.vim.lsp.enable;
           defaultText = literalExpression "config.vim.lsp.enable";
         };
-      package = mkOption {
-        description = "rust-analyzer package, or the command to run as a list of strings";
-        example = ''[lib.getExe pkgs.jdt-language-server "-data" "~/.cache/jdtls/workspace"]'';
-        type = either package (listOf str);
-        default = pkgs.rust-analyzer;
-      };
 
-      opts = mkOption {
-        description = "Options to pass to rust analyzer";
-        type = str;
-        default = "";
-        example = ''
-          ['rust-analyzer'] = {
-            cargo = {allFeature = true},
-            checkOnSave = true,
-            procMacro = {
-              enable = true,
-            },
-          },
-        '';
+      servers = mkOption {
+        type = listOf (enum servers);
+        default = defaultServers;
+        description = "Rust LSP server to use";
       };
     };
 
@@ -87,23 +118,14 @@ in {
         defaultText = literalExpression "config.vim.languages.enableDAP";
       };
 
-      package = mkOption {
-        description = "lldb package";
-        type = package;
-        default = pkgs.lldb;
-      };
-
-      adapter = mkOption {
-        type = enum ["lldb-dap" "codelldb"];
-        default = "codelldb";
-        description = ''
-          Select which LLDB-based debug adapter to use:
-
-          - "codelldb": use the CodeLLDB adapter from the vadimcn.vscode-lldb extension.
-          - "lldb-dap": use the LLDB DAP implementation shipped with LLVM (lldb-dap).
-
-          The default "codelldb" backend generally provides a better debugging experience for Rust.
-        '';
+      debugger = mkOption {
+        description = "Rust debugger to use.";
+        type =
+          deprecatedSingleOrListOf "vim.languages.rust.dap.debugger"
+          (enumWithRename "vim.languages.rust.dap.debugger" (attrNames dapConfigurations) {
+            "lldb-dap" = "lldb";
+          });
+        default = defaultDebugger;
       };
     };
 
@@ -160,6 +182,103 @@ in {
           };
         };
       };
+
+      rustaceanvim = {
+        enable = mkEnableOption "additional rust support [rustaceanvim]";
+        setupOpts = mkPluginSetupOption "rustaceanvim" {
+          tools = mkOption {
+            description = "Plugin configuration";
+            default = {
+              hover_actions = {
+                replace_builtin_hover = false;
+              };
+            };
+            example = {
+              hover_actions = {
+                replace_builtin_hover = true;
+              };
+            };
+          };
+          server = mkOption {
+            description = "LSP configuration";
+            default = {
+              # For some reason rustaceanvim needs the command set explicitly, and does not pick up on vim.lsp.config settings.
+              cmd = [(getExe pkgs.rust-analyzer)];
+
+              on_attach = mkLuaInline ''
+                function(client, bufnr)
+                    default_on_attach(client, bufnr)
+                    local opts = { noremap=true, silent=true, buffer = bufnr }
+
+                    ${optionalString config.vim.vendoredKeymaps.enable ''
+                  vim.keymap.set("n", "<localleader>rr", ":RustLsp runnables<CR>", opts)
+                  vim.keymap.set("n", "<localleader>rp", ":RustLsp parentModule<CR>", opts)
+                  vim.keymap.set("n", "<localleader>rm", ":RustLsp expandMacro<CR>", opts)
+                  vim.keymap.set("n", "<localleader>rc", ":RustLsp openCargo", opts)
+                  vim.keymap.set("n", "<localleader>rg", ":RustLsp crateGraph x11", opts)
+                ''}
+
+                    ${optionalString (cfg.dap.enable && config.vim.vendoredKeymaps.enable) ''
+                  vim.keymap.set("n", "<localleader>rd", ":RustLsp debuggables<cr>", opts)
+                ''}
+
+                    ${optionalString (cfg.dap.enable && config.vim.debugger.nvim-dap.mappings.continue != null) ''
+                  vim.keymap.set(
+                  "n", "${config.vim.debugger.nvim-dap.mappings.continue}",
+                  function()
+                    local dap = require("dap")
+                    if dap.status() == "" then
+                      vim.cmd "RustLsp debuggables"
+                    else
+                      dap.continue()
+                    end
+                  end,
+                  opts
+                  )
+                ''}
+                end
+              '';
+            };
+            example = {
+              on_attach = mkLuaInline ''
+                function(client, bufnr)
+                      -- you can also put keymaps in here
+                end,
+              '';
+            };
+          };
+          dap = mkOption {
+            description = "DAP configuration";
+            default = {
+              adapter =
+                if builtins.elem "lldb" cfg.dap.debugger
+                then
+                  mkLuaInline ''
+                    {
+                      type = "executable",
+                      command = "${pkgs.lldb}/bin/lldb-dap",
+                      name = "rustacean_lldb",
+                    }''
+                else let
+                  codelldb = pkgs.vscode-extensions.vadimcn.vscode-lldb.adapter;
+                  codelldbPath = "${codelldb}/bin/codelldb";
+                  liblldbPath = "${codelldb}/share/lldb/lib/liblldb.so";
+                in
+                  mkLuaInline ''
+                    {
+                      type = "server",
+                      port = "''${port}",
+                      executable = {
+                        command = "${codelldbPath}",
+                        args = { "--liblldb", "${liblldbPath}", "--port", "''${port}" },
+                      },
+                    }
+                  '';
+            };
+            example = {};
+          };
+        };
+      };
     };
   };
 
@@ -177,82 +296,53 @@ in {
       };
     })
 
-    (mkIf (cfg.lsp.enable || cfg.dap.enable) {
+    (mkIf cfg.lsp.enable {
+      vim.lsp = {
+        presets = genAttrs cfg.lsp.servers (_: {enable = true;});
+        servers = genAttrs cfg.lsp.servers (_: {
+          filetypes = [
+            "rust"
+          ];
+        });
+      };
+    })
+
+    (mkIf cfg.dap.enable {
+      vim.debugger.nvim-dap = {
+        enable = true;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations.rust = flatten (map (name: dapConfigurations.${name}) cfg.dap.debugger);
+      };
+    })
+
+    (mkIf cfg.extensions.rustaceanvim.enable {
       vim = {
         startPlugins = ["rustaceanvim"];
         pluginRC.rustaceanvim = entryAfter ["lsp-setup"] ''
-          vim.g.rustaceanvim = {
-          ${optionalString cfg.lsp.enable ''
-            -- LSP
-            tools = {
-              hover_actions = {
-                replace_builtin_hover = false
-              },
-            },
-            server = {
-              cmd = ${
-              if isList cfg.lsp.package
-              then toLuaObject cfg.lsp.package
-              else ''{"${cfg.lsp.package}/bin/rust-analyzer"}''
-            },
-              default_settings = {
-                ${cfg.lsp.opts}
-              },
-              on_attach = function(client, bufnr)
-                default_on_attach(client, bufnr)
-                local opts = { noremap=true, silent=true, buffer = bufnr }
-
-                ${optionalString config.vim.vendoredKeymaps.enable ''
-              vim.keymap.set("n", "<localleader>rr", ":RustLsp runnables<CR>", opts)
-              vim.keymap.set("n", "<localleader>rp", ":RustLsp parentModule<CR>", opts)
-              vim.keymap.set("n", "<localleader>rm", ":RustLsp expandMacro<CR>", opts)
-              vim.keymap.set("n", "<localleader>rc", ":RustLsp openCargo", opts)
-              vim.keymap.set("n", "<localleader>rg", ":RustLsp crateGraph x11", opts)
-            ''}
-
-                ${optionalString (cfg.dap.enable && config.vim.vendoredKeymaps.enable) ''
-              vim.keymap.set("n", "<localleader>rd", ":RustLsp debuggables<cr>", opts)
-            ''}
-
-                ${optionalString (cfg.dap.enable && config.vim.debugger.nvim-dap.mappings.continue != null) ''
-              vim.keymap.set(
-              "n", "${config.vim.debugger.nvim-dap.mappings.continue}",
-              function()
-                local dap = require("dap")
-                if dap.status() == "" then
-                  vim.cmd "RustLsp debuggables"
-                else
-                  dap.continue()
-                end
-              end,
-              opts
-              )
-            ''}
-              end
-            },
-          ''}
-
-            ${optionalString cfg.dap.enable ''
-            dap = {
-              adapter = ${
-              if cfg.dap.adapter == "lldb-dap"
-              then ''
-                {
-                  type = "executable",
-                  command = "${cfg.dap.package}/bin/lldb-dap",
-                  name = "rustacean_lldb",
-                }''
-              else let
-                codelldb = pkgs.vscode-extensions.vadimcn.vscode-lldb.adapter;
-                codelldbPath = "${codelldb}/bin/codelldb";
-                liblldbPath = "${codelldb}/share/lldb/lib/liblldb.so";
-              in ''require("rustaceanvim.config").get_codelldb_adapter("${codelldbPath}", "${liblldbPath}")''
-            },
-            },
-          ''}
-          }
+          vim.g.rustaceanvim = function()
+            return ${toLuaObject cfg.extensions.rustaceanvim.setupOpts}
+          end
         '';
       };
+
+      assertions = [
+        {
+          assertion = !cfg.lsp.enable || (!(builtins.elem "rust-analyzer" cfg.lsp.servers) && !config.vim.lsp.rust-analyzer.enable);
+          message = ''
+            Rustaceanvim fully manages its own rust-analyzer.
+            Therefore you can't use vim.languages.rust.extensions.rustaceanvim.enable with rust-analyzer enabled.
+            To fix this, set vim.languages.rust.lsp.enable to false.
+          '';
+        }
+        {
+          assertion = !cfg.dap.enable || !(builtins.any (name: config.vim.debugger.nvim-dap.presets.${name}.enable) cfg.dap.debugger);
+          message = ''
+            Rustaceanvim fully manages its own DAP adapter.
+            Therefore you can't use vim.languages.rust.extensions.rustaceanvim.enable with DAP debugger presets enabled separately.
+            To fix this, set vim.languages.rust.dap.enable to false.
+          '';
+        }
+      ];
     })
 
     (mkIf cfg.extensions.crates-nvim.enable {

--- a/modules/plugins/lsp/presets/default.nix
+++ b/modules/plugins/lsp/presets/default.nix
@@ -60,6 +60,7 @@
     ./ruby-lsp.nix
     ./ruff.nix
     ./rumdl.nix
+    ./rust-analyzer.nix
     ./solargraph.nix
     ./some-sass-language-server.nix
     ./sqls.nix

--- a/modules/plugins/lsp/presets/rust-analyzer.nix
+++ b/modules/plugins/lsp/presets/rust-analyzer.nix
@@ -1,0 +1,202 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkLspPresetEnableOption;
+  inherit (lib.nvim.dag) entryBefore;
+  inherit (lib.generators) mkLuaInline;
+
+  cfg = config.vim.lsp.presets.rust-analyzer;
+in {
+  options.vim.lsp.presets.rust-analyzer = {
+    enable = mkLspPresetEnableOption {
+      option = "rust-analyzer";
+      display = "Rust Analyzer";
+      extra = ''
+        > [!IMPORTANT]
+        > Don't set `init_options` for this LS config, it will be automatically populated by the contents of `settings["rust-analyzer"]` per
+        > <https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Taken from https://github.com/neovim/nvim-lspconfig/blob/07dff35e7c95288861200b788ef32d6103f107f0/lsp/rust_analyzer.lua
+
+    # This code provides utility for cargo workspace functionality, as it is not wired by default.
+    vim.luaConfigRC.rust-analyzer = entryBefore ["lsp-servers"] ''
+      local function rust_reload_workspace(bufnr)
+        local clients = vim.lsp.get_clients { bufnr = bufnr, name = 'rust-analyzer' }
+        for _, client in ipairs(clients) do
+          vim.notify 'Reloading Cargo Workspace'
+          ---@diagnostic disable-next-line:param-type-mismatch
+          client:request('rust-analyzer/reloadWorkspace', nil, function(err)
+            if err then
+              error(tostring(err))
+            end
+            vim.notify 'Cargo workspace reloaded'
+          end, 0)
+        end
+      end
+
+      local function rust_user_sysroot_src()
+        return vim.tbl_get(vim.lsp.config['rust-analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysrootSrc')
+      end
+
+      -- Determine location of sysroot for stdlib
+      local function rust_default_sysroot_src()
+        local sysroot = vim.tbl_get(vim.lsp.config['rust-analyzer'], 'settings', 'rust-analyzer', 'cargo', 'sysroot')
+        if not sysroot then
+          local rustc = os.getenv 'RUSTC' or 'rustc'
+          local result = vim.system({ rustc, '--print', 'sysroot' }, { text = true }):wait()
+
+          local stdout = result.stdout
+          if result.code == 0 and stdout then
+            if string.sub(stdout, #stdout) == '\n' then
+              if #stdout > 1 then
+                sysroot = string.sub(stdout, 1, #stdout - 1)
+              else
+                sysroot = '''
+              end
+            else
+              sysroot = stdout
+            end
+          end
+        end
+
+        return sysroot and vim.fs.joinpath(sysroot, 'lib/rustlib/src/rust/library') or nil
+      end
+
+      -- Determine if a given file belongs to an external library or our own code.
+      local function rust_is_library(fname)
+        local user_home = vim.fs.normalize(vim.env.HOME)
+        local cargo_home = os.getenv 'CARGO_HOME' or user_home .. '/.cargo'
+        local registry = cargo_home .. '/registry/src'
+        local git_registry = cargo_home .. '/git/checkouts'
+
+        local rustup_home = os.getenv 'RUSTUP_HOME' or user_home .. '/.rustup'
+        local toolchains = rustup_home .. '/toolchains'
+
+        local sysroot_src = rust_user_sysroot_src() or rust_default_sysroot_src()
+
+        for _, item in ipairs { toolchains, registry, git_registry, sysroot_src } do
+          if item and vim.fs.relpath(item, fname) then
+            local clients = vim.lsp.get_clients { name = 'rust-analyzer' }
+            return #clients > 0 and clients[#clients].config.root_dir or nil
+          end
+        end
+      end
+    '';
+
+    vim.lsp.servers.rust-analyzer = {
+      enable = true;
+      cmd = [(getExe pkgs.rust-analyzer)];
+
+      on_attach = mkLuaInline ''
+        function(client, bufnr)
+          vim.api.nvim_buf_create_user_command(bufnr, 'LspCargoReload', function()
+            rust_reload_workspace(bufnr)
+          end, { desc = 'Reload current cargo workspace' })
+        end
+      '';
+
+      # Sends init_params beforehand according to rust-analyzer spec.
+      # See https://github.com/rust-lang/rust-analyzer/blob/eb5da56d839ae0a9e9f50774fa3eb78eb0964550/docs/dev/lsp-extensions.md?plain=1#L26
+      before_init = mkLuaInline ''
+        function(init_params, config)
+          if config.settings and config.settings['rust-analyzer'] then
+            init_params.initializationOptions = config.settings['rust-analyzer']
+          end
+
+          -- Allow for a single run of a program
+          vim.lsp.commands['rust-analyzer.runSingle'] = function(command)
+            local r = command.arguments[1]
+            local cmd = { 'cargo', unpack(r.args.cargoArgs) }
+            if r.args.executableArgs and #r.args.executableArgs > 0 then
+              vim.list_extend(cmd, { '--', unpack(r.args.executableArgs) })
+            end
+
+            local proc = vim.system(cmd, { cwd = r.args.cwd, env = r.args.environment })
+
+            local result = proc:wait()
+
+            if result.code == 0 then
+              vim.notify(result.stdout, vim.log.levels.INFO)
+            else
+              vim.notify(result.stderr, vim.log.levels.ERROR)
+            end
+          end
+        end
+      '';
+
+      # eval root dir taking workspaces into consideration
+      root_dir = mkLuaInline ''
+        function(bufnr, on_dir)
+          local fname = vim.api.nvim_buf_get_name(bufnr)
+          local reused_dir = rust_is_library(fname)
+          if reused_dir then
+            on_dir(reused_dir)
+            return
+          end
+
+          local cargo_crate_dir = vim.fs.root(fname, { 'Cargo.toml' })
+          local cargo_workspace_root
+
+          if cargo_crate_dir == nil then
+            on_dir(
+              vim.fs.root(fname, { 'rust-project.json' })
+                or vim.fs.dirname(vim.fs.find('.git', { path = fname, upward = true })[1])
+            )
+            return
+          end
+
+          local cmd = {
+            'cargo',
+            'metadata',
+            '--no-deps',
+            '--format-version',
+            '1',
+            '--manifest-path',
+            cargo_crate_dir .. '/Cargo.toml',
+          }
+
+          vim.system(cmd, { text = true }, function(output)
+            if output.code == 0 then
+              if output.stdout then
+                local result = vim.json.decode(output.stdout)
+                if result['workspace_root'] then
+                  cargo_workspace_root = vim.fs.normalize(result['workspace_root'])
+                end
+              end
+
+              on_dir(cargo_workspace_root or cargo_crate_dir)
+            else
+              vim.schedule(function()
+                vim.notify(('[rust_analyzer] cmd failed with code %d: %s\n%s'):format(output.code, cmd, output.stderr))
+              end)
+            end
+          end)
+        end
+      '';
+
+      # Advertise support for rust-analyzer's experimental extensions.
+      # As per nvim-lspconfig's recommendation.
+      capabilities = {
+        experimental = {
+          serverStatusNotification = true;
+          commands = {
+            commands = [
+              "rust-analyzer.showReferences"
+              "rust-analyzer.runSingle"
+              "rust-analyzer.debugSingle"
+            ];
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hi all,

Quick PR to migrate the rust away from a rustaceanvim-first config, and move it to be extension based. Related to https://github.com/NotAShelf/nvf/issues/1195.

There are a few of caveats with this approach which I would appreciate comments on. Those being:

- For some reason rustaceanvim is unable to pick up `vim.lsp.config.["rust-analyzer"].cmd` even though from my reading of the source code it should be able to do so. Therefore it is set manually for now. See https://github.com/mrcjkb/rustaceanvim/blob/8727e34809a7448b10ebc660c1425c3e808a0004/lua/rustaceanvim/lsp/init.lua#L166-L173.

- rust-analyzer is inherently, and by design, dependent on rustc and cargo. The nvim-lspconfig settings use them, and rust-analyzer itself is dependent on these tools for its own operation. If they are not in PATH, rust-analyzer is quite limited in its capabilities. My question is whether we should include them in `vim.extraPackages` perhaps? (or place a warning message if they are not present and a rust file is loaded).

- I have used mkForce in 1 area to ensure that we let rustaceanvim do root_dir and on_attach functions. I do not think that this is the most idiomatic. Perhaps setting the default `lsp.servers.rust-analyzer.root_dir` to a very low mkOverride priority, and then making rustaceanvim override it? I feel like we would then need a warning or assertion because of the wacky priorities.

- Should we add a warning that is present on build saying that we no longer use rustaceanvim by default, or is the changelog enough? 

Made with love and without AI.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [x] I have added a section in the manual
  - [x] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
