### PR TITLE
healthchecks: init

### DIFF
--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -356,6 +356,8 @@
 
 - Added {option}`vim.healthchecks`.
 
+- Added healthcheck to clipboard providers.
+
 - Added {option}`vim.formatter.conform-nvim.presets.just.enable` for justfile
   formatting.
 

--- a/docs/manual/release-notes/rl-0.9.md
+++ b/docs/manual/release-notes/rl-0.9.md
@@ -354,6 +354,8 @@
 
 [Snoweuph](https://github.com/snoweuph)
 
+- Added {option}`vim.healthchecks`.
+
 - Added {option}`vim.formatter.conform-nvim.presets.just.enable` for justfile
   formatting.
 

--- a/modules/neovim/init/default.nix
+++ b/modules/neovim/init/default.nix
@@ -6,6 +6,7 @@
     ./debug.nix
     ./diagnostics.nix
     ./filetype.nix
+    ./healthcheck.nix
     ./highlight.nix
     ./lsp.nix
     ./mappings.nix

--- a/modules/neovim/init/healthcheck.nix
+++ b/modules/neovim/init/healthcheck.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption;
+  inherit (lib.strings) concatStringsSep replaceStrings trim;
+  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.types) attrsOf;
+  inherit (lib.nvim.types) luaInline;
+  inherit (lib.generators) mkLuaInline;
+
+  cfg = config.vim.healthchecks;
+in {
+  options.vim.healthchecks = mkOption {
+    type = attrsOf (attrsOf luaInline);
+    default = {};
+    description = "custom healthchecks to register";
+    example = {
+      nvf = {
+        "Executables" = mkLuaInline ''
+          if vim.fn.executable("git") == 1 then
+            vim.health.ok("git found")
+          else
+            vim.health.error("git not found")
+          end
+        '';
+      };
+    };
+  };
+
+  config = mkIf (cfg != {}) {
+    vim.additionalRuntimePaths = [
+      (pkgs.linkFarm "nvf-healthchecks" (mapAttrsToList (name: checks: {
+          name = "lua/${name}/health.lua";
+          path = pkgs.writeText "nvf-healthcheck-${name}" ''
+            local M = {}
+
+            M.check = function()
+              ${concatStringsSep "\n" (mapAttrsToList (name: check: ''
+                vim.health.start("${name}")
+                ${"  " + replaceStrings ["\n"] ["\n  "] (trim check.expr)}
+              '')
+              checks)}
+            end
+
+            return M
+          '';
+        })
+        cfg))
+    ];
+  };
+}

--- a/modules/neovim/init/healthcheck.nix
+++ b/modules/neovim/init/healthcheck.nix
@@ -5,12 +5,11 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.options) mkOption;
-  inherit (lib.strings) concatStringsSep replaceStrings trim;
+  inherit (lib.options) mkOption literalExpression;
+  inherit (lib.strings) concatStringsSep trim;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.types) attrsOf;
   inherit (lib.nvim.types) luaInline;
-  inherit (lib.generators) mkLuaInline;
 
   cfg = config.vim.healthchecks;
 in {
@@ -18,17 +17,31 @@ in {
     type = attrsOf (attrsOf luaInline);
     default = {};
     description = "custom healthchecks to register";
-    example = {
-      nvf = {
-        "Executables" = mkLuaInline ''
-          if vim.fn.executable("git") == 1 then
-            vim.health.ok("git found")
-          else
-            vim.health.error("git not found")
-          end
-        '';
-      };
-    };
+    example = literalExpression ''
+      let
+        inherit (lib.generators) mkLuaInline;
+      in
+      {
+        nvf = {
+          "Executables" = mkLuaInline '''
+            if vim.fn.executable("git") == 1 then
+              vim.health.ok("git found")
+            else
+              vim.health.error("git not found")
+            end
+
+            if vim.fn.executable("pijul") == 1 then
+              vim.health.ok("pijul found")
+            else
+              vim.health.error("pijul not found")
+            end
+          ''';
+          "Nixvim" = mkLuaInline '''
+            vim.health.ok("NVF is better than nixvim")
+          ''';
+        };
+      }
+    '';
   };
 
   config = mkIf (cfg != {}) {
@@ -41,7 +54,7 @@ in {
             M.check = function()
               ${concatStringsSep "\n" (mapAttrsToList (name: check: ''
                 vim.health.start("${name}")
-                ${"  " + replaceStrings ["\n"] ["\n  "] (trim check.expr)}
+                ${trim check.expr}
               '')
               checks)}
             end


### PR DESCRIPTION
As a small example of a custom healthcheck I've added ones for the Clipboard providers
<img width="1918" height="1080" alt="2026-07-14-005121_hyprshot" src="https://github.com/user-attachments/assets/40e57bb6-239d-418b-9386-5b45b69ea222" />


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
