### PR TITLE
DAP rework

### DIFF
--- a/lib/types/custom.nix
+++ b/lib/types/custom.nix
@@ -46,7 +46,7 @@ in {
   # Example:
   #
   # vim.languages.typescript.lsp.servers = mkOption {
-  #   type = renamedEnum
+  #   type = enumWithRename
   #     "vim.languages.typescript.lsp.servers"
   #     ["typescript-language-server" "some-other-server"]
   #     { ts_ls = "typescript-language-server"; };

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -416,6 +416,13 @@ in {
       (mkRemovedOptionModule ["vim" "languages" "java" "dap" "package"] ''
         Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
       '')
+      (mkRenamedOptionModule
+        ["vim" "languages" "php" "dap" "xdebug" "adapter"]
+        ["vim" "debugger" "nvim-dap" "adapters" "xdebug"])
+      (mkRemovedOptionModule ["vim" "languages" "php" "dap" "xdebug" "port"] ''
+        Please use a custom `vim.debugger.nvim-dap.configurations.php`
+        instead.
+      '')
     ]
   ];
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -405,6 +405,11 @@ in {
       (mkRemovedOptionModule ["vim" "languages" "zig" "dap" "package"] ''
         Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
       '')
+      (mkRemovedOptionModule ["vim" "languages" "python" "dap" "package"] ''
+        Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
+        Also see `vim.debugger.nvim-dap.configurations.python` if you want
+        to use a custom python/additional libraries as your debuggee
+      '')
     ]
   ];
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -402,6 +402,9 @@ in {
       (mkRemovedOptionModule ["vim" "languages" "clang" "dap" "package"] ''
         Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
       '')
+      (mkRemovedOptionModule ["vim" "languages" "zig" "dap" "package"] ''
+        Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
+      '')
     ]
   ];
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -396,5 +396,12 @@ in {
         Linters can still be customized via `vim.diagnostics.nvim-lint.<name>.args`
       '')
     ]
+
+    # 2026-06-13
+    [
+      (mkRemovedOptionModule ["vim" "languages" "clang" "dap" "package"] ''
+        Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
+      '')
+    ]
   ];
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -410,6 +410,9 @@ in {
         Also see `vim.debugger.nvim-dap.configurations.python` if you want
         to use a custom python/additional libraries as your debuggee
       '')
+      (mkRemovedOptionModule ["vim" "languages" "odin" "dap" "package"] ''
+        Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
+      '')
     ]
   ];
 }

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -413,6 +413,9 @@ in {
       (mkRemovedOptionModule ["vim" "languages" "odin" "dap" "package"] ''
         Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
       '')
+      (mkRemovedOptionModule ["vim" "languages" "java" "dap" "package"] ''
+        Please use `vim.debugger.nvim-dap.adapters.<debugger>.command` instead.
+      '')
     ]
   ];
 }

--- a/modules/plugins/debugger/nvim-dap/config.nix
+++ b/modules/plugins/debugger/nvim-dap/config.nix
@@ -4,11 +4,13 @@
   lib,
   ...
 }: let
+  inherit (builtins) concatStringsSep;
   inherit (lib.strings) optionalString;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.attrsets) mapAttrs;
+  inherit (lib.attrsets) mapAttrs mapAttrsToList;
   inherit (lib.nvim.binds) mkKeymap;
   inherit (lib.nvim.dag) entryAnywhere entryAfter;
