### PR TITLE
lib/types: fix generation `setupOpts` for plugins in `options.json`

### DIFF
--- a/lib/types/plugins.nix
+++ b/lib/types/plugins.nix
@@ -5,8 +5,9 @@
   inherit (lib.options) mkOption;
   inherit (lib.attrsets) attrNames mapAttrs' filterAttrs nameValuePair;
   inherit (lib.strings) hasPrefix removePrefix;
-  inherit (lib.types) submodule either package enum str lines anything listOf nullOr;
+  inherit (lib.types) submodule either package enum str lines anything listOf nullOr addCheck;
   inherit (lib.nvim.types) luaInline;
+  inherit (lib.nvim.lua) isLuaInline;
 
   # Get the names of all flake inputs that start with the given prefix.
   fromInputs = {
@@ -84,12 +85,21 @@ in {
   ```
   */
   mkPluginSetupOption = pluginName: opts: let
-    luaOrModule =
-      either (submodule {
+    submoduleType =
+      addCheck
+      (submodule {
         freeformType = anything;
         options = opts;
       })
-      luaInline;
+      (x: !(isLuaInline x));
+
+    luaOrModule =
+      (either luaInline submoduleType)
+      // {
+        getSubOptions = prefix: submoduleType.getSubOptions prefix;
+        inherit (submoduleType) getSubModules;
+        substSubModules = _: luaOrModule;
+      };
   in
     mkOption {
       type = luaOrModule;

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -6,8 +6,9 @@
 }: let
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) mkOption mkEnableOption literalMD literalExpression;
-  inherit (lib) attrNames genAttrs;
-  inherit (lib.lists) flatten getExe;
+  inherit (lib.meta) getExe;
+  inherit (lib.attrsets) attrNames genAttrs;
+  inherit (lib.lists) flatten;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.strings) optionalString;
   inherit (lib.types) bool listOf enum int;


### PR DESCRIPTION
Brings back a few missing doc entries

<img width="778" height="909" alt="image" src="https://github.com/user-attachments/assets/8d60e3ee-df20-4d3e-8c99-9d5b66f1f88e" />



<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-json`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
