### PR TITLE
debugger/nvim-dap/presets: define enable option helper, to ensure consistency.

### DIFF
--- a/lib/types/dap.nix
+++ b/lib/types/dap.nix
@@ -1,0 +1,21 @@
+{lib}: let
+  inherit (lib.options) mkEnableOption;
+
+  mkDapPresetEnableOption = {
+    option,
+    display,
+    extra ? "",
+  }:
+    mkEnableOption ''
+      the ${display} debug adapter.
+
+      ${extra}
+
+      Use {option}`vim.debugger.nvim-dap.adapters.${option}` for customization
+
+      A configuration is also needed for your filetype in
+      {option}`vim.debugger.nvim-dap.configurations`.
+    '';
+in {
+  inherit mkDapPresetEnableOption;
+}

--- a/lib/types/default.nix
+++ b/lib/types/default.nix
@@ -6,6 +6,7 @@
   typesPlugin = import ./plugins.nix {inherit lib self;};
   typesLanguage = import ./languages.nix {inherit lib;};
   typesLsp = import ./lsp.nix {inherit lib;};
+  typesDap = import ./dap.nix {inherit lib;};
   typesFormatter = import ./formatter.nix {inherit lib;};
   typesDiagnostics = import ./diagnostics.nix {inherit lib;};
   customTypes = import ./custom.nix {inherit lib;};
@@ -14,6 +15,7 @@ in {
   inherit (typesPlugin) pluginsOpt extraPluginType mkPluginSetupOption luaInline pluginType borderType;
   inherit (typesLanguage) mkGrammarOption mkTreesitterGrammarOption;
   inherit (typesLsp) mkLspPresetEnableOption;
+  inherit (typesDap) mkDapPresetEnableOption;
   inherit (typesFormatter) mkFormatterPresetEnableOption;
   inherit (typesDiagnostics) mkDiagnosticsPresetEnableOption;
   inherit (customTypes) char hexColor mergelessListOf deprecatedSingleOrListOf enumWithRename;

--- a/modules/plugins/debugger/nvim-dap/presets/codelldb.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/codelldb.nix
@@ -5,19 +5,17 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkDapPresetEnableOption;
 
   cfg = config.vim.debugger.nvim-dap.presets.codelldb;
   codelldb = pkgs.vscode-extensions.vadimcn.vscode-lldb.adapter;
 in {
   options.vim.debugger.nvim-dap.presets.codelldb = {
-    enable = mkEnableOption ''
-      adapter configuration for CodeLLDB using the vadimcn.vscode-lldb extension.
-      Use {option}`vim.debugger.nvim-dap.adapters.codelldb` for customization.
-
-      A configuration is also needed for your filetype in
-      {option}`vim.debugger.nvim-dap.configurations`
-    '';
+    enable = mkDapPresetEnableOption {
+      option = "codelldb";
+      display = "CodeLLDB";
+      extra = "Uses the vadimcn.vscode-lldb extension under the hood.";
+    };
   };
 
   config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {

--- a/modules/plugins/debugger/nvim-dap/presets/debugpy.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/debugpy.nix
@@ -5,23 +5,22 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkEnableOption;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.meta) getExe;
+  inherit (lib.nvim.types) mkDapPresetEnableOption;
 
   cfg = config.vim.debugger.nvim-dap.presets.debugpy;
   package = pkgs.python3.withPackages (ps: with ps; [debugpy]);
 in {
   options.vim.debugger.nvim-dap.presets.debugpy = {
-    enable = mkEnableOption ''
-      adapter configuration for debugpy.
-      Use {option}`vim.debugger.nvim-dap.adapters.debugpy` for customization.
-
-      A configuration is also needed for your filetype in
-      {option}`vim.debugger.nvim-dap.configurations`
-      See https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings
-      for supported options.
-    '';
+    enable = mkDapPresetEnableOption {
+      option = "debugpy";
+      display = "`debugpy`";
+      extra = ''
+        See <https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings>
+        for supported options.
+      '';
+    };
   };
 
   config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {

--- a/modules/plugins/debugger/nvim-dap/presets/jls.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/jls.nix
@@ -6,20 +6,17 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkEnableOption;
   inherit (lib.meta) getExe';
+  inherit (lib.nvim.types) mkDapPresetEnableOption;
 
   cfg = config.vim.debugger.nvim-dap.presets.jls;
   pkg = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.jls;
 in {
   options.vim.debugger.nvim-dap.presets.jls = {
-    enable = mkEnableOption ''
-      adapter configuration for JLS.
-      Use {option}`vim.debugger.nvim-dap.adapters.jls` for customization.
-
-      A configuration is also needed for your filetype in
-      {option}`vim.debugger.nvim-dap.configurations`
-    '';
+    enable = mkDapPresetEnableOption {
+      option = "jls";
+      display = "JLS";
+    };
   };
 
   config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {

--- a/modules/plugins/debugger/nvim-dap/presets/lldb.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/lldb.nix
@@ -5,18 +5,16 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkDapPresetEnableOption;
 
   cfg = config.vim.debugger.nvim-dap.presets.lldb;
 in {
   options.vim.debugger.nvim-dap.presets.lldb = {
-    enable = mkEnableOption ''
-      adapter configuration for LLDB using `lldb-dap`.
-      Use {option}`vim.debugger.nvim-dap.adapters.lldb` for customization.
-
-      A configuration is also needed for your filetype in
-      {option}`vim.debugger.nvim-dap.configurations`
-    '';
+    enable = mkDapPresetEnableOption {
+      option = "lldb";
+      display = "LLDB";
+      extra = "Uses `lldb-dap` under the hood.";
+    };
   };
 
   config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {

--- a/modules/plugins/debugger/nvim-dap/presets/xdebug.nix
+++ b/modules/plugins/debugger/nvim-dap/presets/xdebug.nix
@@ -5,19 +5,16 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkEnableOption;
   inherit (lib.meta) getExe;
+  inherit (lib.nvim.types) mkDapPresetEnableOption;
 
   cfg = config.vim.debugger.nvim-dap.presets.xdebug;
 in {
   options.vim.debugger.nvim-dap.presets.xdebug = {
-    enable = mkEnableOption ''
-      adapter configuration for Xdebug.
-      Use {option}`vim.debugger.nvim-dap.adapters.xdebug` for customization.
-
-      A configuration is also needed for your filetype in
-      {option}`vim.debugger.nvim-dap.configurations`
-    '';
+    enable = mkDapPresetEnableOption {
+      option = "xdebug";
+      display = "Xdebug";
+    };
   };
 
   config.vim.debugger.nvim-dap.adapters = mkIf cfg.enable {


### PR DESCRIPTION
This makes it the same like the other presets.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