+  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.debugger.nvim-dap;
   opt = {
@@ -28,6 +30,22 @@ in {
             nvim-dap = entryAnywhere ''
               local dap = require("dap")
               vim.fn.sign_define("DapBreakpoint", { text = "🛑", texthl = "ErrorMsg", linehl = "", numhl = "" })
+
+              ${
+                concatStringsSep "\n"
+                (mapAttrsToList (name: opts: ''
+                    dap.adapters[${toLuaObject name}] = ${toLuaObject opts}
+                  '')
+                  cfg.adapters)
+              }
+
+              ${
+                concatStringsSep "\n"
+                (mapAttrsToList (ft: opts: ''
+                    dap.configurations[${toLuaObject ft}] = ${toLuaObject opts}
+                  '')
+                  cfg.configurations)
+              }
             '';
           }
           // mapAttrs (_: v: (entryAfter ["nvim-dap"] v)) cfg.sources;

--- a/modules/plugins/debugger/nvim-dap/config.nix
+++ b/modules/plugins/debugger/nvim-dap/config.nix
@@ -31,6 +31,14 @@ in {
               local dap = require("dap")
               vim.fn.sign_define("DapBreakpoint", { text = "🛑", texthl = "ErrorMsg", linehl = "", numhl = "" })
 
+              local nvf_dap_input_cache= {}
+              local function nvf_dap_cached_input(cache_key, prompt, default, completion)
+                default = nvf_dap_input_cache[cache_key] or default
+                nvf_dap_input_cache[cache_key] =
+                  vim.fn.input(prompt, default, completion)
+                return nvf_dap_input_cache[cache_key]
+              end
+
               ${
                 concatStringsSep "\n"
                 (mapAttrsToList (name: opts: ''

--- a/modules/plugins/debugger/nvim-dap/default.nix
+++ b/modules/plugins/debugger/nvim-dap/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./presets
     ./config.nix
     ./nvim-dap.nix
   ];

--- a/modules/plugins/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/plugins/debugger/nvim-dap/nvim-dap.nix
@@ -4,9 +4,229 @@
   ...
 }: let
   inherit (lib.options) mkEnableOption mkOption;
-  inherit (lib.types) bool attrsOf str;
-  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (lib.types) bool attrsOf str submodule anything either enum oneOf listOf nullOr int;
+  inherit (lib.nvim.types) mkPluginSetupOption luaInline;
   inherit (config.vim.lib) mkMappingOption;
+
+  commonOptions = {
+    initialize_timeout_sec = mkOption {
+      type = nullOr int;
+      default = null;
+      defaultText = "4"; # plugin default
+      description = ''
+        How many seconds to wait for a response on an initialize request before
+        emitting a warning
+      '';
+    };
+
+    disconnect_timeout_sec = mkOption {
+      type = nullOr int;
+      default = null;
+      defaultText = "3"; # plugin default
+      description = ''
+        How many seconds to wait for a disconnect response before
+        emitting a warning and closing the connection
+      '';
+    };
+
+    source_filetype = mkOption {
+      type = nullOr str;
+      default = null;
+      description = ''
+        The filetype to use for content retrieved via a source request
+      '';
+    };
+  };
+
+  # enrich_config accepted by all adapter types
+  enrich_config = mkOption {
+    type = nullOr luaInline;
+    default = null;
+    description = ''
+      Used to enrich a configurations with additional information.
+      See `:help dap-adapter`.
+    '';
+  };
+
+  execAdapterType = submodule {
+    options = {
+      type = mkOption {
+        type = enum ["executable"];
+      };
+
+      command = mkOption {
+        type = str;
+        description = "Command to invoke";
+      };
+
+      args = mkOption {
+        type = listOf str;
+      };
+
+      options =
+        commonOptions
+        // {
+          env = mkOption {
+            type = nullOr (attrsOf str);
+            default = null;
+            description = "Environment variables passed to the command";
+          };
+
+          cwd = mkOption {
+            type = nullOr str;
+            default = null;
+            description = "Set the working directory for the command";
+          };
+
+          detached = mkOption {
+            type = nullOr bool;
+            default = null;
+            defaultText = "true"; # plugin default
+            description = ''
+              Whether to spawn the debug adapter process in a detached state
+            '';
+          };
+        };
+
+      id = mkOption {
+        type = nullOr str;
+        default = null;
+        description = ''
+          Identifier of the adapter. This is used for the `adapterId` property
+          of the initialize request.
+        '';
+      };
+
+      inherit enrich_config;
+    };
+  };
+
+  serverPipeExecutable = submodule {
+    options = {
+      command = mkOption {
+        type = nullOr str;
+        description = "Command that spawns the debug adapter";
+      };
+
+      args = mkOption {
+        type = nullOr (listOf str);
+        default = null;
+      };
+
+      detached = mkOption {
+        type = nullOr bool;
+        default = null;
+        defaultText = "true"; # plugin default
+        description = ''
+          Whether to spawn the debug adapter process in a detached state
+        '';
+      };
+
+      cwd = mkOption {
+        type = nullOr str;
+        default = null;
+        description = "Working directory";
+      };
+    };
+  };
+
+  serverAdapterType = submodule {
+    options = {
+      type = mkOption {
+        type = enum ["server"];
+      };
+
+      host = mkOption {
+        type = nullOr str;
+        default = null;
+        defaultText = "127.0.0.1"; # plugin default
+        description = "Host to connect to";
+      };
+
+      port = mkOption {
+        type = either int (enum ["\${port}"]);
+        description = ''
+          Port to connect to. Use "''${port}" for a dynamically resolved free
+          port. This is intended to be used with executable.args.
+        '';
+      };
+
+      id = mkOption {
+        type = nullOr str;
+        default = null;
+        description = ''
+          Identifier of the adapter. This is used for the `adapterId` property
+          of the initialize request.
+        '';
+      };
+
+      executable = mkOption {
+        type = nullOr serverPipeExecutable;
+        default = null;
+        description = ''
+          Optional executable configuration to launch the debug adapter before
+          connecting via TCP
+        '';
+      };
+
+      options =
+        commonOptions
+        // {
+          max_retries = mkOption {
+            type = nullOr int;
+            default = null;
+            defaultText = "14"; # plugin default
+            description = ''
+              Amount of times the client should attempt to connect before
+              erroring out (250ms delay between retries)
+            '';
+          };
+        };
+
+      inherit enrich_config;
+    };
+  };
+
+  pipeAdapterType = submodule {
+    options = {
+      type = mkOption {
+        type = enum ["pipe"];
+      };
+
+      pipe = mkOption {
+        type = str;
+        description = ''
+          Absolute path to the pipe file. Use \"''${pipe}\" for a dynamically
+          generated temporary filename
+        '';
+      };
+
+      executable = mkOption {
+        type = nullOr serverPipeExecutable;
+        default = null;
+        description = ''
+          Optional executable configuration to launch the debug adapter before
+          connecting via pipe
+        '';
+      };
+
+      options =
+        commonOptions
+        // {
+          timeout = mkOption {
+            type = nullOr int;
+            default = null;
+            defaultText = "5000"; # plugin default
+            description = ''
+              Max amount of time in ms to wait between spawning the
+              executable and connecting to the pipe
+            '';
+          };
+        };
+
+      inherit enrich_config;
+    };
+  };
 in {
   options.vim.debugger.nvim-dap = {
     enable = mkEnableOption "debugging via nvim-dap";
@@ -19,7 +239,10 @@ in {
       autoStart = mkOption {
         type = bool;
         default = true;
-        description = "Automatically Opens and Closes DAP-UI upon starting/closing a debugging session";
+        description = ''
+          Automatically Opens and Closes DAP-UI upon starting/closing a
+          debugging session
+        '';
       };
     };
 
@@ -27,6 +250,27 @@ in {
       default = {};
       description = "List of debuggers to install";
       type = attrsOf str;
+    };
+
+    adapters = mkOption {
+      type = attrsOf (oneOf [
+        luaInline
+        execAdapterType
+        serverAdapterType
+        pipeAdapterType
+      ]);
+      default = {};
+      description = "Adapter configurations. See `:help dap-adapter`";
+    };
+
+    configurations = mkOption {
+      type = attrsOf (listOf anything);
+      default = {};
+      description = ''
+        Mapping of filetype to list of possible `Configuration`.
+
+        See `:help dap-configuration`.
+      '';
     };
 
     mappings = {

--- a/modules/plugins/debugger/nvim-dap/nvim-dap.nix
+++ b/modules/plugins/debugger/nvim-dap/nvim-dap.nix
@@ -227,6 +227,31 @@
       inherit enrich_config;
     };
   };
+
+  configurationType = submodule {
+    freeformType = attrsOf anything;
+    # These 3 options are required, everything else is passed to the debug
+    # adapter
+    options = {
+      type = mkOption {
+        type = str;
+        description = "Which debug adapter to use";
+      };
+
+      request = mkOption {
+        type = enum ["attach" "launch"];
+        description = ''
+          Indicates whether the debug adapter should launch a debuggee or attach
+          to one that is already running.
+        '';
+      };
+
+      name = mkOption {
+        type = str;
+        description = "A user-readable name for the configuration";
+      };
+    };
+  };
 in {
   options.vim.debugger.nvim-dap = {
     enable = mkEnableOption "debugging via nvim-dap";
@@ -264,10 +289,10 @@ in {
     };
 
     configurations = mkOption {
-      type = attrsOf (listOf anything);
+      type = attrsOf (listOf configurationType);
       default = {};
       description = ''
-        Mapping of filetype to list of possible `Configuration`.
+        Mapping of filetype to list of debuggee configurations.
 
         See `:help dap-configuration`.
       '';

--- a/modules/plugins/debugger/nvim-dap/presets/debugpy.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/debugpy.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.meta) getExe;
+
+  cfg = config.vim.debugger.nvim-dap.presets.debugpy;
+  package = pkgs.python3.withPackages (ps: with ps; [debugpy]);
+in {
+  options.vim.debugger.nvim-dap.presets.debugpy = {
+    enable = mkEnableOption ''
+      adapter configuration for debugpy.
+      Use {option}`vim.debugger.nvim-dap.adapters.debugpy` for customization.
+
+      A configuration is also needed for your filetype in
+      {option}`vim.debugger.nvim-dap.configurations`
+      See https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings
+      for supported options.
+    '';
+  };
+
+  config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {
+    debugpy = mkLuaInline ''
+      function(cb, config)
+        if config.request == "attach" then
+          local port = (config.connect or config).port
+          local host = (config.connect or config).host or "127.0.0.1"
+          cb({
+            type = "server",
+            port = assert(port, "`connect.port` is required for a python `attach` configuration"),
+            host = host,
+            options = {
+              source_filetype = "python",
+            },
+          })
+        else
+          cb({
+            type = "executable",
+            command = "${getExe package}",
+            args = { "-m", "debugpy.adapter" },
+            options = {
+              source_filetype = "python",
+            },
+          })
+        end
+      end
+    '';
+  };
+}

--- a/modules/plugins/debugger/nvim-dap/presets/default.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./lldb.nix
+  ];
+}

--- a/modules/plugins/debugger/nvim-dap/presets/default.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/default.nix
@@ -3,5 +3,6 @@
     ./debugpy.nix
     ./jls.nix
     ./lldb.nix
+    ./xdebug.nix
   ];
 }

