### PR TITLE
treesitter: fix query runtime path load order

### DIFF
--- a/docs/manual/configuring/queries.md
+++ b/docs/manual/configuring/queries.md
@@ -26,9 +26,8 @@ in {
   vim.treesitter.queries = [{
     type = "injections";
     filetypes = ["nix"];
+    loadtype = "extends";
     query = ''
-      ;; extends
-
       ((apply_expression
         function: (variable_expression
           name: (identifier) @_func

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -48,6 +48,9 @@
 - Added `position` option to additional runtime paths, allowing for prepending
   paths, rather than just appending.
 
+- Added required field `loadtype` for entries into
+  {option}`vim.treesitter.queries`, to allow for real overriding of queries.
+
 - Moved all angular related stuff into its own language module.
 
 - Remove `mind.nvim`. This plugin doesn't exist anymore. The original author

--- a/modules/plugins/languages/go.nix
+++ b/modules/plugins/languages/go.nix
@@ -198,9 +198,8 @@ in {
           {
             type = "injections";
             filetypes = ["gotmpl"];
+            loadtype = "extends";
             query = ''
-              ;; extends
-
               ((text) @injection.content
                 (#set! injection.language "${cfg.treesitter.gotmpl.injection}")
                 (#set! injection.combined)

--- a/modules/plugins/languages/jinja.nix
+++ b/modules/plugins/languages/jinja.nix
@@ -61,9 +61,8 @@ in {
           {
             type = "injections";
             filetypes = ["jinja"];
+            loadtype = "extends";
             query = ''
-              ;; extends
-
               ((content) @injection.content
                 (#set! injection.language "${cfg.treesitter.injection}")
                 (#set! injection.combined)

--- a/modules/plugins/languages/nix.nix
+++ b/modules/plugins/languages/nix.nix
@@ -101,9 +101,8 @@ in {
           {
             type = "injections";
             filetypes = ["nix"];
+            loadtype = "extends";
             query = ''
-              ;; extends
-
               ((binding
                 attrpath: (attrpath
                   (identifier) @_path)
@@ -131,9 +130,8 @@ in {
           {
             type = "injections";
             filetypes = ["nix"];
+            loadtype = "extends";
             query = ''
-              ;; extends
-
               ((apply_expression
                 function: (variable_expression
                   name: (identifier) @_func

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -316,9 +316,8 @@ in {
           {
             type = "injections";
             filetypes = ["rust"];
+            loadtype = "extends";
             query = ''
-              ; extends
-
               (macro_invocation
                 macro: (scoped_identifier
                   path: (identifier) @_path

--- a/modules/plugins/languages/tera.nix
+++ b/modules/plugins/languages/tera.nix
@@ -57,9 +57,8 @@ in {
           {
             type = "injections";
             filetypes = ["tera"];
+            loadtype = "extends";
             query = ''
-              ;; extends
-
               ((content) @injection.content
                 (#set! injection.language "${cfg.treesitter.injection}")
                 (#set! injection.combined)

--- a/modules/plugins/treesitter/config.nix
+++ b/modules/plugins/treesitter/config.nix
@@ -6,7 +6,7 @@
 }: let
   inherit (lib) mkIf foldl' mapAttrsToList;
   inherit (lib.strings) optionalString;
-  inherit (lib.lists) optionals;
+  inherit (lib.lists) optionals optional partition;
   inherit (lib.nvim.dag) entryAfter;
   inherit (lib.nvim.lua) toLuaObject;
 
@@ -75,39 +75,41 @@ in {
         '';
       };
 
-      additionalRuntimePaths = mkIf (cfg.queries != []) [
-        (let
-          grouped =
-            foldl'
-            (
-              acc: entry:
-                foldl'
-                (
-                  inner: filetype: let
-                    path = "queries/${filetype}/${entry.type}.scm";
-                    prev = inner.${path} or "";
-                  in
-                    inner
-                    // {
-                      ${path} = prev + entry.query;
-                    }
-                )
-                acc
-                entry.filetypes
-            )
+      additionalRuntimePaths = mkIf (cfg.queries != []) (
+        let
+          mkQueryGroup = entries:
+            foldl' (acc: entry:
+              foldl' (inner: filetype: let
+                path = "queries/${filetype}/${entry.type}.scm";
+                prev = inner.${path} or "";
+                query = ''${optionalString (entry.loadtype == "extends") "; extends"} ${entry.query} '';
+              in
+                inner // {${path} = prev + query;})
+              acc
+              entry.filetypes)
             {}
-            cfg.queries;
+            entries;
 
-          files =
-            mapAttrsToList
-            (path: query: {
-              name = path;
-              path = pkgs.writeText path query;
-            })
-            grouped;
+          mkQueryRuntimePath = name: queries:
+            pkgs.linkFarm "treesitter-queries-${name}" (mapAttrsToList (path: query: {
+                name = path;
+                path = pkgs.writeText path query;
+              })
+              queries);
+
+          inherit (partition (entry: entry.loadtype == "overwrite") cfg.queries) right wrong;
+          overwriteQueries = mkQueryGroup right;
+          extendsQueries = mkQueryGroup wrong;
         in
-          pkgs.linkFarm "treesitter-queries" files)
-      ];
+          optional (overwriteQueries != {}) {
+            path = mkQueryRuntimePath "overwrite" overwriteQueries;
+            position = "prepend";
+          }
+          ++ optional (extendsQueries != {}) {
+            path = mkQueryRuntimePath "extends" extendsQueries;
+            position = "append";
+          }
+      );
     };
   };
 }

--- a/modules/plugins/treesitter/treesitter.nix
+++ b/modules/plugins/treesitter/treesitter.nix
@@ -12,6 +12,10 @@
         type = enum ["injections" "highlights" "folds" "locals" "indents"];
         description = "The kind of query to register.";
       };
+      loadtype = mkOption {
+        type = enum ["overwrite" "extends"];
+        description = "Define how this query should be loaded";
+      };
       filetypes = mkOption {
         type = listOf str;
         default = [];
@@ -20,12 +24,10 @@
       query = mkOption {
         type = lines;
         description = "The queries scm script.";
+        # Syntactica doesnt support `query` so we patch it with the closest it does,
+        # which is `haskell` :bwaa:
         example = literalMD ''
-          ```nix
-          {
-            query = '''
-              ;; extends
-
+          ```haskell
               ((apply_expression
                 function: (variable_expression
                   name: (identifier) @_func
@@ -36,8 +38,6 @@
 
                 (#set! injection.language "lua")
                 (#set! injection.combined)))
-            ''';
-          }
           ```
         '';
       };
@@ -134,6 +134,25 @@ in {
       type = listOf queriesType;
       default = [];
       description = "A list of Neovim treesitter queries to be registered.";
+      example = [
+        {
+          type = "injections";
+          filetypes = ["nix"];
+          loadtype = "extends";
+          query = ''
+            ((apply_expression
+              function: (variable_expression
+                name: (identifier) @_func
+                (#eq? @_func "mkLuaInline"))
+
+              argument: (indented_string_expression
+                (string_fragment) @injection.content)
+
+              (#set! injection.language "lua")
+              (#set! injection.combined)))
+          '';
+        }
+      ];
     };
 
     filetypeMappings = mkOption {


### PR DESCRIPTION
Requires: #1719

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [x] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
