### PR TITLE
feat(twilight) added twilight by folke

### DIFF
--- a/modules/plugins/theme/twilight/config.nix
+++ b/modules/plugins/theme/twilight/config.nix
@@ -1,0 +1,21 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.theme.twilight;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["twilight.nvim"];
+
+      pluginRC.twilight = entryAnywhere ''
+        require("twilight").setup(${toLuaObject cfg.setupOpts})
+      '';
+    };
+  };
+}

--- a/modules/plugins/theme/twilight/default.nix
+++ b/modules/plugins/theme/twilight/default.nix
@@ -1,7 +1,6 @@
 {
   imports = [
-    ./theme.nix
     ./config.nix
-    ./twilight
+    ./twilight.nix
   ];
 }

--- a/modules/plugins/theme/twilight/twilight.nix
+++ b/modules/plugins/theme/twilight/twilight.nix
@@ -1,0 +1,10 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.theme.twilight = {
+    enable = mkEnableOption "twilight.nvim";
+
+    setupOpts = mkPluginSetupOption "twilight.nvim" {};
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2857,6 +2857,22 @@
       "url": "https://github.com/dmmulroy/ts-error-translator.nvim/archive/558abff11b9e8f4cefc0de09df780c56841c7a4b.tar.gz",
       "hash": "sha256-kjZwfvb0B7GC4dBBSdgC/zRmCUCfCm4H5J+8SFzANJ4="
     },
+    "twilight.nvim": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "folke",
+        "repo": "twilight.nvim"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v1.0.0",
+      "revision": "8bb7fa7b918baab1ca81b977102ddb54afa63512",
+      "url": "https://api.github.com/repos/folke/twilight.nvim/tarball/refs/tags/v1.0.0",
+      "hash": "sha256-HqkdXI5nzSkdZeu56BY8Y0Yq64UFqnsxQmJVsBkRDS8="
+    },
     "typst-concealer": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Add native support for [twilight.nvim](https://github.com/folke/twilight.nvim) as a UI module under `vim.ui.twilight`.

## Sanity Checking

* [x] I have updated the [changelog](https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes)
* [x] I have tested, and self-reviewed my code
* [x] My changes fit guidelines found in [hacking nvf]
* Style and consistency
  * [x] I ran **Alejandra** to format my code (`nix fmt`)
  * [x] My code conforms to the [editorconfig] configuration of the project
  * [x] My changes are consistent with the rest of the codebase
* If new changes are particularly complex:
  * [ ] My code includes comments in particularly complex areas
  * [ ] I have added a section in the manual
  * [ ] *(For breaking changes)* I have included a migration guide
* Package(s) built:
  * [x] `.#nix` *(default package)*
  * [x] `.#maximal`
  * [x] `.#docs-html` *(manual, must build)*
  * [x] `.#docs-linkcheck` *(optional, please build if adding links)*
* Tested on platform(s)
  * [x] `x86_64-linux`
  * [ ] `aarch64-linux`
  * [ ] `x86_64-darwin`
  * [ ] `aarch64-darwin`