### PR TITLE
treewide: cleanup of enable options

### DIFF
--- a/lib/languages.nix
+++ b/lib/languages.nix
@@ -1,6 +1,6 @@
 {lib}: let
   inherit (builtins) isString getAttr;
-  inherit (lib.options) mkOption;
+  inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) listOf bool str submodule attrsOf anything either nullOr uniq;
   inherit (lib.nvim.attrsets) mapListToAttrs;
   inherit (lib.nvim.types) luaInline;
@@ -105,11 +105,7 @@ in {
   lspOptions = submodule {
     freeformType = attrsOf anything;
     options = {
-      enable = mkOption {
-        type = bool;
-        default = true;
-        description = "Whether to enable this LSP server.";
-      };
+      enable = mkEnableOption "this LSP server" // {default = true;};
 
       capabilities = mkOption {
         type = nullOr (either luaInline (attrsOf anything));

--- a/modules/plugins/filetree/nvimtree/nvimtree.nix
+++ b/modules/plugins/filetree/nvimtree/nvimtree.nix
@@ -107,11 +107,7 @@ in {
         default = {};
         type = submodule {
           options = {
-            enable = mkOption {
-              type = bool;
-              default = false;
-              description = "update focused file";
-            };
+            enable = mkEnableOption "updating focused files";
 
             update_root = mkOption {
               type = bool;
@@ -206,14 +202,12 @@ in {
       };
 
       hijack_directories = {
-        enable = mkOption {
-          type = bool;
-          description = ''
-            Enable the `hijack_directories` feature. Disable this option if you use vim-dirvish or dirbuf.nvim.
-            If `hijack_netrw` and `disable_netrw` are `false`, this feature will be disabled.
-          '';
-          default = true;
-        };
+        enable =
+          mkEnableOption ''
+            the `hijack_directories` feature. Disable this option if you use vim-dirvish or dirbuf.nvim.
+            If `hijack_netrw` and `disable_netrw` are `false`, this feature will be disabled
+          ''
+          // {default = true;};
 
         auto_open = mkOption {
           type = bool;
@@ -377,11 +371,7 @@ in {
         default = {};
         type = submodule {
           options = {
-            enable = mkOption {
-              description = "Enable filesystem watchers.";
-              type = bool;
-              default = true;
-            };
+            enable = mkEnableOption "filesystem watchers" // {default = true;};
 
             debounce_delay = mkOption {
               description = "Idle milliseconds between filesystem change and action.";
@@ -494,11 +484,7 @@ in {
               default = {};
               type = submodule {
                 options = {
-                  enable = mkOption {
-                    description = "If true, tree window will be floating.";
-                    type = bool;
-                    default = false;
-                  };
+                  enable = mkEnableOption "floating tree windows";
 
                   quit_on_focus_loss = mkOption {
                     description = "Close the floating tree window when it loses focus.";
@@ -892,11 +878,7 @@ in {
               default = {};
               type = submodule {
                 options = {
-                  enable = mkOption {
-                    type = bool;
-                    default = true;
-                    description = "Change the working directory when changing directories in the tree.";
-                  };
+                  enable = mkEnableOption "changing the working directory when changing directories in the tree" // {default = true;};
 
                   global = mkOption {
                     type = bool;
@@ -992,11 +974,7 @@ in {
                     default = {};
                     type = submodule {
                       options = {
-                        enable = mkOption {
-                          type = bool;
-                          description = "Enable the window picker. If this feature is not enabled, files will open in window from which you last opened the tree.";
-                          default = false;
-                        };
+                        enable = mkEnableOption "the window picker. If this feature is not enabled, files will open in window from which you last opened the tree";
 
                         picker = mkOption {
                           type = str;

--- a/modules/plugins/languages/clang.nix
+++ b/modules/plugins/languages/clang.nix
@@ -87,12 +87,12 @@ in {
     };
 
     dap = {
-      enable = mkOption {
-        description = "Enable clang Debug Adapter";
-        type = bool;
-        default = config.vim.languages.enableDAP;
-        defaultText = literalExpression "config.vim.languages.enableDAP";
-      };
+      enable =
+        mkEnableOption "clang Debug Adapter"
+        // {
+          default = config.vim.languages.enableDAP;
+          defaultText = literalExpression "config.vim.languages.enableDAP";
+        };
       debugger = mkOption {
         description = "clang debugger to use";
         type =

--- a/modules/plugins/languages/dart.nix
+++ b/modules/plugins/languages/dart.nix
@@ -47,21 +47,21 @@ in {
     };
 
     dap = {
-      enable = mkOption {
-        description = "Enable Dart DAP support via flutter-tools";
-        type = bool;
-        default = config.vim.languages.enableDAP;
-        defaultText = literalExpression "config.vim.languages.enableDAP";
-      };
+      enable =
+        mkEnableOption "Dart DAP support via flutter-tools"
+        // {
+          default = config.vim.languages.enableDAP;
+          defaultText = literalExpression "config.vim.languages.enableDAP";
+        };
     };
 
     flutter-tools = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.lsp.enable;
-        defaultText = literalExpression "config.vim.lsp.enable";
-        description = "Enable flutter-tools for flutter support";
-      };
+      enable =
+        mkEnableOption "flutter-tools for flutter support"
+        // {
+          default = config.vim.lsp.enable;
+          defaultText = literalExpression "config.vim.lsp.enable";
+        };
 
       flutterPackage = mkOption {
         type = nullOr package;

--- a/modules/plugins/languages/fish.nix
+++ b/modules/plugins/languages/fish.nix
@@ -6,7 +6,7 @@
 }: let
   inherit (lib.options) mkOption mkEnableOption literalExpression;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.types) enum bool listOf;
+  inherit (lib.types) enum listOf;
   inherit (lib) genAttrs;
   inherit (lib.nvim.types) mkGrammarOption enumWithRename;
 
@@ -46,12 +46,12 @@ in {
     };
 
     format = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.languages.enableFormat;
-        defaultText = literalExpression "config.vim.languages.enableFormat";
-        description = "Enable Fish formatting";
-      };
+      enable =
+        mkEnableOption "Fish formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
       type = mkOption {
         type = listOf (enumWithRename
           "vim.languages.fish.format.type"

--- a/modules/plugins/languages/lua.nix
+++ b/modules/plugins/languages/lua.nix
@@ -7,7 +7,7 @@
   inherit (lib.options) literalExpression mkEnableOption mkOption;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib) genAttrs;
-  inherit (lib.types) bool enum listOf;
+  inherit (lib.types) enum listOf;
   inherit (lib.nvim.types) mkGrammarOption;
   inherit (lib.nvim.dag) entryBefore;
 
@@ -57,12 +57,12 @@ in {
     };
 
     format = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.languages.enableFormat;
-        defaultText = literalExpression "config.vim.languages.enableFormat";
-        description = "Enable Lua formatting";
-      };
+      enable =
+        mkEnableOption "Lua formatting"
+        // {
+          default = config.vim.languages.enableFormat;
+          defaultText = literalExpression "config.vim.languages.enableFormat";
+        };
       type = mkOption {
         type = listOf (enum formats);
         default = defaultFormat;

--- a/modules/plugins/languages/markdown.nix
+++ b/modules/plugins/languages/markdown.nix
@@ -7,7 +7,7 @@
   inherit (lib) genAttrs;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.types) bool enum listOf str nullOr;
+  inherit (lib.types) enum listOf str nullOr;
   inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption deprecatedSingleOrListOf enumWithRename;
   inherit (lib.nvim.dag) entryAnywhere;
@@ -25,12 +25,12 @@ in {
     enable = mkEnableOption "Markdown markup language support";
 
     treesitter = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.languages.enableTreesitter;
-        defaultText = literalExpression "config.vim.languages.enableTreesitter";
-        description = "Enable Markdown treesitter";
-      };
+      enable =
+        mkEnableOption "Markdown treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+          defaultText = literalExpression "config.vim.languages.enableTreesitter";
+        };
       mdPackage = mkGrammarOption pkgs "markdown";
       mdInlinePackage = mkGrammarOption pkgs "markdown_inline";
     };

--- a/modules/plugins/languages/python.nix
+++ b/modules/plugins/languages/python.nix
@@ -9,7 +9,7 @@
   inherit (lib.lists) flatten;
   inherit (lib) genAttrs;
   inherit (lib.modules) mkIf mkMerge;
-  inherit (lib.types) enum package bool listOf;
+  inherit (lib.types) enum package listOf;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.types) deprecatedSingleOrListOf enumWithRename;
   inherit (lib.trivial) warn;
@@ -111,12 +111,12 @@ in {
 
     # TODO this implementation is very bare bones, I don't know enough python to implement everything
     dap = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.languages.enableDAP;
-        defaultText = literalExpression "config.vim.languages.enableDAP";
-        description = "Enable Python Debug Adapter";
-      };
+      enable =
+        mkEnableOption "Python Debug Adapter"
+        // {
+          default = config.vim.languages.enableDAP;
+          defaultText = literalExpression "config.vim.languages.enableDAP";
+        };
 
       debugger = mkOption {
         type = deprecatedSingleOrListOf "vim.languages.python.dap.debugger" (enum (attrNames dapConfigurations));

--- a/modules/plugins/languages/rust.nix
+++ b/modules/plugins/languages/rust.nix
@@ -112,12 +112,12 @@ in {
     };
 
     dap = {
-      enable = mkOption {
-        description = "Rust Debug Adapter support";
-        type = bool;
-        default = config.vim.languages.enableDAP;
-        defaultText = literalExpression "config.vim.languages.enableDAP";
-      };
+      enable =
+        mkEnableOption "Rust Debug Adapter"
+        // {
+          default = config.vim.languages.enableDAP;
+          defaultText = literalExpression "config.vim.languages.enableDAP";
+        };
 
       debugger = mkOption {
         description = "Rust debugger to use.";

--- a/modules/plugins/languages/tex.nix
+++ b/modules/plugins/languages/tex.nix
@@ -7,7 +7,7 @@
   inherit (lib) genAttrs;
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.options) literalExpression mkEnableOption mkOption;
-  inherit (lib.types) bool enum listOf;
+  inherit (lib.types) enum listOf;
   inherit (lib.nvim.types) mkGrammarOption;
 
   cfg = config.vim.languages.tex;
@@ -21,12 +21,12 @@ in {
     enable = mkEnableOption "TeX language support";
 
     treesitter = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.languages.enableTreesitter;
-        defaultText = literalExpression "config.vim.languages.enableTreesitter";
-        description = "Enable TeX treesitter";
-      };
+      enable =
+        mkEnableOption "TeX treesitter"
+        // {
+          default = config.vim.languages.enableTreesitter;
+          defaultText = literalExpression "config.vim.languages.enableTreesitter";
+        };
       latexPackage = mkGrammarOption pkgs "latex";
       bibtexPackage = mkGrammarOption pkgs "bibtex";
     };

--- a/modules/plugins/languages/zig.nix
+++ b/modules/plugins/languages/zig.nix
@@ -10,7 +10,7 @@
   inherit (lib.generators) mkLuaInline;
   inherit (lib.attrsets) genAttrs;
   inherit (lib.lists) flatten;
-  inherit (lib.types) bool enum listOf;
+  inherit (lib.types) enum listOf;
   inherit (lib.nvim.types) mkGrammarOption deprecatedSingleOrListOf enumWithRename;
 
   cfg = config.vim.languages.zig;
@@ -71,12 +71,12 @@ in {
     };
 
     dap = {
-      enable = mkOption {
-        type = bool;
-        default = config.vim.languages.enableDAP;
-        defaultText = literalExpression "config.vim.languages.enableDAP";
-        description = "Enable Zig Debug Adapter";
-      };
+      enable =
+        mkEnableOption "Zig Debug Adapter"
+        // {
+          default = config.vim.languages.enableDAP;
+          defaultText = literalExpression "config.vim.languages.enableDAP";
+        };
 
       debugger = mkOption {
         type =

--- a/modules/plugins/theme/theme.nix
+++ b/modules/plugins/theme/theme.nix
@@ -3,7 +3,7 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkOption;
+  inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.attrsets) attrNames;
   inherit (lib.strings) hasPrefix;
   inherit (lib.types) bool lines enum;
@@ -33,10 +33,7 @@
     numbers;
 in {
   options.vim.theme = {
-    enable = mkOption {
-      type = bool;
-      description = "Enable theming";
-    };
+    enable = mkEnableOption "theming";
     name = mkOption {
       type = enum (attrNames supportedThemes);
       description = ''

--- a/modules/plugins/utility/new-file-template/new-file-template.nix
+++ b/modules/plugins/utility/new-file-template/new-file-template.nix
@@ -1,22 +1,18 @@
 {lib, ...}: let
-  inherit (lib.options) mkOption;
+  inherit (lib.options) mkOption mkEnableOption;
   inherit (lib.types) attrsOf bool listOf str;
   inherit (lib.nvim.types) mkPluginSetupOption;
 in {
   options.vim.utility.new-file-template = {
-    enable = mkOption {
-      type = bool;
-      default = false;
-      description = ''
-        new-file-template.nvim: Automatically insert a template on new files in neovim.
-        ::: {.note}
-        For custom templates add a directory containing `lua/templates/*.lua`
-        to `vim.additionalRuntimePaths`.
-        :::
-        [custom-template-docs]: https://github.com/otavioschwanck/new-file-template.nvim?tab=readme-ov-file#creating-new-templates
-        More documentation on the templates available at [custom-template-docs]
-      '';
-    };
+    enable = mkEnableOption ''
+      new-file-template.nvim: Automatically insert a template on new files in neovim.
+      ::: {.note}
+      For custom templates add a directory containing `lua/templates/*.lua`
+      to `vim.additionalRuntimePaths`.
+      :::
+      [custom-template-docs]: https://github.com/otavioschwanck/new-file-template.nvim?tab=readme-ov-file#creating-new-templates
+      More documentation on the templates available at [custom-template-docs]
+    '';
 
     setupOpts = mkPluginSetupOption "nvim-file-template.nvim" {
       disableInsert = mkOption {

--- a/modules/plugins/utility/smart-splits/smart-splits.nix
+++ b/modules/plugins/utility/smart-splits/smart-splits.nix
@@ -3,22 +3,17 @@
   lib,
   ...
 }: let
-  inherit (lib.options) mkOption;
-  inherit (lib.types) bool;
+  inherit (lib.options) mkEnableOption;
   inherit (lib.nvim.types) mkPluginSetupOption;
   inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.utility.smart-splits = {
-    enable = mkOption {
-      type = bool;
-      default = false;
-      description = ''
-        Whether to enable smart-splits.nvim, a Neovim plugin for smart,
-        seamless, directional navigation and resizing of splits.
+    enable = mkEnableOption ''
+      smart-splits.nvim, a Neovim plugin for smart,
+      seamless, directional navigation and resizing of splits.
 
-        Supports tmux, Wezterm, Kitty, and Zellij multiplexer integrations.
-      '';
-    };
+      Supports tmux, Wezterm, Kitty, and Zellij multiplexer integrations
+    '';
 
     setupOpts = mkPluginSetupOption "smart-splits" {};
 


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
