### PR TITLE
plugins/utility/jupyter: add magma-nvim and jupytext-nvim modules

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -233,6 +233,12 @@ isMaximal: {
       undotree.enable = isMaximal;
       nvim-biscuits.enable = isMaximal;
       grug-far-nvim.enable = isMaximal;
+      jupyter.magma-nvim = {
+        enable = isMaximal;
+        setupOpts.imageProvider = "kitty";
+        setupOpts.preferNixVenvWrapper = true;
+      };
+      jupytext-nvim.enable = isMaximal;
 
       motion = {
         hop.enable = true;

--- a/docs/manual/release-notes/rl-26.12.md
+++ b/docs/manual/release-notes/rl-26.12.md
@@ -28,6 +28,19 @@
 
 ## Changelog {#sec-release-26-12-changelog}
 
+[jack-thesparrow](https://github.com/jack-thesparrow)
+
+- Added the `vim.utility.jupyter.magma-nvim` module, providing Jupyter
+  integration for Neovim: kernel management, cell evaluation, and output
+  rendering through magma-nvim.
+
+- Added the `vim.utility.jupytext-nvim` module, which pairs `.ipynb` notebooks
+  with text files (percent format) for editing in Neovim.
+
+- Patched `codewindow.nvim` so its treesitter-based minimap highlighting no
+  longer crashes when enabled with newer `nvim-treesitter` versions, which
+  removed the deprecated `ts_utils` module.
+
 [snoweuph](https://github.com/snoweuph)
 
 - `languages/lua`: fix arguments for `formatter/conform-nvim/presets/stylua` to

--- a/modules/plugins/utility/default.nix
+++ b/modules/plugins/utility/default.nix
@@ -11,6 +11,7 @@
     ./icon-picker
     ./images
     ./grug-far-nvim
+    ./jupyter
     ./leetcode-nvim
     ./mkdir
     ./motion

--- a/modules/plugins/utility/jupyter/default.nix
+++ b/modules/plugins/utility/jupyter/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./magma-nvim
+    ./jupytext-nvim
+  ];
+}

--- a/modules/plugins/utility/jupyter/jupytext-nvim/config.nix
+++ b/modules/plugins/utility/jupyter/jupytext-nvim/config.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.utility.jupytext-nvim;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["jupytext.nvim"];
+
+      extraPackages = [pkgs.python3Packages.jupytext];
+
+      pluginRC.jupytext-nvim = entryAnywhere ''
+        require("jupytext").setup(${toLuaObject cfg.setupOpts})
+
+        local jupytext_utils = require("jupytext.utils")
+        local language_extensions = {
+          python = "py", julia = "jl", r = "r", R = "r", bash = "sh",
+        }
+        local language_names = { python3 = "python" }
+
+        jupytext_utils.get_ipynb_metadata = function(filename)
+          local f = io.open(filename, "r")
+          if not f then return { language = "python", extension = "py" } end
+          local ok, decoded = pcall(vim.json.decode, f:read("a"))
+          f:close()
+          if not ok or not decoded or not decoded.metadata then
+            return { language = "python", extension = "py" }
+          end
+          local meta = decoded.metadata
+          local language = nil
+          if meta.kernelspec then
+            language = meta.kernelspec.language
+            if not language then
+              language = language_names[meta.kernelspec.name]
+            end
+          end
+          if not language and meta.language_info then
+            language = meta.language_info.name
+          end
+          language = language or "python"
+          local extension = language_extensions[language] or "py"
+          return { language = language, extension = extension }
+        end
+      '';
+    };
+  };
+}

--- a/modules/plugins/utility/jupyter/jupytext-nvim/default.nix
+++ b/modules/plugins/utility/jupyter/jupytext-nvim/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./jupytext-nvim.nix
+  ];
+}

--- a/modules/plugins/utility/jupyter/jupytext-nvim/jupytext-nvim.nix
+++ b/modules/plugins/utility/jupyter/jupytext-nvim/jupytext-nvim.nix
@@ -1,0 +1,26 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.utility.jupytext-nvim = {
+    enable = mkEnableOption "jupytext-nvim to automatically convert .ipynb files in Neovim";
+
+    setupOpts = mkPluginSetupOption "jupytext-nvim" {
+      style = lib.mkOption {
+        type = lib.types.str;
+        default = "percent";
+        description = "Default format to convert notebooks into (e.g., 'markdown', 'light', 'percent').";
+      };
+      output_extension = lib.mkOption {
+        type = lib.types.str;
+        default = "py";
+        description = "Extension of the output file (e.g., 'auto', 'md', 'py').";
+      };
+      force_ft = lib.mkOption {
+        type = lib.types.str;
+        default = "python";
+        description = "Force the filetype of the converted document.";
+      };
+    };
+  };
+}

