### PR TITLE
plugins/utility/fff-nvim: add fff.nvim module

### DIFF
--- a/flake/pkgs/by-name/fff-nvim/package.nix
+++ b/flake/pkgs/by-name/fff-nvim/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  pins,
+  rustPlatform,
+  stdenv,
+  vimUtils,
+  pkgs,
+  ...
+}: let
+  pin = pins.fff-nvim;
+
+  pname = "fff-nvim-lib";
+  version = pin.revision;
+  src = pkgs.fetchFromGitHub {
+    inherit (pin.repository) owner repo;
+    rev = pin.revision;
+    sha256 = pin.hash;
+  };
+
+  fff-nvim-lib = rustPlatform.buildRustPackage {
+    inherit pname version src;
+
+    cargoLock = {
+      lockFile = "${src}/Cargo.lock";
+    };
+
+    cargoBuildFlags = ["-p" "fff-nvim"];
+    cargoTestFlags = ["-p" "fff-nvim"];
+
+    doCheck = false;
+
+    env.RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+  };
+in
+  vimUtils.buildVimPlugin {
+    pname = "fff-nvim";
+    inherit version src;
+
+    doCheck = false;
+
+    postInstall = let
+      ext = stdenv.hostPlatform.extensions.sharedLibrary;
+    in ''
+      mkdir -p $out/target/release
+      ln -s ${fff-nvim-lib}/lib/libfff_nvim${ext} $out/target/release/libfff_nvim${ext}
+    '';
+
+    nvimSkipModules = [
+      "fff.download"
+    ];
+
+    meta = {
+      description = "A high-performance Neovim file picker with fuzzy search and frecency scoring";
+      homepage = "https://github.com/dmtrKovalenko/fff";
+      license = lib.licenses.mit;
+      maintainers = [];
+    };
+  }

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -4,6 +4,7 @@
     ./ccc
     ./diffview
     ./direnv
+    ./fff-nvim
     ./fzf-lua
     ./gestures
     ./harpoon

--- a/modules/plugins/utility/fff-nvim/config.nix
+++ b/modules/plugins/utility/fff-nvim/config.nix
@@ -1,0 +1,25 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+
+  cfg = config.vim.utility.fff-nvim;
+in {
+  vim.lazy.plugins."fff-nvim" = mkIf cfg.enable {
+    package = "fff-nvim";
+    setupModule = "fff";
+    inherit (cfg) setupOpts;
+
+    cmd = [
+      "FFFFind"
+      "FFFScan"
+      "FFFRefreshGit"
+      "FFFClearCache"
+      "FFFHealth"
+      "FFFDebug"
+      "FFFOpenLog"
+    ];
+  };
+}

--- a/modules/plugins/utility/fff-nvim/default.nix
+++ b/modules/plugins/utility/fff-nvim/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./fff-nvim.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/utility/fff-nvim/fff-nvim.nix
+++ b/modules/plugins/utility/fff-nvim/fff-nvim.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) attrs;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.utility.fff-nvim = {
+    enable = mkEnableOption "fff.nvim, a fast file picker for Neovim";
+
+    setupOpts = mkPluginSetupOption "fff.nvim" {
+      base_path = mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Base directory for searching files. Defaults to the current working directory.";
+      };
+
+      prompt = mkOption {
+        type = lib.types.str;
+        default = "  ";
+        description = "Prompt symbol used by the picker.";
+      };
+
+      title = mkOption {
+        type = lib.types.str;
+        default = "FFF Files";
+        description = "Title of the picker window.";
+      };
+
+      max_results = mkOption {
+        type = lib.types.int;
+        default = 100;
+        description = "Maximum number of results to display.";
+      };
+
+      max_threads = mkOption {
+        type = lib.types.int;
+        default = 4;
+        description = "Maximum number of background threads used for search.";
+      };
+
+      layout = mkOption {
+        type = attrs;
+        default = {};
+        description = "Layout settings (height, width, prompt_position, preview_position, ...).";
+      };
+
+      preview = mkOption {
+        type = attrs;
+        default = {};
+        description = "Preview settings (enabled, max_size, line_numbers, ...).";
+      };
+
+      keymaps = mkOption {
+        type = attrs;
+        default = {};
+        description = "Keymap overrides for the picker.";
+      };
+
+      icons = mkOption {
+        type = attrs;
+        default = {};
+        description = "Icon settings (requires a Nerd Font / icon provider).";
+      };
+
+      frecency = mkOption {
+        type = attrs;
+        default = {};
+        description = "Frecency database settings.";
+      };
+
+      debug = mkOption {
+        type = attrs;
+        default = {};
+        description = "Debug-related settings.";
+      };
+    };
+  };
+}

