### PR TITLE
feat: add csvview.nvim plugin

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -235,6 +235,9 @@
   `languages/haskell.nix`
 - Made the haskell LSP and formatter configurable
 
+- Added [csvview.nvim](https://github.com/hat0uma/csvview.nvim) support under
+  `vim.utility.csvview` for rendering CSV/TSV files as aligned tables.
+
 [alfarel](https://github.com/alfarelcynthesis):
 
 [obsidian.nvim]: https://github.com/obsidian-nvim/obsidian.nvim

--- a/modules/plugins/utility/csvview/config.nix
+++ b/modules/plugins/utility/csvview/config.nix
@@ -1,0 +1,50 @@
+{
+  options,
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.binds) mkKeymap;
+
+  cfg = config.vim.utility.csvview;
+
+  keys = cfg.mappings;
+  inherit (options.vim.utility.csvview) mappings;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      lazy.plugins.csvview-nvim = {
+        package = "csvview-nvim";
+        setupModule = "csvview";
+        inherit (cfg) setupOpts;
+
+        cmd = ["CsvViewEnable" "CsvViewDisable" "CsvViewToggle" "CsvViewInfo"];
+
+        keys = [
+          (mkKeymap "n" keys.toggle "<cmd>CsvViewToggle<CR>" {desc = mappings.toggle.description;})
+        ];
+      };
+
+      # csvview.nvim has no built-in auto-enable, so drive it with a FileType
+      # autocommand. The `is_enabled` guard keeps this idempotent so
+      # re-firing FileType (e.g. `:e!`, `:set ft=csv`) doesn't warn about an
+      # already-attached buffer.
+      autocmds = mkIf cfg.autoEnable [
+        {
+          event = ["FileType"];
+          pattern = ["csv" "tsv"];
+          callback = mkLuaInline ''
+            function(args)
+              if not require("csvview").is_enabled(args.buf) then
+                require("csvview").enable()
+              end
+            end
+          '';
+          desc = "Automatically enable CSV view for CSV/TSV files";
+        }
+      ];
+    };
+  };
+}

--- a/modules/plugins/utility/csvview/csvview.nix
+++ b/modules/plugins/utility/csvview/csvview.nix
@@ -1,0 +1,80 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit (lib.types) bool int str listOf enum;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
+in {
+  options.vim.utility.csvview = {
+    enable = mkEnableOption "View CSV/TSV files as aligned tables [csvview.nvim]";
+
+    autoEnable =
+      mkEnableOption ''
+        Automatically enable the CSV view when opening CSV/TSV files.
+      ''
+      // {default = true;};
+
+    mappings = {
+      toggle = mkMappingOption "Toggle CSV view [csvview]" "<leader>tc";
+    };
+
+    # Note: These defaults are a subset of the csvview default configuration, as defined in
+    # [https://github.com/hat0uma/csvview.nvim/blob/5c22774c3ecc7f8883af5d143b366e45b1f0875d/README.md?plain=1#L97]
+    # which I think users would most likely want to modify
+    setupOpts = mkPluginSetupOption "csvview.nvim" {
+      parser = {
+        async_chunksize = mkOption {
+          type = int;
+          default = 50;
+          description = "Number of lines processed per asynchronous parsing cycle. If the UI freezes, try reducing this value.";
+        };
+
+        comments = mkOption {
+          type = listOf str;
+          default = [];
+          description = ''
+            List of comment prefixes. Lines starting with one of these are
+            treated as comments and excluded from table rendering, e.g.
+            `["#" "//"]`.
+          '';
+        };
+      };
+
+      view = {
+        min_column_width = mkOption {
+          type = int;
+          default = 5;
+          description = "Minimum width of a column";
+        };
+
+        spacing = mkOption {
+          type = int;
+          default = 2;
+          description = "Spacing between columns";
+        };
+
+        display_mode = mkOption {
+          type = enum ["highlight" "border"];
+          default = "highlight";
+          description = ''
+            Display method for the column delimiter.
+
+            - `highlight`: highlight the delimiter character.
+            - `border`: render the delimiter as a vertical border.
+          '';
+        };
+
+        sticky_header = {
+          enabled = mkOption {
+            type = bool;
+            default = true;
+            description = "Keep the header row visible at the top while scrolling";
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/plugins/utility/csvview/default.nix
+++ b/modules/plugins/utility/csvview/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./csvview.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./binds
     ./ccc
+    ./csvview
     ./diffview
     ./direnv
     ./fzf-lua

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -423,6 +423,19 @@
       "url": "https://github.com/Decodetalkers/csharpls-extended-lsp.nvim/archive/be8093d19af1538aad9ee77dc5589e55b083967a.tar.gz",
       "hash": "sha256-MDr3n9LaQ/YTHD7egDohQ7YmT2+itWXNoMLigmZp3KQ="
     },
+    "csvview-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "hat0uma",
+        "repo": "csvview.nvim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "5c22774c3ecc7f8883af5d143b366e45b1f0875d",
+      "url": "https://github.com/hat0uma/csvview.nvim/archive/5c22774c3ecc7f8883af5d143b366e45b1f0875d.tar.gz",
+      "hash": "sha256-JJZCrLhUzausIs61UfsE4472B1KzgZyI+BlbZH+gUn0="
+    },
     "dashboard-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Adds [csvview.nvim](https://github.com/hat0uma/csvview.nvim), a plugin for pretty-rendering tabular files like `.csv` and `.tsv`, under `vim.utility.csvview`.
- Included configuration options use plugin defaults.
- The plugin is enabled by default for `.csv` and `.tsv` buffers.
- A single keymap to toggle the plugin rendering is created by default: `<leader>tc`. Grepping confirmed no conflicts with existing default keymaps.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
