### PR TITLE
manual: fix calls, to use ndg from <nixpkgs> instead

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -138,6 +138,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= feel-co.cachix.org-1:nwEFNnwZvtl4KKSH5LDg+/+K7bV0vcs6faMHAJ6xx0w= nvf.cachix.org-1:GMQWiUhZ6ux9D5CvFFMwnc2nFrUHTeGaXRlVBXo+naI=
 
       - name: Build linkcheck package
+        continue-on-error: true # FIXME: remove when nixpkgs has atleast ndg 2.9.1
         run: nix build .#docs-linkcheck -Lv
 
   check-editorconfig:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -9,13 +9,6 @@ on:
       - "modules/**"
       - "docs/**"
 
-# Defining permissions here passes it to all jobs.
-# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -23,8 +16,15 @@ concurrency:
 jobs:
   build-preview:
     runs-on: ubuntu-latest
+    # NOTE: This job runs untrusted code.
+    # Don't give it any permissions.
+    permissions: {}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
       - uses: cachix/install-nix-action@v31.10.6
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -44,6 +44,25 @@ jobs:
       - name: Build documentation packages
         run: nix build .#docs-html --print-build-logs || exit 1
 
+      - name: Upload built docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: result/share/doc/
+          retention-days: 1
+
+  deploy-preview:
+    needs: build-preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download built docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: built-docs
+
       - name: Deploy to GitHub Pages preview
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
@@ -57,7 +76,7 @@ jobs:
           mkdir -p $PREVIEW_DIR
 
           # Copy the build files to the preview subdirectory
-          cp -rvf ../result/share/doc/* ./$PREVIEW_DIR
+          cp -rvf ../built-docs/* ./$PREVIEW_DIR
 
           # Configure git to use the GitHub Actions token for authentication
           git config --global user.name "GitHub Actions"
@@ -71,9 +90,11 @@ jobs:
           git commit -m "Deploy PR #${PR_NUMBER} preview" || echo "No changes to commit"
           git push --force origin $BRANCH_NAME
 
-  comment-url:
-    needs: build-preview
+  comment:
+    needs: deploy-preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Prepare Environment
         id: prelude
@@ -130,9 +151,11 @@ jobs:
               <p>Reruns: ${{ env.RUNS }}</p>
             </details>
 
-  cleanup:
+  cleanup-preview:
     if: ${{ github.event.pull_request.merged == true || github.event.pull_request.state == 'closed' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -168,8 +191,10 @@ jobs:
           git push origin $BRANCH_NAME
 
   cleanup-comment:
-    needs: cleanup
+    needs: cleanup-preview
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -92,7 +92,6 @@
 
   # Generate the HTML manual pages
   html = pkgs.callPackage ./manual.nix {
-    inherit inputs;
     inherit (nvimModuleDocs) optionsJSON;
   };
 in {

--- a/docs/manual.nix
+++ b/docs/manual.nix
@@ -1,9 +1,9 @@
 {
-  inputs,
   path,
   stdenvNoCC,
   optionsJSON,
   jaq,
+  ndg,
   gnused,
 } @ args: let
   manual-release = args.release or "unstable";
@@ -14,10 +14,7 @@ in
     src = ./manual;
 
     nativeBuildInputs = [
-      (inputs.ndg.packages.${stdenvNoCC.system}.ndg.overrideAttrs {
-        # FIXME: the tests take too long to build
-        doCheck = false;
-      })
+      ndg
       jaq
       gnused
     ];


### PR DESCRIPTION
Some Linkchecks fail because of the Downgrade of NDG from `2.8.1` to `2.8.0`, but at leas the docs build.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
