### PR TITLE
wrapper: expose `appName` in `mnw` via `config.vim.appname`

### DIFF
--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -80,7 +80,7 @@
   # Wrap the user's desired (unwrapped) Neovim package with arguments that'll be used to
   # generate a wrapped Neovim package.
   neovim-wrapped = inputs.mnw.lib.wrap {inherit pkgs;} {
-    appName = "nvf";
+    appName = config.vim.appname;
     neovim = config.vim.package;
     initLua = config.vim.builtLuaConfigRC;
     luaFiles = config.vim.extraLuaFiles;

--- a/modules/wrapper/rc/options.nix
+++ b/modules/wrapper/rc/options.nix
@@ -4,6 +4,19 @@
   inherit (lib.nvim.types) dagOf;
 in {
   options.vim = {
+    appname = mkOption {
+      type = str;
+      default = "nvf";
+      description = ''
+        Sets the {env}`NVIM_APPNAME` variable.
+
+        In traditional Neovim setups, standard directories can be further configured
+        by the {env}`NVIM_APPNAME` environment variable. This variable controls the
+        sub-directory that Nvim will read from (and auto-create) in each of the base
+        directories. See `:help $NVIM_APPNAME` for more details.
+      '';
+    };
+
     enableLuaLoader = mkOption {
       type = bool;
       default = false;


### PR DESCRIPTION
Fixes the hardcoded appname in the build wrapper. I've noticed that the way we set wrapper options is a bit... messy. We have `vim.build`, but it's used only for `finalPackage`. I'd like to establish a naming convention with @horriblename, @snoweuph and @Soliprem so this PR can be repurposed as a general-purpose wrapper refactoring one. Alternatively we should allow additional args to be passed to mnw. Maybe @Gerg-L can chime in on that. Recursive merge? Just `//`?