--- a/modules/plugins/utility/jupyter/magma-nvim/config.nix
+++ b/modules/plugins/utility/jupyter/magma-nvim/config.nix
@@ -1,0 +1,236 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.dag) entryAnywhere;
+  inherit (lib.nvim.lua) toLuaObject;
+  inherit (lib.nvim.binds) mkKeymap;
+
+  cfg = config.vim.utility.jupyter.magma-nvim;
+  opts = cfg.setupOpts;
+  keys = cfg.mappings;
+in {
+  config = mkIf cfg.enable {
+    vim = {
+      startPlugins = ["magma-nvim"];
+      withPython3 = true;
+      python3Packages = ["pynvim" "jupyter-client" "ipykernel"] ++ cfg.python3Packages;
+
+      pluginRC.magma-nvim = entryAnywhere ''
+        vim.g.magma_automatically_open_output = ${toLuaObject opts.automaticallyOpenOutput}
+        vim.g.magma_image_provider = ${toLuaObject opts.imageProvider}
+        vim.g.magma_wrap_output = ${toLuaObject opts.wrapOutput}
+        vim.g.magma_output_window_borders = ${toLuaObject opts.outputWindowBorders}
+        vim.g.magma_cell_highlight_group = ${toLuaObject opts.cellHighlightGroup}
+        ${lib.optionalString (opts.savePath != null) "vim.g.magma_save_path = ${toLuaObject opts.savePath}"}
+        vim.g.magma_copy_output = ${toLuaObject opts.copyOutput}
+        vim.g.magma_show_mimetype_debug = ${toLuaObject opts.showMimetypeDebug}
+
+        vim.g.loaded_remote_plugins = mnw.configDir .. "/rplugin.vim"
+
+        local magma_script = vim.api.nvim_get_runtime_file("rplugin/python3/magma", true)[1]
+        if magma_script then
+          vim.cmd([[
+            call remote#host#RegisterPlugin('python3', ']] .. magma_script .. [[', [
+              \ {'sync': v:true, 'name': 'MagmaDeinit', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaDelete', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaDeleteAll', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaEnterOutput', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaReevaluateCell', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaEvaluateLine', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaEvaluateOperator', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaEvaluateVisual', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaInit', 'type': 'command', 'opts': {'complete': 'file', 'nargs': '?'}},
+              \ {'sync': v:true, 'name': 'MagmaInterrupt', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaLoad', 'type': 'command', 'opts': {'nargs': '?'}},
+              \ {'sync': v:true, 'name': 'MagmaRestart', 'type': 'command', 'opts': {'bang': ""}},
+              \ {'sync': v:true, 'name': 'MagmaSave', 'type': 'command', 'opts': {'nargs': '?'}},
+              \ {'sync': v:true, 'name': 'MagmaShowOutput', 'type': 'command', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaEvaluateArgument', 'type': 'command', 'opts': {'nargs': 1}},
+              \ {'sync': v:true, 'name': 'MagmaClearInterface', 'type': 'function', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaDefineCell', 'type': 'function', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaOperatorfunc', 'type': 'function', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaTick', 'type': 'function', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaOnBufferUnload', 'type': 'function', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaOnExitPre', 'type': 'function', 'opts': {}},
+              \ {'sync': v:true, 'name': 'MagmaUpdateInterface', 'type': 'function', 'opts': {}},
+              \ ])
+          ]])
+        end
+
+        local function magma_insert_cell(kind, above)
+          local marker = kind == "markdown" and "# %% [markdown]" or "# %%"
+          local line = vim.api.nvim_win_get_cursor(0)[1]
+          if above then
+            vim.api.nvim_buf_set_lines(0, line - 1, line - 1, false, { marker, "" })
+            vim.api.nvim_win_set_cursor(0, { line + 1, 0 })
+          else
+            vim.api.nvim_buf_set_lines(0, line, line, false, { "", marker })
+            vim.api.nvim_win_set_cursor(0, { line + 3, 0 })
+          end
+        end
+        vim.g.magma_insert_cell = magma_insert_cell
+
+        local function magma_run_cell()
+          local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+          local cur = vim.api.nvim_win_get_cursor(0)[1] - 1
+          local n = #lines
+          local is_marker = function(l)
+            return l ~= nil and (vim.startswith(l, "# %%") or vim.startswith(l, "#%%"))
+          end
+          local is_markdown = function(l)
+            return l ~= nil and l:match("^#%s*%%+%s*%[markdown%]") ~= nil
+          end
+          local marker_row = nil
+          local start = 0
+          if is_marker(lines[cur + 1]) then
+            marker_row = cur
+            start = cur + 1
+          else
+            for r = cur - 1, 0, -1 do
+              if is_marker(lines[r + 1]) then
+                marker_row = r
+                start = r + 1
+                break
+              end
+            end
+          end
+          local endline = n - 1
+          for r = cur + 1, n - 1 do
+            if is_marker(lines[r + 1]) then
+              endline = r - 1
+              break
+            end
+          end
+          while endline >= start and lines[endline + 1]:match("^%s*$") do
+            endline = endline - 1
+          end
+          while start <= endline and lines[start + 1]:match("^%s*$") do
+            start = start + 1
+          end
+          if marker_row ~= nil and is_markdown(lines[marker_row + 1]) then
+            vim.notify("Magma: markdown cell, nothing to run", vim.log.levels.INFO)
+            return
+          end
+          if endline < start then
+            vim.notify("Magma: cell is empty", vim.log.levels.WARN)
+            return
+          end
+          vim.fn.setpos("'<", { 0, start + 1, 1, 0 })
+          vim.fn.setpos("'>", { 0, endline + 1, vim.fn.col("$"), 0 })
+          vim.cmd("MagmaEvaluateVisual")
+        end
+        vim.g.magma_run_cell = magma_run_cell
+
+        local function magma_register_kernel()
+          local function venv_name(dir)
+            local base = vim.fn.fnamemodify(dir, ":t")
+            if base == ".venv" or base == "venv" then
+              return vim.fn.fnamemodify(dir, ":h:t") .. "-" .. base
+            end
+            return base
+          end
+
+          local python = ""
+          local name = ""
+          local env = vim.fn.getenv("VIRTUAL_ENV")
+          if env ~= vim.NIL and env ~= "" then
+            python = env .. "/bin/python"
+            name = venv_name(env)
+          else
+            env = vim.fn.getenv("CONDA_PREFIX")
+            if env ~= vim.NIL and env ~= "" then
+              python = env .. "/bin/python"
+              name = vim.fn.fnamemodify(env, ":t")
+            elseif vim.fn.getenv("IN_NIX_SHELL") ~= vim.NIL and vim.fn.getenv("IN_NIX_SHELL") ~= "" then
+              python = vim.fn.exepath("python")
+              name = "nix-shell"
+            else
+              python = vim.fn.exepath("python3")
+              name = "system"
+            end
+          end
+          if python == "" then
+            python = vim.fn.exepath("python3")
+            if python == "" then
+              vim.notify("Magma: no Python interpreter found to register", vim.log.levels.ERROR)
+              return
+            end
+          end
+
+          if ${toLuaObject opts.preferNixVenvWrapper} then
+            local nix_wrapper = vim.fn.fnamemodify(python, ":h") .. "/python3-nix"
+            if vim.fn.filereadable(nix_wrapper) == 1 then
+              python = nix_wrapper
+            end
+          end
+
+          local check = vim.fn.system(python .. " -c 'import ipykernel' 2>&1")
+          if vim.v.shell_error ~= 0 then
+            local detail = vim.fn.trim(check)
+            if detail == "" then
+              detail = "ipykernel is missing (install it with `" .. python
+                .. " -m pip install ipykernel`)"
+            end
+            vim.notify(
+              "Magma: import ipykernel failed in " .. python .. ": " .. detail,
+              vim.log.levels.ERROR
+            )
+            return
+          end
+
+          local data_dir = vim.fn.getenv("JUPYTER_DATA_DIR")
+          if data_dir == vim.NIL or data_dir == "" then
+            data_dir = vim.fn.expand("~/.local/share/jupyter")
+          end
+          local kernels_dir = data_dir .. "/kernels/" .. name
+          vim.fn.mkdir(kernels_dir, "p")
+          vim.fn.writefile({
+            vim.json.encode({
+              argv = { python, "-m", "ipykernel_launcher", "-f", "{connection_file}" },
+              display_name = name,
+              language = "python",
+            }),
+          }, kernels_dir .. "/kernel.json")
+
+          vim.notify(
+            "Magma: registered kernel '" .. name .. "' from " .. python
+              .. ". Use <leader>mk or :MagmaInit to select it.",
+            vim.log.levels.INFO
+          )
+        end
+        vim.g.magma_register_kernel = magma_register_kernel
+      '';
+
+      keymaps = [
+        (mkKeymap "n" keys.init "<cmd>MagmaInit ${opts.defaultKernel}<CR>" {desc = "Initialize kernel";})
+        (mkKeymap "n" keys.deinit "<cmd>MagmaDeinit<CR>" {desc = "Deinitialize kernel";})
+        (mkKeymap "n" keys.evaluateLine "<cmd>MagmaEvaluateLine<CR>" {desc = "Evaluate line";})
+        (mkKeymap "n" keys.evaluateOperator "nvim_exec('MagmaEvaluateOperator', v:true)" {
+          desc = "Evaluate operator";
+          expr = true;
+        })
+        (mkKeymap "v" keys.evaluateVisual ":<C-u>MagmaEvaluateVisual<CR>" {desc = "Evaluate visual selection";})
+        (mkKeymap "n" keys.reevaluateCell "<cmd>MagmaReevaluateCell<CR>" {desc = "Re-evaluate cell";})
+        (mkKeymap "n" keys.delete "<cmd>MagmaDelete<CR>" {desc = "Delete cell";})
+        (mkKeymap "n" keys.deleteAll "<cmd>MagmaDeleteAll<CR>" {desc = "Delete all cell outputs";})
+        (mkKeymap "n" keys.showOutput "<cmd>MagmaShowOutput<CR>" {desc = "Show output";})
+        (mkKeymap "n" keys.restart "<cmd>MagmaRestart!<CR>" {desc = "Restart kernel";})
+        (mkKeymap "n" keys.interrupt "<cmd>MagmaInterrupt<CR>" {desc = "Interrupt execution";})
+        (mkKeymap "n" keys.save "<cmd>MagmaSave<CR>" {desc = "Save cells";})
+        (mkKeymap "n" keys.load "<cmd>MagmaLoad<CR>" {desc = "Load cells";})
+        (mkKeymap "n" keys.enterOutput "<cmd>noautocmd MagmaEnterOutput<CR>" {desc = "Enter output window";})
+        (mkKeymap "n" keys.runAll "ggVG<cmd>MagmaEvaluateVisual<CR>" {desc = "Evaluate entire buffer";})
+        (mkKeymap "n" keys.runCell "<cmd>lua vim.g.magma_run_cell()<CR>" {desc = "Run cell under cursor";})
+        (mkKeymap "n" keys.insertCodeCellBelow "<cmd>lua vim.g.magma_insert_cell('code', false)<CR>" {desc = "Insert code cell below";})
+        (mkKeymap "n" keys.insertCodeCellAbove "<cmd>lua vim.g.magma_insert_cell('code', true)<CR>" {desc = "Insert code cell above";})
+        (mkKeymap "n" keys.insertMarkdownCellBelow "<cmd>lua vim.g.magma_insert_cell('markdown', false)<CR>" {desc = "Insert markdown cell below";})
+        (mkKeymap "n" keys.insertMarkdownCellAbove "<cmd>lua vim.g.magma_insert_cell('markdown', true)<CR>" {desc = "Insert markdown cell above";})
+        (mkKeymap "n" keys.selectKernel "<cmd>MagmaInit<CR>" {desc = "Select Jupyter kernel";})
+        (mkKeymap "n" keys.registerKernel "<cmd>lua vim.g.magma_register_kernel()<CR>" {desc = "Register current environment as kernel";})
+      ];
+    };
+  };
+}

--- a/modules/plugins/utility/jupyter/magma-nvim/default.nix
+++ b/modules/plugins/utility/jupyter/magma-nvim/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./config.nix
+    ./magma-nvim.nix
+  ];
+}

