### PR TITLE
formatter/conform-nvim/presets/ruff: fix indent-width option

### DIFF
--- a/docs/manual/release-notes/rl-26.12.md
+++ b/docs/manual/release-notes/rl-26.12.md
@@ -42,3 +42,9 @@
 
 - Add beancount support under `vim.languages.beancount` using
   [beancount-language-server] and [bean-format].
+
+[Exflikt](https://github.com/exflikt)
+
+- `formatter/conform-nvim/presets/ruff`: fix `indent-width` option whose key
+  name was not recognized by `ruff format`, which in turn exited with an unknown
+  key error.

--- a/modules/plugins/formatter/conform-nvim/presets/ruff.nix
+++ b/modules/plugins/formatter/conform-nvim/presets/ruff.nix
@@ -45,7 +45,7 @@ in {
 
             return {
               "format",
-              "--config", "format.indent-width = " .. vim.bo[ctx.buf].shiftwidth,
+              "--config", "indent-width = " .. vim.bo[ctx.buf].shiftwidth,
               "--config", "format.indent-style = " .. style,
               "--force-exclude",
               "--stdin-filename", "$FILENAME",
@@ -59,7 +59,7 @@ in {
 
             return {
               "format",
-              "--config", "format.indent-width = " .. vim.bo[ctx.buf].shiftwidth,
+              "--config", "indent-width = " .. vim.bo[ctx.buf].shiftwidth,
               "--config", "format.indent-style = " .. style,
               "--force-exclude",
               "--range", string.format(


### PR DESCRIPTION
`ruff format` complains that `indent-width` cannot be configured through `format.*` namespace. Using top-level key solved the issue.

Fixes #1762

## Sanity Checking

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`
