### PR TITLE
languages/java: fix dap running glob on nvim startup

### DIFF
--- a/modules/plugins/languages/java.nix
+++ b/modules/plugins/languages/java.nix
@@ -32,10 +32,44 @@
           {
             type = "jls",
             request = "attach",
-            name = "Attach",
+            name = "Attach Auto",
             hostName = "localhost",
             port = 5005,
-            sourceRoots = vim.fn.glob("**/src/main/java", true, true),
+            sourceRoots = function()
+              local matches = {}
+
+              -- only look max 3 deep, due to performance reasons
+              for _, pattern in ipairs({
+                "src/main/java",
+                "*/src/main/java",
+                "*/*/src/main/java",
+                "*/*/*/src/main/java",
+              }) do
+                vim.list_extend(matches, vim.fn.glob(pattern, true, true))
+              end
+
+              return matches
+            end,
+          },
+          {
+            type = "jls",
+            request = "attach",
+            name = "Attach Manual",
+            hostName = "localhost",
+            port = 5005,
+            sourceRoots = function()
+              local path = vim.fn.input(
+                "Path to src/main/java: ",
+                vim.fn.getcwd() .. "/",
+                "dir"
+              )
+
+              if path == "" then
+                return {}
+              end
+
+              return { vim.fn.fnamemodify(path, ":p") }
+            end,
           },
         }
       '';
@@ -97,20 +131,7 @@ in {
           You can change this by modifying `vim.debugger.nvim-dap.sources.java-debugger`.
           ```nix
           vim.debugger.nvim-dap.sources.java-debugger = /* lua */ '''
-            dap.adapters.jls= {
-              type = 'executable',
-              command = ''\'''${getExe' inputs.self.packages.''${pkgs.stdenv.hostPlatform.system}.jls "jls-dap"}',
-            }
-            dap.configurations.java = {
-              {
-                type = "jls",
-                request = "attach",
-                name = "Attach",
-                hostName = "localhost",
-                port = 6969, -- your custom port
-                sourceRoots = vim.fn.glob("**/src/main/java", true, true),
-              },
-            }
+            ${debuggers.jls.config}
           ''';
           ```
 


### PR DESCRIPTION
Fixes: #1638

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