--- a/modules/plugins/utility/jupyter/magma-nvim/magma-nvim.nix
+++ b/modules/plugins/utility/jupyter/magma-nvim/magma-nvim.nix
@@ -1,0 +1,126 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.options) mkOption mkEnableOption;
+  inherit (lib.types) bool str enum nullOr listOf;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+  inherit (config.vim.lib) mkMappingOption;
+in {
+  options.vim.utility.jupyter.magma-nvim = {
+    enable = mkEnableOption "magma-nvim Jupyter integration for Neovim";
+    python3Packages = mkOption {
+      type = listOf str;
+      default = [];
+      description = ''
+        Additional Python package attribute names to make available to the
+        built-in `python3` Jupyter kernel shipped with this module.
+
+        The minimal set magma-nvim itself needs to run is always included: the
+        `pynvim` rplugin host, `jupyter-client` to drive kernels, and
+        `ipykernel` for the fallback `python3` kernel. Only add packages here if
+        you want extra libraries in that fallback kernel.
+
+        This is **not** the place to collect the libraries your notebooks
+        `import`. magma-nvim launches kernels as external processes, and each
+        kernel runs in its own environment: a venv, uv-managed environment,
+        nix shell or the system Python that you have registered as a Jupyter
+        kernelspec. Those kernels are discovered automatically, so project
+        dependencies should live in the environment they belong to, not in the
+        Neovim host.
+      '';
+    };
+    setupOpts = mkPluginSetupOption "magma-nvim" {
+      automaticallyOpenOutput = mkOption {
+        type = bool;
+        default = true;
+        description = "Automatically open floating output window after cell execution.";
+      };
+      defaultKernel = mkOption {
+        type = str;
+        default = "python3";
+        description = ''
+          Name of the Jupyter kernelspec that `<leader>mn` (or the configured
+          init mapping) launches by default. Any kernelspec Jupyter can find is
+          valid — including ones registered from a project venv, a uv-managed
+          environment, a nix shell, or the system Python. Use the
+          `<leader>mk` mapping or `:MagmaInit` with no arguments to pick a
+          different kernel interactively.
+        '';
+      };
+      preferNixVenvWrapper = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          When registering a venv kernel (`<leader>mK`), prefer the venv's
+          `bin/python3-nix` wrapper script over the bare interpreter if it
+          exists. Some nix + uv devShells ship such a wrapper to inject the
+          nix shared libraries (libstdc++, zlib, glib) that pip-built wheels
+          like `pyzmq` need at runtime. Off by default so the framework does
+          not assume any particular venv convention; enable it if your
+          devShell provides such a wrapper.
+        '';
+      };
+      imageProvider = mkOption {
+        type = enum ["none" "ueberzug" "kitty"];
+        default = "none";
+        description = "Backend provider for rendering images and plots.";
+      };
+      wrapOutput = mkOption {
+        type = bool;
+        default = true;
+        description = "Wrap text inside floating output windows.";
+      };
+      outputWindowBorders = mkOption {
+        type = bool;
+        default = true;
+        description = "Display borders around floating output windows.";
+      };
+      cellHighlightGroup = mkOption {
+        type = str;
+        default = "CursorLine";
+        description = "Highlight group applied to active cell lines.";
+      };
+      savePath = mkOption {
+        type = nullOr str;
+        default = null;
+        description = "Directory path where magma-nvim saves state JSON files.";
+      };
+      copyOutput = mkOption {
+        type = bool;
+        default = false;
+        description = "Automatically copy evaluated cell outputs to system clipboard.";
+      };
+      showMimetypeDebug = mkOption {
+        type = bool;
+        default = false;
+        description = "Display raw MIME-type debug headers in floating output windows.";
+      };
+    };
+    mappings = {
+      init = mkMappingOption "Initialize a Jupyter kernel for the current buffer" "<leader>mn";
+      deinit = mkMappingOption "Deinitialize the current buffer's kernel" "<leader>mq";
+      evaluateLine = mkMappingOption "Evaluate current line" "<leader>ml";
+      evaluateOperator = mkMappingOption "Evaluate text object or selection operator" "<leader>mO";
+      evaluateVisual = mkMappingOption "Evaluate visual selection" "<leader>mv";
+      reevaluateCell = mkMappingOption "Re-evaluate current cell" "<leader>mC";
+      delete = mkMappingOption "Delete current cell output" "<leader>md";
+      deleteAll = mkMappingOption "Delete all cell outputs" "<leader>mD";
+      showOutput = mkMappingOption "Show output window for current cell" "<leader>ms";
+      restart = mkMappingOption "Restart current Jupyter kernel" "<leader>mr";
+      interrupt = mkMappingOption "Interrupt current kernel execution" "<leader>mi";
+      save = mkMappingOption "Save cells and outputs to a JSON file" "<leader>mw";
+      load = mkMappingOption "Load cells and outputs from a JSON file" "<leader>mL";
+      enterOutput = mkMappingOption "Enter the output window" "<leader>me";
+      runAll = mkMappingOption "Evaluate the entire buffer" "<leader>ma";
+      runCell = mkMappingOption "Evaluate the jupytext cell under the cursor" "<leader>mR";
+      insertCodeCellAbove = mkMappingOption "Insert a code cell above the cursor" "<leader>mB";
+      insertCodeCellBelow = mkMappingOption "Insert a code cell below the cursor" "<leader>mb";
+      insertMarkdownCellAbove = mkMappingOption "Insert a markdown cell above the cursor" "<leader>mT";
+      insertMarkdownCellBelow = mkMappingOption "Insert a markdown cell below the cursor" "<leader>mt";
+      selectKernel = mkMappingOption "Select a Jupyter kernel interactively" "<leader>mk";
+      registerKernel = mkMappingOption "Register the current Python environment as a kernel" "<leader>mK";
+    };
+  };
+}

