### PR TITLE
wrapper/environment: add `vim.appName` to configure `NVIM_APPNAME`

### DIFF
--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -4,17 +4,25 @@
   pkgs,
   lib,
   ...
-}: let
+}:
+let
   inherit (pkgs) vimPlugins;
   inherit (lib.trivial) flip;
-  inherit (builtins) filter isString hasAttr getAttr;
+  inherit (builtins)
+    filter
+    isString
+    hasAttr
+    getAttr
+    ;
 
   getPin = flip getAttr (inputs.mnw.lib.npinsToPluginsAttrs pkgs ../../../npins/sources.json);
 
   # Build a Vim plugin with the given name and arguments.
-  buildPlug = attrs: let
-    pin = getPin attrs.pname;
-  in
+  buildPlug =
+    attrs:
+    let
+      pin = getPin attrs.pname;
+    in
     pkgs.vimUtils.buildVimPlugin (
       {
         version = pin.revision or "dirty";
@@ -24,16 +32,14 @@
     );
 
   # Build a given Treesitter grammar.
-  buildTreesitterPlug = grammars:
-    vimPlugins.nvim-treesitter.withPlugins (
-      _: builtins.filter (g: g != null) grammars
-    );
+  buildTreesitterPlug =
+    grammars: vimPlugins.nvim-treesitter.withPlugins (_: builtins.filter (g: g != null) grammars);
 
   pluginBuilders = {
     nvim-treesitter = buildTreesitterPlug config.vim.treesitter.grammars;
     flutter-tools-patched = buildPlug {
       pname = "flutter-tools-nvim";
-      patches = [./patches/flutter-tools.patch];
+      patches = [ ./patches/flutter-tools.patch ];
 
       # Disable failing require check hook checks
       doCheck = false;
@@ -60,27 +66,28 @@
     inherit (inputs.self.packages.${pkgs.stdenv.system}) blink-cmp avante-nvim;
   };
 
-  buildConfigPlugins = plugins:
-    map (plug:
-      if (isString plug)
-      then
-        if hasAttr plug config.vim.pluginOverrides
-        then
-          (let
-            plugin = config.vim.pluginOverrides.${plug};
-          in
-            if (lib.isType "flake" plugin)
-            then plugin // {name = plug;}
-            else plugin)
-        else pluginBuilders.${plug} or (getPin plug)
-      else plug) (
-      filter (f: f != null) plugins
-    );
+  buildConfigPlugins =
+    plugins:
+    map (
+      plug:
+      if (isString plug) then
+        if hasAttr plug config.vim.pluginOverrides then
+          (
+            let
+              plugin = config.vim.pluginOverrides.${plug};
+            in
+            if (lib.isType "flake" plugin) then plugin // { name = plug; } else plugin
+          )
+        else
+          pluginBuilders.${plug} or (getPin plug)
+      else
+        plug
+    ) (filter (f: f != null) plugins);
 
   # Wrap the user's desired (unwrapped) Neovim package with arguments that'll be used to
   # generate a wrapped Neovim package.
-  neovim-wrapped = inputs.mnw.lib.wrap {inherit pkgs;} {
-    appName = "nvf";
+  neovim-wrapped = inputs.mnw.lib.wrap { inherit pkgs; } {
+    appName = config.vim.appName;
     neovim = config.vim.package;
     initLua = config.vim.builtLuaConfigRC;
     luaFiles = config.vim.extraLuaFiles;
@@ -97,7 +104,7 @@
       nodeJs.enable = config.vim.withNodeJs;
       python3 = {
         enable = config.vim.withPython3;
-        extraPackages = ps: (map (flip builtins.getAttr ps) config.vim.python3Packages) ++ [ps.pynvim];
+        extraPackages = ps: (map (flip builtins.getAttr ps) config.vim.python3Packages) ++ [ ps.pynvim ];
       };
     };
 
@@ -121,7 +128,11 @@
   # or module consumption.
   neovim = pkgs.symlinkJoin {
     name = "nvf-with-helpers";
-    paths = [neovim-wrapped printConfig printConfigPath];
+    paths = [
+      neovim-wrapped
+      printConfig
+      printConfigPath
+    ];
     postBuild = "echo Helpers added";
 
     passthru = {
@@ -142,13 +153,12 @@
       mnwConfigDir = neovim-wrapped.passthru.configDir;
     };
 
-    meta =
-      neovim-wrapped.meta
-      // {
-        description = "Wrapped Neovim package with helper scripts to print the config (path)";
-      };
+    meta = neovim-wrapped.meta // {
+      description = "Wrapped Neovim package with helper scripts to print the config (path)";
+    };
   };
-in {
+in
+{
   config.vim.build = {
     finalPackage = neovim;
   };

--- a/modules/wrapper/environment/options.nix
+++ b/modules/wrapper/environment/options.nix
@@ -3,11 +3,34 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkOption mkEnableOption literalMD literalExpression;
-  inherit (lib.types) package bool str listOf attrsOf;
+  inherit
+    (lib.options)
+    mkOption
+    mkEnableOption
+    literalMD
+    literalExpression
+    ;
+  inherit
+    (lib.types)
+    package
+    bool
+    str
+    listOf
+    attrsOf
+    ;
   inherit (lib.nvim.types) pluginsOpt extraPluginType;
 in {
   options.vim = {
+    appName = mkOption {
+      type = str;
+      default = "nvf";
+      description = ''
+        The neovim application name corresponding to the
+        `NVIM_APPNAME`
+        [environment variable](https://neovim.io/doc/user/starting/#_nvim_appname).
+      '';
+    };
+
     package = mkOption {
       type = package;
       default = pkgs.neovim-unwrapped;
@@ -99,7 +122,7 @@ in {
     extraPackages = mkOption {
       type = listOf package;
       default = [];
-      example = ''[pkgs.fzf pkgs.ripgrep]'';
+      example = "[pkgs.fzf pkgs.ripgrep]";
       description = ''
         List of additional packages to make available to the Neovim
         wrapper.


### PR DESCRIPTION
Closes #1629.

@snoweuph : Please -> Before you judge somebody that they use AI, please ask. 

I am not using any agent or what so ever also for #1643. Stupid copilot runs on my PRs, cause I use it sometimes, I disabled it now. I hate GH with all their forcing into this AI crap.

Question: If he code base would be formatted, there wouldnt be so many diffs, I ran `nix fmt .` and thats the PR.

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
