### PR TITLE
feat: add vim-dadbod plugin

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -242,6 +242,9 @@
 - Added [csvview.nvim](https://github.com/hat0uma/csvview.nvim) support under
   `vim.utility.csvview` for rendering CSV/TSV files as aligned tables.
 
+- Added [vim-dadbod](https://github.com/tpope/vim-dadbod) support under
+  `vim.utility.dadbod`, which uses the `:DB` command to interact with databases.
+
 [alfarel](https://github.com/alfarelcynthesis):
 
 [obsidian.nvim]: https://github.com/obsidian-nvim/obsidian.nvim

--- a/modules/plugins/utility/dadbod/config.nix
+++ b/modules/plugins/utility/dadbod/config.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+
+  cfg = config.vim.utility.dadbod;
+in {
+  config = mkIf cfg.enable {
+    vim.lazy.plugins.vim-dadbod = {
+      package = "vim-dadbod";
+      cmd = ["DB"];
+    };
+  };
+}

--- a/modules/plugins/utility/dadbod/dadbod.nix
+++ b/modules/plugins/utility/dadbod/dadbod.nix
@@ -1,0 +1,7 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+in {
+  options.vim.utility.dadbod = {
+    enable = mkEnableOption "modern database interface for Vim [vim-dadbod]";
+  };
+}

--- a/modules/plugins/utility/dadbod/default.nix
+++ b/modules/plugins/utility/dadbod/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./dadbod.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -3,6 +3,7 @@
     ./binds
     ./ccc
     ./csvview
+    ./dadbod
     ./diffview
     ./direnv
     ./fzf-lua

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2840,6 +2840,19 @@
       "url": "https://github.com/mbbill/undotree/archive/6fa6b57cda8459e1e4b2ca34df702f55242f4e4d.tar.gz",
       "hash": "sha256-0fSCkozz9UWkkV1PsCCnIimOHsmXw9jLd9/oF9dLjMk="
     },
+    "vim-dadbod": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "tpope",
+        "repo": "vim-dadbod"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "6d1d41da4873a445c5605f2005ad2c68c99d8770",
+      "url": "https://github.com/tpope/vim-dadbod/archive/6d1d41da4873a445c5605f2005ad2c68c99d8770.tar.gz",
+      "hash": "sha256-1CA+H8wXDcA5sQLpHsJHHn9hNhWNyzZHHkVx3LqSPeA="
+    },
     "vim-dirtytalk": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Adds [vim-dadbod](https://github.com/tpope/vim-dadbod), a barebones plugin for interacting with databases. 

- This plugin introduces a single `:DB` command which sends buffer content to a configurable database backend. It does not include the more complex `vim-dadbod-ui`, or `vim-dadbod-completion`.
- Database backends are provided by the user, not by the plugin; thus, zero backends are included in the derivation.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
