### PR TITLE
nix: bump flake inputs; fix documentation CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -138,7 +138,6 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= feel-co.cachix.org-1:nwEFNnwZvtl4KKSH5LDg+/+K7bV0vcs6faMHAJ6xx0w= nvf.cachix.org-1:GMQWiUhZ6ux9D5CvFFMwnc2nFrUHTeGaXRlVBXo+naI=
 
       - name: Build linkcheck package
-        continue-on-error: true # FIXME: remove when nixpkgs has atleast ndg 2.9.1
         run: nix build .#docs-linkcheck -Lv
 
   check-editorconfig:

--- a/docs/manual/release-notes/rl-0.6.md
+++ b/docs/manual/release-notes/rl-0.6.md
@@ -177,6 +177,6 @@ vim.api.nvim_set_keymap('n', '<leader>a', ':lua camelToSnake()<CR>', { noremap =
 - Made Treesitter options configurable, and moved treesitter-context to
   `setupOpts` while it is enabled.
 
-- Added {option}`vim.notify.nvim-notify.setupOpts.render` which takes either a
-  string of enum, or a Lua function. The default is "compact", but you may
-  change it according to nvim-notify documentation.
+- Added `vim.notify.nvim-notify.setupOpts.render` which takes either a string of
+  enum, or a Lua function. The default is "compact", but you may change it
+  according to nvim-notify documentation.

--- a/docs/manual/release-notes/rl-0.7.md
+++ b/docs/manual/release-notes/rl-0.7.md
@@ -125,8 +125,8 @@ The changes are, in no particular order:
 [frothymarrow](https://github.com/frothymarrow):
 
 - Modified type for
-  {option}`vim.visuals.fidget-nvim.setupOpts.progress.display.overrides` from
-  `anything` to a `submodule` for better type checking.
+  `vim.visuals.fidget-nvim.setupOpts.progress.display.overrides` from `anything`
+  to a `submodule` for better type checking.
 
 - Fix null `vim.lsp.mappings` generating an error and not being filtered out.
 
@@ -134,8 +134,8 @@ The changes are, in no particular order:
   group for `Normal`, `NormalFloat`, `LineNr`, `SignColumn` and optionally
   `NvimTreeNormal` to `none`.
 
-- Fix {option}`vim.ui.smartcolumn.setupOpts.custom_colorcolumn` using the wrong
-  type `int` instead of the expected type `string`.
+- Fix `vim.ui.smartcolumn.setupOpts.custom_colorcolumn` using the wrong type
+  `int` instead of the expected type `string`.
 
 [horriblename](https://github.com/horriblename):
 
@@ -227,7 +227,7 @@ The changes are, in no particular order:
     friendly-snippets for bundled snippets.
     {option}`vim.snippets.luasnip.enable` can be used to toggle Luasnip.
   - Add sorting function options for completion sources under
-    {option}`vim.autocomplete.nvim-cmp.setupOpts.sorting.comparators`
+    `vim.autocomplete.nvim-cmp.setupOpts.sorting.comparators`
 
 - Add C# support under `vim.languages.csharp`, with support for both
   omnisharp-roslyn and csharp-language-server.

--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781216227,
-        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "lastModified": 1782847225,
+        "narHash": "sha256-JC9PjqKYG9ve5U8aDOLQipp3+KLANBHUvGdLZlxzdKI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "rev": "95ca1e203c0750115fd4a6f17d5a245dfe6b1edd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Waiting for the next NDG release to come, before we pull 0.9 

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
