### PR TITLE
languages/haskell: respect existing binaries during HLS resolution

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -254,6 +254,9 @@
 - Added [csvview.nvim](https://github.com/hat0uma/csvview.nvim) support under
   `vim.utility.csvview` for rendering CSV/TSV files as aligned tables.
 
+- Switched from prepending -> appending our haskell-language-server binary to
+  PATH, so our binary is only used as a default / fallback.
+
 [alfarel](https://github.com/alfarelcynthesis):
 
 [obsidian.nvim]: https://github.com/obsidian-nvim/obsidian.nvim

--- a/modules/plugins/languages/haskell.nix
+++ b/modules/plugins/languages/haskell.nix
@@ -115,7 +115,7 @@ in {
                   # wrap HLS-wrapper so it can find the actual binary
                   postBuild = ''
                     wrapProgram $out/bin/haskell-language-server-wrapper \
-                      --prefix PATH : ${haskellPackages.haskell-language-server}/bin
+                      --suffix PATH : ${haskellPackages.haskell-language-server}/bin
                   '';
                 }))
                 "--lsp"

--- a/modules/plugins/lsp/presets/haskell-language-server.nix
+++ b/modules/plugins/lsp/presets/haskell-language-server.nix
@@ -25,10 +25,21 @@ in {
           paths = [pkgs.haskellPackages.haskell-language-server];
           meta.mainProgram = "haskell-language-server-wrapper";
           buildInputs = [pkgs.makeBinaryWrapper];
-          # wrap HLS-wrapper so it can find the actual binary
+          /*
+          Wrap HLS-wrapper so it can find the actual GHC-specific binary.
+
+          HLS binaries are incredibly picky about which GHC version they run against
+          -- even failing between two GHC builds with identical version numbers, because one has a newer ABI.
+
+          Because of this, we shouldn't assume our provided HLS version is the right
+          one for a given project. Appending to PATH with `--suffix` takes advantage
+          of PATH's first-match lookup, so an existing HLS already in
+          the user's dev environment is found first and takes precedence over ours.
+          This way we provide a useful default without clobbering existing setups.
+          */
           postBuild = ''
             wrapProgram $out/bin/haskell-language-server-wrapper \
-              --prefix PATH : ${pkgs.haskellPackages.haskell-language-server}/bin
+              --suffix PATH : ${pkgs.haskellPackages.haskell-language-server}/bin
           '';
         })}/bin/haskell-language-server-wrapper"
         "--lsp"


### PR DESCRIPTION
Fixes a bug I encountered where NVF's pinned nixpkgs drifted far enough out of sync with one of my haskell project's pinned nixpkgs that the NVF-supplied HLS and my shell-supplied GHC stopped playing nicely together.

From the block comment I left in source:

>           HLS binaries are incredibly picky about which GHC version they run against
>           -- even failing between two GHC builds with identical version numbers, because one has a newer ABI.
>
>           Because of this, we shouldn't assume our provided HLS version is the right
>           one for a given project. Appending to PATH with `--suffix` takes advantage
>           of PATH's first-match lookup, so an existing HLS already in
>           the user's dev environment is found first and takes precedence over ours.
>           This way we provide a useful default without clobbering existing setups.

I can confirm that using `--suffix` no longer clobbered the HLS supplied by my dev shell, and all my haskell tooling worked as expected again.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