--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -57,7 +57,7 @@
     # Get plugins built from source from self.packages
     # If adding a new plugin to be built from source, it must also be inherited
     # here.
-    inherit (inputs.self.packages.${pkgs.stdenv.system}) blink-cmp avante-nvim;
+    inherit (inputs.self.packages.${pkgs.stdenv.system}) blink-cmp avante-nvim fff-nvim;
   };
 
   buildConfigPlugins = plugins:

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -530,6 +530,19 @@
       "url": "https://github.com/Chaitanyabsprip/fastaction.nvim/archive/b147d91727cb35be4f722f17e7d4ed5b4a5801d8.tar.gz",
       "hash": "sha256-va00sqM2Ap9faUXww5CpWJQyCixN9fIwh8p8oSLQMy8="
     },
+    "fff-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "dmtrKovalenko",
+        "repo": "fff"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "7d7910b6ba78ea8406671eaac8cdb5eb9850d9d1",
+      "url": "https://github.com/dmtrKovalenko/fff/archive/7d7910b6ba78ea8406671eaac8cdb5eb9850d9d1.tar.gz",
+      "hash": "sha256-q/RfjfVZMM8RyfOP1o2NjUP6NrOh7D2ribgq5Dvwxkc="
+    },
     "fidget-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Adds [fff.nvim](https://github.com/dmtrKovalenko/fff), a high-performance Neovim file picker with Rust-backed fuzzy search and frecency scoring.

Inspired by @notashelf's tweet (https://x.com/notashelf/status/2064925631930925270) about expanding nvf's plugin coverage.

## What

- Pin fetched via `npins` (manually appended to `npins/sources.json` because the local `npins` predates schema v7; happy to regenerate via `npins upgrade && npins add ...` on request).
- Rust shared library built from source with `rustPlatform.buildRustPackage` (the plugin requires its own `libfff_nvim.{dylib,so,dll}` to function — falling back to its bundled downloader is incompatible with Nix).
- Built artifact symlinked into `target/release/lib<name>` inside the plugin output, which is where the loader at `lua/fff/rust/init.lua` searches.
- Wired into `pluginBuilders` in `modules/wrapper/build/config.nix` alongside the existing `blink-cmp` / `avante-nvim` from-source plugins.
- Module exposes `vim.utility.fff-nvim.enable` and a `setupOpts` attrset (freeform) for the `fff.setup({...})` table. Common subtables (`layout`, `preview`, `keymaps`, `icons`, `frecency`, `debug`) are typed as `attrs` so users can pass arbitrary options without the module ever drifting from upstream.
- User commands (`FFFFind`, `FFFScan`, `FFFRefreshGit`, `FFFClearCache`, `FFFHealth`, `FFFDebug`, `FFFOpenLog`) registered as lazy `cmd` triggers via `lz.n`.

## Verified

- `nix build .#fff-nvim` succeeds on `aarch64-darwin`. Output contains `target/release/libfff_nvim.dylib` symlinked from the Rust derivation, plus the `lua/`, `plugin/`, and `doc/` trees.

## Notes

- `lua/fff/download.lua` is added to `nvimSkipModules` since the prebuilt-binary download path is irrelevant under Nix and pulls in `vim.uv` calls that the require-check hook can't satisfy.
- `cargoLock.lockFile` is used (instead of `cargoHash`) because the upstream workspace has a number of crates and pinning by hash on every bump is annoying for a fast-moving plugin.
- I'm @gustav-fff, an automated triage bot for the upstream fff repo (dmtrKovalenko/fff). This PR was prepared on @dmtrKovalenko's instruction; he is happy to review feedback. Tag him on questions specific to fff itself; I'll handle nvf-side iterations.

Honk-Honk 🪿