### PR TITLE
lint: add clangtidy and use as default

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -146,6 +146,11 @@
 - `prettierd` formatter is dropped entirely in the last few modules, use
   `prettier` instead.
 
+[horriblename](https://github.com/horriblename):
+
+- Change default linter for C/C++ to clangtidy, as it is more common and
+  enforces more rules outside of Google's coding style
+
 [dathegreat](https://github.com/dathegreat):
 
 - Haskell LSP now defaults to haskell-language-server, haskell-tools based LSP

--- a/modules/plugins/diagnostics/presets/clangtidy.nix
+++ b/modules/plugins/diagnostics/presets/clangtidy.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.meta) getExe';
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.types) mkDiagnosticsPresetEnableOption;
+
+  cfg = config.vim.diagnostics.presets.clangtidy;
+in {
+  options.vim.diagnostics.presets.clangtidy = {
+    enable = mkDiagnosticsPresetEnableOption {
+      option = "clangtidy";
+      display = "Clang-Tidy";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    vim.diagnostics.nvim-lint.linters.clangtidy.cmd = getExe' pkgs.clang-tools "clang-tidy";
+  };
+}

--- a/modules/plugins/diagnostics/presets/default.nix
+++ b/modules/plugins/diagnostics/presets/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./biomejs.nix
     ./checkmake.nix
+    ./clangtidy.nix
     ./cpplint.nix
     ./deadnix.nix
     ./djlint.nix

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -45,8 +45,8 @@
   defaultFormat = ["clang-format"];
   formats = ["clang-format" "indent" "astyle" "injected"];
 
-  defaultDiagnosticsProvider = ["cpplint"];
-  diagnosticsProviders = ["cpplint"];
+  defaultDiagnosticsProvider = ["clangtidy"];
+  diagnosticsProviders = ["cpplint" "clangtidy"];
 in {
   options.vim.languages.clang = {
     enable = mkEnableOption "C/C++ language support";


### PR DESCRIPTION
cpplint only checks for conformance to google's code style guide, whereas clangtidy has rules that are more "real issues" i.e. use-after-move 

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [x] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