--- a/modules/plugins/debugger/nvim-dap/presets/default.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./debugpy.nix
     ./lldb.nix
   ];
 }

--- a/modules/plugins/debugger/nvim-dap/presets/default.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./debugpy.nix
+    ./jls.nix
     ./lldb.nix
   ];
 }

--- a/modules/plugins/debugger/nvim-dap/presets/jls.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/jls.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  pkgs,
+  config,
+  inputs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.meta) getExe';
+
+  cfg = config.vim.debugger.nvim-dap.presets.jls;
+  pkg = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.jls;
+in {
+  options.vim.debugger.nvim-dap.presets.jls = {
+    enable = mkEnableOption ''
+      adapter configuration for JLS.
+      Use {option}`vim.debugger.nvim-dap.adapters.jls` for customization.
+
+      A configuration is also needed for your filetype in
+      {option}`vim.debugger.nvim-dap.configurations`
+    '';
+  };
+
+  config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {
+    jls = {
+      type = "executable";
+      command = getExe' pkg "jls-dap";
+    };
+  };
+}

--- a/modules/plugins/debugger/nvim-dap/presets/lldb.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/lldb.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption;
+
+  cfg = config.vim.debugger.nvim-dap.presets.lldb;
+in {
+  options.vim.debugger.nvim-dap.presets.lldb = {
+    enable = mkEnableOption ''
+      adapter configuration for LLDB using `lldb-dap`.
+      Use {option}`vim.debugger.nvim-dap.adapters.lldb` for customization.
+
+      A configuration is also needed for your filetype in
+      {option}`vim.debugger.nvim-dap.configurations`
+    '';
+  };
+
+  config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {
+    lldb = {
+      type = "executable";
+      command = "${pkgs.lldb}/bin/lldb-dap";
+    };
+  };
+}

