### PR TITLE
pins: revert obsidian-nvim and freeze to fix pickers

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2270,10 +2270,11 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v3.16.5",
-      "revision": "9577347ad6d92d60b915e63840bb6849fd7ac8de",
-      "url": "https://api.github.com/repos/obsidian-nvim/obsidian.nvim/tarball/refs/tags/v3.16.5",
-      "hash": "sha256-jSaAT7DCGsgzNJCd+ey3My2zqQ7kDcRm5ALDTOJKmJM="
+      "version": "v3.16.4",
+      "revision": "190bcb5f6a6f36f69754cdddd1abf6cdb54641e7",
+      "url": "https://api.github.com/repos/obsidian-nvim/obsidian.nvim/tarball/refs/tags/v3.16.4",
+      "hash": "sha256-9Su5t8cJAHlXV+EE4GLa1+BhezfHZIZgl2P6kBrkX8E=",
+      "frozen": true
     },
     "oil-git-status.nvim": {
       "type": "Git",


### PR DESCRIPTION
The plugin never correctly found the pickers in :checkhealth, but it also now fails to use at least snacks.picker.
Will need more investigation, but it's likely due to some issue with a recent api internal change for detecting which plugins are present - the nix way probably disagrees with their function.

Probably, the fact that it was not finding the plugin but still using it was a bug, that is now fixed, so we will need to figure out how to get it to see them correctly.
It seems to check the runtimepaths, but honestly forking the plugin for debugging is probably the easiest..

I plan on fixing this when I have time, but it's preferable to keep it working in the meantime.
This seems like a possible bug-fix PR that could have patched the issue we rely on: obsidian-nvim/obsidian.nvim#880, but it's possible it was some other api-internal change.
Alternatively, this could be a plugin-loading-order issue, but the nvf obsidian-nvim setup seems to be correctly lazy loading on filetype/cmd, so I don't see how the pickers could be getting loaded afterwards.


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