--- a/modules/wrapper/build/config.nix
+++ b/modules/wrapper/build/config.nix
@@ -31,6 +31,19 @@
 
   pluginBuilders = {
     nvim-treesitter = buildTreesitterPlug config.vim.treesitter.grammars;
+    # magma-nvim is unmaintained upstream and crashes on Neovim 0.10+ because
+    # it passes `style = nil` to `nvim_open_win`, which newer Neovim rejects.
+    magma-nvim = buildPlug {
+      pname = "magma-nvim";
+      patches = [./patches/magma-nvim.patch];
+    };
+    # codewindow's `use_treesitter` path requires the deprecated
+    # `nvim-treesitter.ts_utils`, removed in newer nvim-treesitter; the patch
+    # degrades gracefully to the non-treesitter minimap when it is absent.
+    codewindow-nvim = buildPlug {
+      pname = "codewindow-nvim";
+      patches = [./patches/codewindow-nvim.patch];
+    };
     flutter-tools-patched = buildPlug {
       pname = "flutter-tools-nvim";
       patches = [./patches/flutter-tools.patch];

--- a/modules/wrapper/build/patches/codewindow-nvim.patch
+++ b/modules/wrapper/build/patches/codewindow-nvim.patch
@@ -1,0 +1,23 @@
+diff --git a/lua/codewindow/highlight.lua b/lua/codewindow/highlight.lua
+index 535b43d..4d85f3a 100644
+--- a/lua/codewindow/highlight.lua
++++ b/lua/codewindow/highlight.lua
+@@ -124,8 +124,16 @@ end
+ 
+ if config.use_treesitter then
+   highlighter = require("vim.treesitter.highlighter")
+-  ts_utils = require("nvim-treesitter.ts_utils")
+-  M.extract_highlighting = extract_highlighting
++  -- Newer nvim-treesitter versions removed the deprecated `ts_utils` module,
++  -- which used to crash codewindow at startup when `use_treesitter` is on.
++  -- Fall back to the non-treesitter minimap rendering path when it is absent.
++  local ok, ts_utils_mod = pcall(require, "nvim-treesitter.ts_utils")
++  if ok then
++    ts_utils = ts_utils_mod
++    M.extract_highlighting = extract_highlighting
++  else
++    M.extract_highlighting = function() end
++  end
+ else
+   M.extract_highlighting = function() end
+ end

--- a/modules/wrapper/build/patches/magma-nvim.patch
+++ b/modules/wrapper/build/patches/magma-nvim.patch
@@ -1,0 +1,195 @@
+diff -ru '--exclude=.git' /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/__init__.py ./rplugin/python3/magma/__init__.py
+--- /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/__init__.py	1970-01-01 05:30:01.000000000 +0530
++++ ./rplugin/python3/magma/__init__.py	2026-08-15 23:43:30.214885049 +0530
+@@ -321,6 +321,16 @@
+ 
+         magma.delete_cell()
+ 
++    @pynvim.command("MagmaDeleteAll", nargs=0, sync=True)  # type: ignore
++    @nvimui  # type: ignore
++    def command_delete_all(self) -> None:
++        self._initialize_if_necessary()
++
++        magma = self._get_magma(True)
++        assert magma is not None
++
++        magma.delete_all_cells()
++
+     @pynvim.command("MagmaShowOutput", nargs=0, sync=True)  # type: ignore
+     @nvimui  # type: ignore
+     def command_show_output(self) -> None:
+diff -ru '--exclude=.git' /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/magmabuffer.py ./rplugin/python3/magma/magmabuffer.py
+--- /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/magmabuffer.py	1970-01-01 05:30:01.000000000 +0530
++++ ./rplugin/python3/magma/magmabuffer.py	2026-08-15 23:21:24.219306718 +0530
+@@ -134,6 +134,16 @@
+             )
+         if did_stuff:
+             self.update_interface()
++        if self.runtime._kernel_died and not self.runtime.is_ready():
++            if not self.runtime._kernel_died_reported:
++                self.runtime._kernel_died_reported = True
++                self.nvim.api.notify(
++                    "Kernel '%s' died during startup. Check the kernelspec "
++                    "(`jupyter kernelspec list`) or the environment it points "
++                    "to." % self.runtime.kernel_name,
++                    pynvim.logging.ERROR,
++                    {"title": "Magma"},
++                )
+         if not was_ready and self.runtime.is_ready():
+             self.nvim.api.notify(
+                 "Kernel '%s' is ready." % self.runtime.kernel_name,
+@@ -193,6 +203,11 @@
+         self.outputs[self.selected_cell].clear_interface()
+         del self.outputs[self.selected_cell]
+ 
++    def delete_all_cells(self) -> None:
++        for output_span in reversed(list(self.outputs.keys())):
++            self.outputs[output_span].clear_interface()
++            del self.outputs[output_span]
++
+     def update_interface(self) -> None:
+         if self.buffer.number != self.nvim.current.buffer.number:
+             return
+diff -ru '--exclude=.git' /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/options.py ./rplugin/python3/magma/options.py
+--- /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/options.py	1970-01-01 05:30:01.000000000 +0530
++++ ./rplugin/python3/magma/options.py	2026-08-15 23:00:30.272156341 +0530
+@@ -28,7 +28,7 @@
+             "magma_cell_highlight_group", "CursorLine"
+         )
+         self.save_path = nvim.vars.get(
+-            "magma_save_cell",
++            "magma_save_path",
+             os.path.join(nvim.funcs.stdpath("data"), "magma"),
+         )
+         self.image_provider = nvim.vars.get("magma_image_provider", "none")
+diff -ru '--exclude=.git' /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/outputbuffer.py ./rplugin/python3/magma/outputbuffer.py
+--- /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/outputbuffer.py	1970-01-01 05:30:01.000000000 +0530
++++ ./rplugin/python3/magma/outputbuffer.py	2026-08-15 23:00:30.272156341 +0530
+@@ -123,7 +123,7 @@
+                     "width": win_width,
+                     "height": min(win_height - win_row, lineno + 1),
+                     "anchor": "NW",
+-                    "style": None
++                    "style": ""
+                     if self.options.output_window_borders
+                     else "minimal",
+                     "border": "rounded"
+diff -ru '--exclude=.git' /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/runtime.py ./rplugin/python3/magma/runtime.py
+--- /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/runtime.py	1970-01-01 05:30:01.000000000 +0530
++++ ./rplugin/python3/magma/runtime.py	2026-08-15 23:02:34.351899577 +0530
+@@ -40,6 +40,9 @@
+     def __init__(self, kernel_name: str, options: MagmaOptions):
+         self.state = RuntimeState.STARTING
+         self.kernel_name = kernel_name
++        self._kernel_info_sent = False
++        self._kernel_died = False
++        self._kernel_died_reported = False
+ 
+         if ".json" not in self.kernel_name:
+ 
+@@ -97,6 +100,30 @@
+     def run_code(self, code: str) -> None:
+         self.kernel_client.execute(code)
+ 
++    def _poll_kernel_ready(self) -> bool:
++        """Non-blocking kernel_info handshake.
++
++        `wait_for_ready` blocks for up to a second per call, which freezes
++        Neovim because `MagmaTick` runs synchronously on the UI thread while
++        the kernel is still starting. Instead we fire the request once and
++        only inspect messages that are already waiting on the shell channel.
++        """
++        if not self.kernel_client.is_alive():
++            self._kernel_died = True
++            raise RuntimeError("Kernel died before becoming ready")
++
++        if not self._kernel_info_sent:
++            self._kernel_info_sent = True
++            request = self.kernel_client.session.msg("kernel_info_request")
++            self.kernel_client.shell_channel.send(request)
++            return False
++
++        try:
++            message = self.kernel_client.shell_channel.get_msg(timeout=0)
++        except EmptyQueueException:
++            return False
++        return message.get("msg_type") == "kernel_info_reply"
++
+     @contextmanager
+     def _alloc_file(
+         self, extension: str, mode: str
+@@ -134,20 +161,15 @@
+ 
+         if message_type == "execute_input":
+             output.execution_count = content["execution_count"]
+-            if self.external_kernel is False:
+-                assert output.status != OutputStatus.DONE
+-                if output.status == OutputStatus.HOLD:
+-                    output.status = OutputStatus.RUNNING
+-                elif output.status == OutputStatus.RUNNING:
+-                    output.status = OutputStatus.DONE
+-                else:
+-                    raise ValueError(
+-                        "bad value for output.status: %r" % output.status
+-                    )
++            if output.status == OutputStatus.HOLD:
++                output.status = OutputStatus.RUNNING
++            elif output.status == OutputStatus.RUNNING:
++                output.status = OutputStatus.DONE
+             return True
+         elif message_type == "status":
+             execution_state = content["execution_state"]
+-            assert execution_state != "starting"
++            if execution_state == "starting":
++                return False
+             if execution_state == "idle":
+                 self.state = RuntimeState.IDLE
+                 output.status = OutputStatus.DONE
+@@ -206,9 +228,9 @@
+ 
+         if not self.is_ready():
+             try:
+-                self.kernel_client.wait_for_ready(timeout=0)
+-                self.state = RuntimeState.IDLE
+-                did_stuff = True
++                if self._poll_kernel_ready():
++                    self.state = RuntimeState.IDLE
++                    did_stuff = True
+             except RuntimeError:
+                 return False
+ 
+diff -ru '--exclude=.git' /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/utils.py ./rplugin/python3/magma/utils.py
+--- /nix/store/49vf34m15h10bqi1hj8v48ghd4majy9g-magma-nvim-ff3deba8/rplugin/python3/magma/utils.py	1970-01-01 05:30:01.000000000 +0530
++++ ./rplugin/python3/magma/utils.py	2026-08-15 23:43:41.363776482 +0530
+@@ -1,4 +1,5 @@
+ from typing import Union, List
++import threading
+ 
+ from pynvim import Nvim
+ 
+@@ -58,9 +59,22 @@
+         )
+ 
+     def __del__(self) -> None:
+-        self.nvim.funcs.nvim_buf_del_extmark(
+-            self.bufno, self.extmark_namespace, self.extmark_id
+-        )
++        # Destructors may run on whatever thread triggered the garbage
++        # collection. jupyter_client runs its kernel-startup coroutine on a
++        # dedicated background thread (see jupyter_core's `_TaskRunner`), so a
++        # `DynamicPosition` can be finalized there. pynvim rejects requests
++        # from threads other than its RPC loop, so only touch nvim when the
++        # loop is idle on the main thread; any extmark left behind is wiped by
++        # magma's next `clear_interface`, and never raise from `__del__`.
++        try:
++            loop_thread = self.nvim._session._loop_thread
++            if loop_thread is not None and threading.current_thread() != loop_thread:
++                return
++            self.nvim.funcs.nvim_buf_del_extmark(
++                self.bufno, self.extmark_namespace, self.extmark_id
++            )
++        except Exception:
++            pass
+ 
+     def _get_pos(self) -> List[int]:
+         out = self.nvim.funcs.nvim_buf_get_extmark_by_id(

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -961,6 +961,19 @@
       "url": "https://github.com/lukas-reineke/indent-blankline.nvim/archive/d28a3f70721c79e3c5f6693057ae929f3d9c0a03.tar.gz",
       "hash": "sha256-Vc79ff416uJFqKH8zlM1y208SxaQGpQPqGVbiz5Vflg="
     },
+    "jupytext.nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "GCBallesteros",
+        "repo": "jupytext.nvim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "c8baf3ad344c59b3abd461ecc17fc16ec44d0f7b",
+      "url": "https://github.com/GCBallesteros/jupytext.nvim/archive/c8baf3ad344c59b3abd461ecc17fc16ec44d0f7b.tar.gz",
+      "hash": "sha256-LBBRZOSqn70qruSA/vbPMTzS7y05F/z4EqC+5JlU6NM="
+    },
     "lazydev-nvim": {
       "type": "Git",
       "repository": {
@@ -1104,6 +1117,19 @@
       "revision": "ef746afb55467984ef3200d9709c8059ee0257d0",
       "url": "https://github.com/horriblename/lzn-auto-require/archive/ef746afb55467984ef3200d9709c8059ee0257d0.tar.gz",
       "hash": "sha256-KC1z+zC9vKODllZVpBu+udzM12oYJaS8e6LdXWtQ89U="
+    },
+    "magma-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "dccsillag",
+        "repo": "magma-nvim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "ff3deba8a879806a51c005e50782130246143d06",
+      "url": "https://github.com/dccsillag/magma-nvim/archive/ff3deba8a879806a51c005e50782130246143d06.tar.gz",
+      "hash": "sha256-IrMR57gk9iCk73esHO24KZeep9VrlkV5sOC4PzGexyo="
     },
     "markview-nvim": {
       "type": "Git",


### PR DESCRIPTION
## Summary

Add Jupyter integration to nvf via two new modules:

1. **`vim.utility.jupyter.magma-nvim`** - Full Jupyter kernel management, cell evaluation, and output rendering in Neovim using magma-nvim
2. **`vim.utility.jupytext-nvim`** - Automatic bidirectional sync between `.ipynb` notebooks and percent-format text files (`.py`, `.md`, etc.)

Also includes a patch for `codewindow.nvim` to fix a crash when `use_treesitter` is enabled with newer `nvim-treesitter` versions (which removed the deprecated `ts_utils` module).

## Changes

### New Modules
- `modules/plugins/utility/jupyter/magma-nvim/` - Magma-nvim module with options, config, and 6 patches fixing:
  - Neovim 0.10+ crash: `style = nil` → `style = ""` in output windows
  - Thread-safe `DynamicPosition.__del__` (race condition fix)
  - Non-blocking kernel startup (prevents UI freeze during `MagmaTick`)
  - `MagmaDeleteAll` command to clear all cells
  - Typo fix: `magma_save_cell` → `magma_save_path`
  - Kernel death notification during startup

- `modules/plugins/utility/jupyter/jupytext-nvim/` - Jupytext-nvim module with monkey-patch for notebooks missing `metadata.kernelspec` (falls back to `language_info` or defaults to python)

### Build & Pins
- `npins/sources.json` - Added `magma-nvim` (dccsillag/magma-nvim, ff3deba8) and `jupytext.nvim` (c8baf3ad) sources
- `modules/wrapper/build/config.nix` - Plugin builders for both patched plugins

### Configuration
- `configuration.nix` - Enabled both modules in maximal config with `kitty` image provider and `preferNixVenvWrapper` for campusopt

### Documentation
- `docs/manual/release-notes/rl-26.12.md` - Changelog entry under jack-thesparrow

## Plugin Sources
- magma-nvim: https://github.com/dccsillag/magma-nvim (fork with needed commit ff3deba8, patched locally via nix)
- jupytext.nvim: https://github.com/GCBallesteros/jupytext.nvim
- codewindow.nvim: https://github.com/gorbit99/codewindow.nvim

## Sanity Checking

- [x] I have updated the changelog as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in hacking nvf
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the editorconfig configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` (default package)
  - [x] `.#maximal`
  - [x] `.#docs-html` (manual, must build)
  - [x] `.#docs-linkcheck` (optional, please build if adding links)
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`