--- a/modules/plugins/debugger/nvim-dap/presets/xdebug.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/xdebug.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.meta) getExe;
+
+  cfg = config.vim.debugger.nvim-dap.presets.xdebug;
+in {
+  options.vim.debugger.nvim-dap.presets.xdebug = {
+    enable = mkEnableOption ''
+      adapter configuration for Xdebug.
+      Use {option}`vim.debugger.nvim-dap.adapters.xdebug` for customization.
+
+      A configuration is also needed for your filetype in
+      {option}`vim.debugger.nvim-dap.configurations`
+    '';
+  };
+
+  config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {
+    xdebug = {
+      type = "executable";
+      command = getExe pkgs.nodejs;
+      args = [
+        "${pkgs.vscode-extensions.xdebug.php-debug}/share/vscode/extensions/xdebug.php-debug/out/phpDebug.js"
+      ];
+    };
+  };
+}

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -6,47 +6,38 @@
 }: let
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
-  inherit (lib.types) bool enum package listOf;
+  inherit (lib.types) bool enum listOf;
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe getExe';
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.generators) mkLuaInline;
+  inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.dag) entryAfter;
   inherit (lib.nvim.attrsets) mapListToAttrs;
+  inherit (lib.nvim.types) deprecatedSingleOrListOf enumWithRename;
 
   cfg = config.vim.languages.clang;
 
   defaultServers = ["clangd"];
   servers = ["ccls" "clangd"];
 
-  defaultDebugger = "lldb-vscode";
-  debuggers = {
-    lldb-vscode = {
-      package = pkgs.lldb;
-      dapConfig = ''
-        dap.adapters.lldb = {
-          type = 'executable',
-          command = '${cfg.dap.package}/bin/lldb-dap',
-          name = 'lldb'
-        }
-        dap.configurations.cpp = {
-          {
-            name = 'Launch',
-            type = 'lldb',
-            request = 'launch',
-            program = function()
-              return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
-            end,
-            cwd = "''${workspaceFolder}",
-            stopOnEntry = false,
-            args = {},
-          },
-        }
-
-        dap.configurations.c = dap.configurations.cpp
-      '';
-    };
+  defaultDebugger = ["lldb"];
+  dapConfigurations = {
+    lldb = [
+      {
+        name = "Launch";
+        type = "lldb";
+        request = "launch";
+        program = mkLuaInline ''
+          function()
+            return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+          end
+        '';
+        cwd = "\${workspaceFolder}";
+        stopOnEntry = false;
+        args = [];
+      }
+    ];
   };
 
   defaultFormat = ["clang-format"];
@@ -147,13 +138,12 @@ in {
       };
       debugger = mkOption {
         description = "clang debugger to use";
-        type = enum (attrNames debuggers);
+        type =
+          deprecatedSingleOrListOf "vim.languages.clang.dap.debugger"
+          (enumWithRename "vim.languages.clang.dap.debugger" (attrNames dapConfigurations) {
+            lldb-vscode = "lldb";
+          });
         default = defaultDebugger;
-      };
-      package = mkOption {
-        description = "clang debugger package.";
-        type = package;
-        default = debuggers.${cfg.dap.debugger}.package;
       };
     };
 
