### PR TITLE
ci: add nvf cachix to linkcheck job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -134,8 +134,8 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
-            substituters = https://cache.nixos.org/ https://feel-co.cachix.org
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= feel-co.cachix.org-1:nwEFNnwZvtl4KKSH5LDg+/+K7bV0vcs6faMHAJ6xx0w=
+            substituters = https://cache.nixos.org/ https://feel-co.cachix.org https://nvf.cachix.org
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= feel-co.cachix.org-1:nwEFNnwZvtl4KKSH5LDg+/+K7bV0vcs6faMHAJ6xx0w= nvf.cachix.org-1:GMQWiUhZ6ux9D5CvFFMwnc2nFrUHTeGaXRlVBXo+naI=
 
       - name: Build linkcheck package
         run: nix build .#docs-linkcheck -Lv


### PR DESCRIPTION
Added nvf.cachix.org to the final job taking forever to finish

Alternatively I could add nvf.cachix.org as substituter to every install-nix job. idk if there's any reason to