### PR TITLE
packages/prettier-plugin-pug: update insecure pnpm version

### DIFF
--- a/flake/pkgs/by-name/prettier-plugin-pug/package.nix
+++ b/flake/pkgs/by-name/prettier-plugin-pug/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   nodejs,
   gitMinimal,
-  pnpm_9,
+  pnpm_11,
   pnpmConfigHook,
   zstd,
   fetchPnpmDeps,
@@ -27,9 +27,9 @@ in
     };
 
     pnpmDeps = fetchPnpmDeps {
-      pnpm = pnpm_9;
+      pnpm = pnpm_11;
       inherit (finalAttrs) pname version src;
-      hash = "sha256-NBetqPzn99W0mvv2niL9bJ3iOexOB4VAIGA7CmUn00M=";
+      hash = "sha256-vpbevN2jgde4qsoRvWMEvkXBYDTeZEggpY0FlAAJomo=";
       fetcherVersion = 3;
     };
 
@@ -38,9 +38,9 @@ in
       gitMinimal
       writableTmpDirAsHomeHook
       (pnpmConfigHook.override {
-        pnpm = pnpm_9;
+        pnpm = pnpm_11;
       })
-      pnpm_9
+      pnpm_11
       zstd
     ];
 


### PR DESCRIPTION
I tried updating the pnpm version for the astro plugin, but I get an error related to an incompatible lockfile.
Just wanted to quickly send this up and notify yall if you weren't aware of the issue for astro.

Note that this error doesn't seem to present in 26.05, which is what nvf uses.
The pnpm_9 version from there is obviously still insecure, though (probably the PR hasn't been backported yet(?)).

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
   - it builds fine, no reason it wouldn't work the same
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