@@ -208,8 +198,16 @@ in {
     })
 
     (mkIf cfg.dap.enable {
-      vim.debugger.nvim-dap.enable = true;
-      vim.debugger.nvim-dap.sources.clang-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
+      vim.debugger.nvim-dap = let
+        conf = mkMerge (map (name: dapConfigurations.${name}) cfg.dap.debugger);
+      in {
+        enable = true;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations = {
+          c = conf;
+          cpp = conf;
+        };
+      };
     })
 
     (mkIf cfg.format.enable {

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -30,7 +30,11 @@
         request = "launch";
         program = mkLuaInline ''
           function()
-            return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+            return nvf_dap_cached_input(
+              'clang_lldb_launch_exe',
+              "Path to executable: ",
+              vim.fn.getcwd() .. "/",
+              "file")
           end
         '';
         cwd = "\${workspaceFolder}";

--- a/modules/plugins/languages/java.nix
+++ b/modules/plugins/languages/java.nix
@@ -53,7 +53,8 @@
         port = 5005;
         sourceRoots = mkLuaInline ''
           function()
-            local path = vim.fn.input(
+            local path = nvf_dap_cached_input(
+              "java_jls_attach_root",
               "Path to src/main/java: ",
               vim.fn.getcwd() .. "/",
               "dir"

--- a/modules/plugins/languages/java.nix
+++ b/modules/plugins/languages/java.nix
@@ -2,78 +2,72 @@
   config,
   pkgs,
   lib,
-  inputs,
   ...
 }: let
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.types) listOf str enum package;
+  inherit (lib.types) listOf str enum;
   inherit (lib.attrsets) attrNames genAttrs;
-  inherit (lib.meta) getExe getExe';
-  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption enumWithRename;
+  inherit (lib.lists) flatten;
+  inherit (lib.meta) getExe;
+  inherit (lib.generators) mkLuaInline toPretty;
+  inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf enumWithRename;
 
   cfg = config.vim.languages.java;
 
   defaultServers = ["jdt-language-server"];
   servers = ["jdt-language-server" "jls"];
 
-  defaultDebugger = "jls";
-  debuggers = {
-    jls = let
-      pkg = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.jls;
-    in {
-      package = pkg;
-      config = ''
-        dap.adapters.jls= {
-          type = 'executable',
-          command = '${getExe' pkg "jls-dap"}',
-        }
-        dap.configurations.java = {
-          {
-            type = "jls",
-            request = "attach",
-            name = "Attach Auto",
-            hostName = "localhost",
-            port = 5005,
-            sourceRoots = function()
-              local matches = {}
+  defaultDebugger = ["jls"];
+  dapConfigurations = {
+    jls = [
+      {
+        type = "jls";
+        request = "attach";
+        name = "Attach Auto";
+        hostName = "localhost";
+        port = 5005;
+        sourceRoots = mkLuaInline ''
+          function()
+            local matches = {}
 
-              -- only look max 3 deep, due to performance reasons
-              for _, pattern in ipairs({
-                "src/main/java",
-                "*/src/main/java",
-                "*/*/src/main/java",
-                "*/*/*/src/main/java",
-              }) do
-                vim.list_extend(matches, vim.fn.glob(pattern, true, true))
-              end
+            -- only look max 3 deep, due to performance reasons
+            for _, pattern in ipairs({
+              "src/main/java",
+              "*/src/main/java",
+              "*/*/src/main/java",
+              "*/*/*/src/main/java",
+            }) do
+              vim.list_extend(matches, vim.fn.glob(pattern, true, true))
+            end
 
-              return matches
-            end,
-          },
-          {
-            type = "jls",
-            request = "attach",
-            name = "Attach Manual",
-            hostName = "localhost",
-            port = 5005,
-            sourceRoots = function()
-              local path = vim.fn.input(
-                "Path to src/main/java: ",
-                vim.fn.getcwd() .. "/",
-                "dir"
-              )
+            return matches
+          end
+        '';
+      }
+      {
+        type = "jls";
+        request = "attach";
+        name = "Attach Manual";
+        hostName = "localhost";
+        port = 5005;
+        sourceRoots = mkLuaInline ''
+          function()
+            local path = vim.fn.input(
+              "Path to src/main/java: ",
+              vim.fn.getcwd() .. "/",
+              "dir"
+            )
 
-              if path == "" then
-                return {}
-              end
+            if path == "" then
+              return {}
+            end
 
-              return { vim.fn.fnamemodify(path, ":p") }
-            end,
-          },
-        }
-      '';
-    };
+            return { vim.fn.fnamemodify(path, ":p") }
+          end
+        '';
+      }
+    ];
   };
 in {
   options.vim.languages.java = {
@@ -117,22 +111,28 @@ in {
         };
 
       debugger = mkOption {
-        type = enum (attrNames debuggers);
+        type =
+          deprecatedSingleOrListOf "vim.languages.java.dap.debugger"
+          (enum (attrNames dapConfigurations));
         default = defaultDebugger;
         description = ''
           Java debugger to use.
 
           **JLS**
 
-          For `jls` to work, you need to run your application with debug symbols and networking.
+          For `jls` to work, you need to run your application with debug
+          symbols and networking.
 
-          The `jls` configuration is hardcoded to listen on port `5005`.
-          This matches the configuration described [upstream](https://github.com/idelice/jls#usage).
-          You can change this by modifying `vim.debugger.nvim-dap.sources.java-debugger`.
+          The `jls` configuration is hardcoded to listen on port `5005`. This
+          matches the configuration described
+          [upstream](https://github.com/idelice/jls#usage). You can change this
+          by modifying {option}`vim.debugger.nvim-dap.configurations.java`.
           ```nix
-          vim.debugger.nvim-dap.sources.java-debugger = /* lua */ '''
-            ${debuggers.jls.config}
-          ''';
+          # mkForce can be omitted if you want to retain our default
+          # configurations
+          vim.debugger.nvim-dap.configurations.java =
+            lib.mkForce
+            ${toPretty {indent = "  ";} dapConfigurations.jls};
           ```
 
           *Examples:*
@@ -147,17 +147,12 @@ in {
                java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -jar your.jar
                ```
           - Springboot Maven:
-            For Springboot you can just pass the JVM args directly into the `spring-boot:run`.
+            For Springboot you can just pass the JVM args directly into the
+            `spring-boot:run`.
             ```sh
             mvn spring-boot:run -Dspring-boot.run.jvmArguments="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
             ```
         '';
-      };
-
-      package = mkOption {
-        type = package;
-        default = debuggers.${cfg.dap.debugger}.package;
-        description = "Java debugger package.";
       };
     };
 
@@ -218,7 +213,8 @@ in {
     (mkIf cfg.dap.enable {
       vim.debugger.nvim-dap = {
         enable = true;
-        sources.java-debugger = debuggers.${cfg.dap.debugger}.config;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations.java = flatten (map (name: dapConfigurations.${name}) cfg.dap.debugger);
       };
     })
 

--- a/modules/plugins/languages/odin.nix
+++ b/modules/plugins/languages/odin.nix
@@ -26,7 +26,11 @@
         request = "launch";
         program = mkLuaInline ''
           function()
-            return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+            return nvf_dap_cached_input(
+              'odin_lldb_launch_exe',
+              "Path to executable: ",
+              vim.fn.getcwd() .. "/",
+              "file")
           end
         '';
         cwd = "\${workspaceFolder}";

--- a/modules/plugins/languages/odin.nix
+++ b/modules/plugins/languages/odin.nix
@@ -7,27 +7,33 @@
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.types) enum package listOf;
-  inherit (lib.nvim.dag) entryAfter;
-  inherit (lib) genAttrs;
-  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.types) enum listOf;
+  inherit (lib.attrsets) genAttrs;
+  inherit (lib.lists) flatten;
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf enumWithRename;
 
   cfg = config.vim.languages.odin;
 
   defaultServers = ["ols"];
   servers = ["ols"];
-  defaultDebugger = "codelldb";
-  debuggers = {
-    codelldb = {
-      package = pkgs.lldb;
-      dapConfig = ''
-        dap.adapters.codelldb = {
-          type = 'executable',
-          command = '${cfg.dap.package}/bin/lldb-dap',
-          name = 'codelldb'
-        }
-      '';
-    };
+  defaultDebugger = ["lldb"];
+  dapConfigurations = {
+    lldb = [
+      {
+        name = "Launch";
+        type = "lldb";
+        request = "launch";
+        program = mkLuaInline ''
+          function()
+            return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+          end
+        '';
+        cwd = "\${workspaceFolder}";
+        stopOnEntry = false;
+        args = [];
+      }
+    ];
   };
 in {
   options.vim.languages.odin = {
@@ -68,14 +74,13 @@ in {
 
       debugger = mkOption {
         description = "Odin debugger to use";
-        type = enum (attrNames debuggers);
-        default = defaultDebugger;
-      };
+        type =
+          deprecatedSingleOrListOf "vim.languages.clang.dap.debugger"
+          (enumWithRename "vim.languages.clang.dap.debugger" (attrNames dapConfigurations) {
+            codelldb = "lldb";
+          });
 
-      package = mkOption {
-        description = "Odin debugger package.";
-        type = package;
-        default = debuggers.${cfg.dap.debugger}.package;
+        default = defaultDebugger;
       };
     };
   };
@@ -96,15 +101,10 @@ in {
     })
 
     (mkIf cfg.dap.enable {
-      vim = {
-        startPlugins = ["nvim-dap-odin"];
-        debugger.nvim-dap.sources.odin-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
-        pluginRC.nvim-dap-odin = entryAfter ["nvim-dap"] ''
-          require('nvim-dap-odin').setup({
-            notifications = false -- contains no useful information
-          })
-        '';
-        debugger.nvim-dap.enable = true;
+      vim.debugger.nvim-dap = {
+        enable = true;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations.odin = flatten (map (name: dapConfigurations.${name}) cfg.dap.debugger);
       };
     })
   ]);

--- a/modules/plugins/languages/php.nix
+++ b/modules/plugins/languages/php.nix
@@ -7,10 +7,9 @@
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib) genAttrs;
-  inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.types) enum int attrs listOf;
-  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.types) enum listOf;
+  inherit (lib.lists) flatten;
   inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.attrsets) mapListToAttrs;
 
@@ -36,6 +35,20 @@
 
   defaultDiagnosticsProvider = ["phpstan"];
   diagnosticsProviders = ["phpstan"];
+
+  defaultDebugger = ["xdebug"];
+  dapConfigurations = {
+    xdebug = let
+      port = 9003;
+    in [
+      {
+        type = "xdebug";
+        request = "launch";
+        name = "Listen for XDebug at port ${toString port}";
+        inherit port;
+      }
+    ];
+  };
 in {
   options.vim.languages.php = {
     enable = mkEnableOption "PHP language support";
@@ -87,23 +100,11 @@ in {
           default = config.vim.languages.enableDAP;
           defaultText = literalExpression "config.vim.languages.enableDAP";
         };
-      xdebug = {
-        adapter = mkOption {
-          type = attrs;
-          default = {
-            type = "executable";
-            command = getExe pkgs.nodejs;
-            args = [
-              "${pkgs.vscode-extensions.xdebug.php-debug}/share/vscode/extensions/xdebug.php-debug/out/phpDebug.js"
-            ];
-          };
-          description = "XDebug adapter to use for nvim-dap";
-        };
-        port = mkOption {
-          type = int;
-          default = 9003;
-          description = "Port to use for XDebug";
-        };
+
+      debugger = mkOption {
+        type = listOf (enum (attrNames dapConfigurations));
+        default = defaultDebugger;
+        description = "PHP debugger to use";
       };
     };
 
@@ -154,21 +155,10 @@ in {
     })
 
     (mkIf cfg.dap.enable {
-      vim = {
-        debugger.nvim-dap = {
-          enable = true;
-          sources.php-debugger = ''
-            dap.adapters.xdebug = ${toLuaObject cfg.dap.xdebug.adapter}
-            dap.configurations.php = {
-              {
-                  type = 'xdebug',
-                  request = 'launch',
-                  name = 'Listen for XDebug',
-                  port = ${toString cfg.dap.xdebug.port},
-              },
-            }
-          '';
-        };
+      vim.debugger.nvim-dap = {
+        enable = true;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations.php = flatten (map (name: dapConfigurations.${name}) cfg.dap.debugger);
       };
     })
 

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -11,6 +11,7 @@
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.types) enum package bool listOf;
+  inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.nvim.types) deprecatedSingleOrListOf;
   inherit (lib.trivial) warn;
@@ -49,67 +50,34 @@
     };
   };
 
-  defaultDebugger = "debugpy";
-  debuggers = {
-    debugpy = {
-      # idk if this is the best way to install/run debugpy
-      package = pkgs.python3.withPackages (ps: with ps; [debugpy]);
-      dapConfig = ''
-        dap.adapters.debugpy = function(cb, config)
-          if config.request == 'attach' then
-            ---@diagnostic disable-next-line: undefined-field
-            local port = (config.connect or config).port
-            ---@diagnostic disable-next-line: undefined-field
-            local host = (config.connect or config).host or '127.0.0.1'
-            cb({
-              type = 'server',
-              port = assert(port, '`connect.port` is required for a python `attach` configuration'),
-              host = host,
-              options = {
-                source_filetype = 'python',
-              },
-            })
-          else
-            cb({
-              type = 'executable',
-              command = '${getExe cfg.dap.package}',
-              args = { '-m', 'debugpy.adapter' },
-              options = {
-                source_filetype = 'python',
-              },
-            })
+  defaultDebugger = ["debugpy"];
+  dapConfigurations = {
+    debugpy = [
+      {
+        type = "debugpy";
+        request = "launch";
+        name = "Launch file";
+
+        program = "\${file}";
+        pythonPath = mkLuaInline ''
+          function()
+            -- debugpy supports launching an application with a different interpreter then the one used to launch debugpy itself.
+            -- The code below looks for a `venv` or `.venv` folder in the current directly and uses the python within.
+            -- You could adapt this - to for example use the `VIRTUAL_ENV` environment variable.
+            local cwd = vim.fn.getcwd()
+            if vim.fn.executable(cwd .. "/venv/bin/python") == 1 then
+              return cwd .. "/venv/bin/python"
+            elseif vim.fn.executable(cwd .. "/.venv/bin/python") == 1 then
+              return cwd .. "/.venv/bin/python"
+            elseif vim.fn.executable("python") == 1 then
+              return vim.fn.exepath("python")
+            else -- this uses the same python package as the debugger
+              return nil
+            end
           end
-        end
-
-        dap.configurations.python = {
-          {
-            -- The first three options are required by nvim-dap
-            type = 'debugpy'; -- the type here established the link to the adapter definition: `dap.adapters.debugpy`
-            request = 'launch';
-            name = "Launch file";
-
-            -- Options below are for debugpy, see https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings for supported options
-
-            program = "''${file}"; -- This configuration will launch the current file if used.
-            pythonPath = function()
-              -- debugpy supports launching an application with a different interpreter then the one used to launch debugpy itself.
-              -- The code below looks for a `venv` or `.venv` folder in the current directly and uses the python within.
-              -- You could adapt this - to for example use the `VIRTUAL_ENV` environment variable.
-              local cwd = vim.fn.getcwd()
-              if vim.fn.executable(cwd .. '/venv/bin/python') == 1 then
-                return cwd .. '/venv/bin/python'
-              elseif vim.fn.executable(cwd .. '/.venv/bin/python') == 1 then
-                return cwd .. '/.venv/bin/python'
-              elseif vim.fn.executable("python") == 1 then
-                return vim.fn.exepath("python")
-              else -- WARNING cfg.dap.package probably has NO libraries other than builtins and debugpy
-                return '${getExe cfg.dap.package}'
-              end
-            end;
-          },
-        }
-      '';
-    };
+        '';
+      }
+    ];
   };
   defaultDiagnosticsProvider = ["mypy"];
   diagnosticsProviders = ["mypy"];
@@ -171,19 +139,9 @@ in {
       };
 
       debugger = mkOption {
-        type = enum (attrNames debuggers);
+        type = deprecatedSingleOrListOf "vim.languages.python.dap.debugger" (enum (attrNames dapConfigurations));
         default = defaultDebugger;
         description = "Python debugger to use";
-      };
-
-      package = mkOption {
-        type = package;
-        default = debuggers.${cfg.dap.debugger}.package;
-        example = literalExpression "with pkgs; python39.withPackages (ps: with ps; [debugpy])";
-        description = ''
-          Python debugger package.
-          This is a python package with debugpy installed, see https://nixos.wiki/wiki/Python#Install_Python_Packages.
-        '';
       };
     };
 
@@ -250,8 +208,11 @@ in {
     })
 
     (mkIf cfg.dap.enable {
-      vim.debugger.nvim-dap.enable = true;
-      vim.debugger.nvim-dap.sources.python-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
+      vim.debugger.nvim-dap = {
+        enable = true;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations.python = flatten (map (name: dapConfigurations.${name}) cfg.dap.debugger);
+      };
     })
 
     (mkIf cfg.extraDiagnostics.enable {

--- a/modules/plugins/languages/zig.nix
+++ b/modules/plugins/languages/zig.nix
@@ -7,43 +7,34 @@
   inherit (builtins) attrNames;
   inherit (lib.options) mkEnableOption mkOption literalExpression;
   inherit (lib.modules) mkIf mkMerge mkDefault;
-  inherit (lib) genAttrs;
-  inherit (lib.types) bool package enum listOf;
-  inherit (lib.nvim.types) mkGrammarOption;
+  inherit (lib.generators) mkLuaInline;
+  inherit (lib.attrsets) genAttrs;
+  inherit (lib.lists) flatten;
+  inherit (lib.types) bool enum listOf;
+  inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf enumWithRename;
 
   cfg = config.vim.languages.zig;
 
   defaultServers = ["zls"];
   servers = ["zls"];
 
-  # TODO: dap.adapter.lldb is duplicated when enabling the
-  # vim.languages.clang.dap module. This does not cause
-  # breakage... but could be cleaner.
-  defaultDebugger = "lldb-vscode";
-  debuggers = {
-    lldb-vscode = {
-      package = pkgs.lldb;
-      dapConfig = ''
-        dap.adapters.lldb = {
-          type = 'executable',
-          command = '${cfg.dap.package}/bin/lldb-dap',
-          name = 'lldb'
-        }
-        dap.configurations.zig = {
-          {
-            name = 'Launch',
-            type = 'lldb',
-            request = 'launch',
-            program = function()
-              return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
-            end,
-            cwd = "''${workspaceFolder}",
-            stopOnEntry = false,
-            args = {},
-          },
-        }
-      '';
-    };
+  defaultDebugger = ["lldb"];
+  dapConfigurations = {
+    lldb = [
+      {
+        name = "Launch";
+        type = "lldb";
+        request = "launch";
+        program = mkLuaInline ''
+          function()
+            return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+          end
+        '';
+        cwd = "\${workspaceFolder}";
+        stopOnEntry = false;
+        args = [];
+      }
+    ];
   };
 in {
   options.vim.languages.zig = {
@@ -83,15 +74,13 @@ in {
       };
 
       debugger = mkOption {
-        type = enum (attrNames debuggers);
+        type =
+          deprecatedSingleOrListOf "vim.languages.zig.dap.debugger"
+          (enumWithRename "vim.languages.zig.dap.debugger" (attrNames dapConfigurations) {
+            lldb-vscode = "lldb";
+          });
         default = defaultDebugger;
         description = "Zig debugger to use";
-      };
-
-      package = mkOption {
-        type = package;
-        default = debuggers.${cfg.dap.debugger}.package;
-        description = "Zig debugger package.";
       };
     };
   };
@@ -119,9 +108,10 @@ in {
     })
 
     (mkIf cfg.dap.enable {
-      vim = {
-        debugger.nvim-dap.enable = true;
-        debugger.nvim-dap.sources.zig-debugger = debuggers.${cfg.dap.debugger}.dapConfig;
+      vim.debugger.nvim-dap = {
+        enable = true;
+        presets = genAttrs cfg.dap.debugger (_: {enable = true;});
+        configurations.zig = flatten (map (name: dapConfigurations.${name}) cfg.dap.debugger);
       };
     })
   ]);

--- a/modules/plugins/languages/zig.nix
+++ b/modules/plugins/languages/zig.nix
@@ -27,7 +27,12 @@
         request = "launch";
         program = mkLuaInline ''
           function()
-            return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+            return nvf_dap_cached_input(
+              'zig_lldb_launch_exe',
+              'Path to executable: ',
+              vim.fn.getcwd() .. '/',
+              'file'
+            )
           end
         '';
         cwd = "\${workspaceFolder}";


### PR DESCRIPTION
following our trend of nix-friendly APIs (e.g. vim.lsp.servers), this is a draft for a reworked DAP API. the main additions are `vim.debugger.nvim-dap.adapters` and `configurations`. I went a bit hard on the type for adapters maybe we can simplify it just to make maintaining easier

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
