### PR TITLE
tree: lazy loading for a bunch of plugins

### DIFF
--- a/docs/manual/release-notes/rl-26.12.md
+++ b/docs/manual/release-notes/rl-26.12.md
@@ -84,6 +84,20 @@
   - `languages/java`: lazy-load `maven.nvim` on Maven commands.
   - `languages/java`: lazy-load `gradle.nvim` on Gradle commands.
   - `plugins/otter`: lazy-load `otter` on keybind.
+  - `alpha.nvim`: lazy-load.
+  - `nvim-colorizer.lua`: lazy-load.
+  - `conform.nvim`: lazy-load.
+  - `git-conflict.nvim`: lazy-load.
+  - `gitsigns.nvim`: lazy-load.
+  - `highlight-undo.nvim`: lazy-load.
+  - `img-clip.nvim`: lazy-load.
+  - `indent-blankline.nvim`: lazy-load.
+  - `smartcolumn.nvim`: lazy-load.
+  - `todo-comments.nvim`: lazy-load.
+  - `nvim-treesitter-context`: lazy-load.
+  - `typst-preview.nvim`: lazy-load.
+  - `vim-illuminate`: lazy-load.
+  - `which-key.nvim`: lazy-load.
 
 [gmvar](https://github.com/gmvar):
 

--- a/modules/plugins/dashboard/alpha/config.nix
+++ b/modules/plugins/dashboard/alpha/config.nix
@@ -4,7 +4,6 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.dashboard.alpha;
   themeDefined = cfg.theme != null;
@@ -12,19 +11,20 @@
 in {
   config = mkIf cfg.enable {
     vim = {
-      startPlugins = ["alpha-nvim"];
       visuals.nvim-web-devicons.enable = true;
 
-      pluginRC.alpha = let
+      lazy.plugins.alpha-nvim = {
+        package = "alpha-nvim";
+        setupModule = "alpha";
         setupOpts =
           if themeDefined
           then lib.generators.mkLuaInline "require'alpha.themes.${cfg.theme}'.config"
           else {
             inherit (cfg) layout opts;
           };
-      in ''
-        require('alpha').setup(${toLuaObject setupOpts})
-      '';
+        event = ["VimEnter"];
+        cmd = ["Alpha" "AlphaRedraw" "AlphaRemap"];
+      };
     };
 
     assertions = [

--- a/modules/plugins/formatter/conform-nvim/config.nix
+++ b/modules/plugins/formatter/conform-nvim/config.nix
@@ -4,17 +4,21 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.formatter.conform-nvim;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["conform-nvim"];
-      pluginRC.conform-nvim = entryAnywhere ''
-        require("conform").setup(${toLuaObject cfg.setupOpts})
-      '';
+    vim.lazy.plugins.conform-nvim = {
+      package = "conform-nvim";
+      setupModule = "conform";
+      inherit (cfg) setupOpts;
+      event = [
+        {
+          event = "User";
+          pattern = "LazyFile";
+        }
+      ];
+      cmd = ["ConformInfo"];
     };
   };
 }

--- a/modules/plugins/git/git-conflict/config.nix
+++ b/modules/plugins/git/git-conflict/config.nix
@@ -4,33 +4,38 @@
   options,
   ...
 }: let
-  inherit (lib.modules) mkIf mkMerge;
+  inherit (lib.modules) mkIf;
   inherit (lib.nvim.binds) mkKeymap;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.git.git-conflict;
 
   inherit (options.vim.git.git-conflict) mappings;
 in {
-  config = mkIf cfg.enable (mkMerge [
-    {
-      vim = {
-        startPlugins = ["git-conflict-nvim"];
-
-        keymaps = [
-          (mkKeymap "n" cfg.mappings.ours "<Plug>(git-conflict-ours)" {desc = mappings.ours.description;})
-          (mkKeymap "n" cfg.mappings.theirs "<Plug>(git-conflict-theirs)" {desc = mappings.theirs.description;})
-          (mkKeymap "n" cfg.mappings.both "<Plug>(git-conflict-both)" {desc = mappings.both.description;})
-          (mkKeymap "n" cfg.mappings.none "<Plug>(git-conflict-none)" {desc = mappings.none.description;})
-          (mkKeymap "n" cfg.mappings.prevConflict "<Plug>(git-conflict-prev-conflict)" {desc = mappings.prevConflict.description;})
-          (mkKeymap "n" cfg.mappings.nextConflict "<Plug>(git-conflict-next-conflict)" {desc = mappings.nextConflict.description;})
-        ];
-
-        pluginRC.git-conflict = entryAnywhere ''
-          require('git-conflict').setup(${toLuaObject ({default_mappings = false;} // cfg.setupOpts)})
-        '';
-      };
-    }
-  ]);
+  config = mkIf cfg.enable {
+    vim.lazy.plugins.git-conflict-nvim = {
+      package = "git-conflict-nvim";
+      setupModule = "git-conflict";
+      setupOpts = {default_mappings = false;} // cfg.setupOpts;
+      event = ["BufReadPre" "BufNewFile"];
+      cmd = [
+        "GitConflictRefresh"
+        "GitConflictListQf"
+        "GitConflictChooseOurs"
+        "GitConflictChooseTheirs"
+        "GitConflictChooseBoth"
+        "GitConflictChooseBase"
+        "GitConflictChooseNone"
+        "GitConflictNextConflict"
+        "GitConflictPrevConflict"
+      ];
+      keys = [
+        (mkKeymap "n" cfg.mappings.ours "<Plug>(git-conflict-ours)" {desc = mappings.ours.description;})
+        (mkKeymap "n" cfg.mappings.theirs "<Plug>(git-conflict-theirs)" {desc = mappings.theirs.description;})
+        (mkKeymap "n" cfg.mappings.both "<Plug>(git-conflict-both)" {desc = mappings.both.description;})
+        (mkKeymap "n" cfg.mappings.none "<Plug>(git-conflict-none)" {desc = mappings.none.description;})
+        (mkKeymap "n" cfg.mappings.prevConflict "<Plug>(git-conflict-prev-conflict)" {desc = mappings.prevConflict.description;})
+        (mkKeymap "n" cfg.mappings.nextConflict "<Plug>(git-conflict-next-conflict)" {desc = mappings.nextConflict.description;})
+      ];
+    };
+  };
 }

--- a/modules/plugins/git/gitsigns/config.nix
+++ b/modules/plugins/git/gitsigns/config.nix
@@ -8,8 +8,6 @@
   inherit (lib.modules) mkIf mkMerge;
   inherit (lib.generators) mkLuaInline;
   inherit (lib.nvim.binds) mkKeymap pushDownDefault;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.git.gitsigns;
 
@@ -18,104 +16,110 @@ in {
   config = mkIf cfg.enable (mkMerge [
     {
       vim = {
-        startPlugins = ["gitsigns-nvim"];
+        lazy.plugins.gitsigns-nvim = {
+          package = "gitsigns-nvim";
+          setupModule = "gitsigns";
+          inherit (cfg) setupOpts;
+          event = [
+            {
+              event = "User";
+              pattern = "LazyFile";
+            }
+          ];
+          cmd = ["Gitsigns"];
+          keys = [
+            (mkKeymap "n" cfg.mappings.nextHunk ''
+                function()
+                  if vim.wo.diff then return ${toJSON cfg.mappings.nextHunk} end
 
-        keymaps = [
-          (mkKeymap "n" cfg.mappings.nextHunk ''
-              function()
-                if vim.wo.diff then return ${toJSON cfg.mappings.nextHunk} end
+                  vim.schedule(function() package.loaded.gitsigns.next_hunk() end)
 
-                vim.schedule(function() package.loaded.gitsigns.next_hunk() end)
+                  return '<Ignore>'
+                end
+              '' {
+                desc = mappings.nextHunk.description;
+                lua = true;
+                expr = true;
+              })
 
-                return '<Ignore>'
-              end
-            '' {
-              desc = mappings.nextHunk.description;
+            (mkKeymap "n" cfg.mappings.previousHunk ''
+                function()
+                  if vim.wo.diff then return ${toJSON cfg.mappings.previousHunk} end
+
+                  vim.schedule(function() package.loaded.gitsigns.prev_hunk() end)
+
+                  return '<Ignore>'
+                end
+              '' {
+                desc = mappings.previousHunk.description;
+                lua = true;
+                expr = true;
+              })
+
+            (mkKeymap "n" cfg.mappings.stageHunk "function() package.loaded.gitsigns.stage_hunk() end" {
+              desc = mappings.stageHunk.description;
               lua = true;
-              expr = true;
+            })
+            (mkKeymap "n" cfg.mappings.resetHunk "function() package.loaded.gitsigns.reset_hunk() end" {
+              desc = mappings.resetHunk.description;
+              lua = true;
+            })
+            (mkKeymap "n" cfg.mappings.undoStageHunk "function() package.loaded.gitsigns.undo_stage_hunk() end" {
+              desc = mappings.undoStageHunk.description;
+              lua = true;
             })
 
-          (mkKeymap "n" cfg.mappings.previousHunk ''
-              function()
-                if vim.wo.diff then return ${toJSON cfg.mappings.previousHunk} end
-
-                vim.schedule(function() package.loaded.gitsigns.prev_hunk() end)
-
-                return '<Ignore>'
-              end
-            '' {
-              desc = mappings.previousHunk.description;
+            (mkKeymap "n" cfg.mappings.stageBuffer "function() package.loaded.gitsigns.stage_buffer() end" {
+              desc = mappings.stageBuffer.description;
               lua = true;
-              expr = true;
+            })
+            (mkKeymap "n" cfg.mappings.resetBuffer "function() package.loaded.gitsigns.reset_buffer() end" {
+              desc = mappings.resetBuffer.description;
+              lua = true;
             })
 
-          (mkKeymap "n" cfg.mappings.stageHunk "package.loaded.gitsigns.stage_hunk" {
-            desc = mappings.stageHunk.description;
-            lua = true;
-          })
-          (mkKeymap "n" cfg.mappings.resetHunk "package.loaded.gitsigns.reset_hunk" {
-            desc = mappings.resetHunk.description;
-            lua = true;
-          })
-          (mkKeymap "n" cfg.mappings.undoStageHunk "package.loaded.gitsigns.undo_stage_hunk" {
-            desc = mappings.undoStageHunk.description;
-            lua = true;
-          })
+            (mkKeymap "n" cfg.mappings.previewHunk "function() package.loaded.gitsigns.preview_hunk() end" {
+              desc = mappings.previewHunk.description;
+              lua = true;
+            })
 
-          (mkKeymap "n" cfg.mappings.stageBuffer "package.loaded.gitsigns.stage_buffer" {
-            desc = mappings.stageBuffer.description;
-            lua = true;
-          })
-          (mkKeymap "n" cfg.mappings.resetBuffer "package.loaded.gitsigns.reset_buffer" {
-            desc = mappings.resetBuffer.description;
-            lua = true;
-          })
+            (mkKeymap "n" cfg.mappings.blameLine "function() package.loaded.gitsigns.blame_line{full=true} end" {
+              desc = mappings.blameLine.description;
+              lua = true;
+            })
+            (mkKeymap "n" cfg.mappings.toggleBlame "function() package.loaded.gitsigns.toggle_current_line_blame() end" {
+              desc = mappings.toggleBlame.description;
+              lua = true;
+            })
 
-          (mkKeymap "n" cfg.mappings.previewHunk "package.loaded.gitsigns.preview_hunk" {
-            desc = mappings.previewHunk.description;
-            lua = true;
-          })
+            (mkKeymap "n" cfg.mappings.diffThis "function() package.loaded.gitsigns.diffthis() end" {
+              desc = mappings.diffThis.description;
+              lua = true;
+            })
+            (mkKeymap "n" cfg.mappings.diffProject "function() package.loaded.gitsigns.diffthis('~') end" {
+              desc = mappings.diffProject.description;
+              lua = true;
+            })
 
-          (mkKeymap "n" cfg.mappings.blameLine "function() package.loaded.gitsigns.blame_line{full=true} end" {
-            desc = mappings.blameLine.description;
-            lua = true;
-          })
-          (mkKeymap "n" cfg.mappings.toggleBlame "package.loaded.gitsigns.toggle_current_line_blame" {
-            desc = mappings.toggleBlame.description;
-            lua = true;
-          })
+            (mkKeymap "n" cfg.mappings.toggleDeleted "function() package.loaded.gitsigns.toggle_deleted() end" {
+              desc = mappings.toggleDeleted.description;
+              lua = true;
+            })
 
-          (mkKeymap "n" cfg.mappings.diffThis "package.loaded.gitsigns.diffthis" {
-            desc = mappings.diffThis.description;
-            lua = true;
-          })
-          (mkKeymap "n" cfg.mappings.diffProject "function() package.loaded.gitsigns.diffthis('~') end" {
-            desc = mappings.diffProject.description;
-            lua = true;
-          })
-
-          (mkKeymap "n" cfg.mappings.toggleDeleted "package.loaded.gitsigns.toggle_deleted" {
-            desc = mappings.toggleDeleted.description;
-            lua = true;
-          })
-
-          (mkKeymap "v" cfg.mappings.stageHunk "function() package.loaded.gitsigns.stage_hunk {vim.fn.line('.'), vim.fn.line('v')} end" {
-            desc = mappings.stageHunk.description;
-            lua = true;
-          })
-          (mkKeymap "v" cfg.mappings.resetHunk "function() package.loaded.gitsigns.reset_hunk {vim.fn.line('.'), vim.fn.line('v')} end" {
-            desc = mappings.resetHunk.description;
-            lua = true;
-          })
-        ];
+            (mkKeymap "v" cfg.mappings.stageHunk "function() package.loaded.gitsigns.stage_hunk {vim.fn.line('.'), vim.fn.line('v')} end" {
+              desc = mappings.stageHunk.description;
+              lua = true;
+            })
+            (mkKeymap "v" cfg.mappings.resetHunk "function() package.loaded.gitsigns.reset_hunk {vim.fn.line('.'), vim.fn.line('v')} end" {
+              desc = mappings.resetHunk.description;
+              lua = true;
+            })
+          ];
+        };
 
         binds.whichKey.register = pushDownDefault {
           "<leader>h" = "+Gitsigns";
         };
-
-        pluginRC.gitsigns = entryAnywhere ''
-          require('gitsigns').setup(${toLuaObject cfg.setupOpts})
-        '';
       };
     }
 

--- a/modules/plugins/languages/typst.nix
+++ b/modules/plugins/languages/typst.nix
@@ -10,8 +10,6 @@
   inherit (lib) genAttrs;
   inherit (lib.meta) getExe;
   inherit (lib.nvim.types) mkGrammarOption mkPluginSetupOption;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.nvim.binds) mkKeymap;
   inherit (config.vim.lib) mkMappingOption;
 
@@ -186,10 +184,21 @@ in {
 
     # Extensions
     (mkIf cfg.extensions.typst-preview-nvim.enable {
-      vim.startPlugins = ["typst-preview-nvim"];
-      vim.pluginRC.typst-preview-nvim = entryAnywhere ''
-        require("typst-preview").setup(${toLuaObject cfg.extensions.typst-preview-nvim.setupOpts})
-      '';
+      vim.lazy.plugins.typst-preview-nvim = {
+        package = "typst-preview-nvim";
+        setupModule = "typst-preview";
+        setupOpts = cfg.extensions.typst-preview-nvim.setupOpts;
+        cmd = [
+          "TypstPreviewUpdate"
+          "TypstPreview"
+          "TypstPreviewStop"
+          "TypstPreviewToggle"
+          "TypstPreviewFollowCursor"
+          "TypstPreviewNoFollowCursor"
+          "TypstPreviewFollowCursorToggle"
+          "TypstPreviewSyncCursor"
+        ];
+      };
     })
 
     (mkIf cfg.extensions.typst-concealer.enable {

--- a/modules/plugins/notes/todo-comments/config.nix
+++ b/modules/plugins/notes/todo-comments/config.nix
@@ -7,18 +7,23 @@
   inherit (lib.modules) mkIf;
   inherit (lib.lists) optional;
   inherit (lib.nvim.binds) mkKeymap;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.notes.todo-comments;
   inherit (options.vim.notes.todo-comments) mappings;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = [
-        "todo-comments-nvim"
+    vim.lazy.plugins.todo-comments-nvim = {
+      package = "todo-comments-nvim";
+      setupModule = "todo-comments";
+      inherit (cfg) setupOpts;
+      event = [
+        {
+          event = "User";
+          pattern = "LazyFile";
+        }
       ];
-
-      keymaps =
+      cmd = ["TodoQuickFix" "TodoLocList" "TodoTelescope" "TodoFzfLua" "TodoTrouble"];
+      keys =
         [
           (mkKeymap "n" cfg.mappings.quickFix ":TodoQuickFix<CR>" {desc = mappings.quickFix.description;})
         ]
@@ -30,10 +35,6 @@ in {
           optional config.vim.lsp.trouble.enable
           (mkKeymap "n" cfg.mappings.trouble ":TodoTrouble<CR>" {desc = mappings.trouble.description;})
         );
-
-      pluginRC.todo-comments = ''
-        require('todo-comments').setup(${toLuaObject cfg.setupOpts})
-      '';
     };
   };
 }

--- a/modules/plugins/treesitter/ts-context/config.nix
+++ b/modules/plugins/treesitter/ts-context/config.nix
@@ -4,21 +4,22 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.dag) entryAfter;
 
   inherit (config.vim) treesitter;
   cfg = treesitter.context;
 in {
   config = mkIf (treesitter.enable && cfg.enable) {
-    vim = {
-      startPlugins = ["nvim-treesitter-context"];
-
-      # set up treesitter-context after Treesitter. The ordering
-      # should not matter, but there is no harm in doing this
-      pluginRC.treesitter-context = entryAfter ["treesitter"] ''
-        require("treesitter-context").setup(${toLuaObject cfg.setupOpts})
-      '';
+    vim.lazy.plugins.nvim-treesitter-context = {
+      package = "nvim-treesitter-context";
+      setupModule = "treesitter-context";
+      inherit (cfg) setupOpts;
+      event = [
+        {
+          event = "User";
+          pattern = "LazyFile";
+        }
+      ];
+      cmd = ["TSContext"];
     };
   };
 }

--- a/modules/plugins/ui/colorizer/config.nix
+++ b/modules/plugins/ui/colorizer/config.nix
@@ -4,18 +4,15 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.ui.colorizer;
 in {
   config = mkIf cfg.enable {
-    vim.startPlugins = [
-      "nvim-colorizer-lua"
-    ];
-
-    vim.pluginRC.colorizer = entryAnywhere ''
-      require('colorizer').setup(${toLuaObject cfg.setupOpts})
-    '';
+    vim.lazy.plugins.nvim-colorizer-lua = {
+      package = "nvim-colorizer-lua";
+      setupModule = "colorizer";
+      inherit (cfg) setupOpts;
+      event = ["BufReadPre" "BufNewFile"];
+    };
   };
 }

--- a/modules/plugins/ui/illuminate/config.nix
+++ b/modules/plugins/ui/illuminate/config.nix
@@ -5,17 +5,21 @@
 }: let
   inherit (lib.modules) mkIf;
   inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.ui.illuminate;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["vim-illuminate"];
-
-      # vim-illuminate does not have a setup function. It is instead called 'configure'
-      # and does what you expect from a setup function. Wild.
-      pluginRC.vim-illuminate = entryAnywhere ''
+    # vim-illuminate does not have a setup function. It is instead called
+    # 'configure' and does what you expect from a setup function.
+    vim.lazy.plugins.vim-illuminate = {
+      package = "vim-illuminate";
+      event = [
+        {
+          event = "User";
+          pattern = "LazyFile";
+        }
+      ];
+      after = ''
         require('illuminate').configure(${toLuaObject cfg.setupOpts})
       '';
     };

--- a/modules/plugins/ui/smartcolumn/config.nix
+++ b/modules/plugins/ui/smartcolumn/config.nix
@@ -4,18 +4,15 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.ui.smartcolumn;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["smartcolumn-nvim"];
-
-      pluginRC.smartcolumn = entryAnywhere ''
-        require("smartcolumn").setup(${toLuaObject cfg.setupOpts})
-      '';
+    vim.lazy.plugins.smartcolumn-nvim = {
+      package = "smartcolumn-nvim";
+      setupModule = "smartcolumn";
+      inherit (cfg) setupOpts;
+      event = ["BufReadPre" "BufNewFile"];
     };
   };
 }

--- a/modules/plugins/utility/binds/which-key/config.nix
+++ b/modules/plugins/utility/binds/which-key/config.nix
@@ -7,19 +7,19 @@
   inherit (lib.nvim.lua) toLuaObject;
   inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.generators) mkLuaInline;
-  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.binds.whichKey;
   register = mapAttrsToList (n: v: lib.lists.optional (v != null) (mkLuaInline "{ '${n}', desc = '${v}' }")) cfg.register;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["which-key-nvim"];
-
-      pluginRC.whichkey = entryAnywhere ''
-        local wk = require("which-key")
-        wk.setup (${toLuaObject cfg.setupOpts})
-        wk.add(${toLuaObject register})
+    vim.lazy.plugins.which-key-nvim = {
+      package = "which-key-nvim";
+      setupModule = "which-key";
+      inherit (cfg) setupOpts;
+      event = ["DeferredUIEnter"];
+      cmd = ["WhichKey"];
+      after = ''
+        require("which-key").add(${toLuaObject register})
       '';
     };
   };

--- a/modules/plugins/utility/images/img-clip/config.nix
+++ b/modules/plugins/utility/images/img-clip/config.nix
@@ -4,20 +4,21 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.dag) entryAnywhere;
-  inherit (lib.nvim.lua) toLuaObject;
 
   cfg = config.vim.utility.images.img-clip;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = [
-        "img-clip"
+    vim.lazy.plugins.img-clip = {
+      package = "img-clip";
+      setupModule = "img-clip";
+      inherit (cfg) setupOpts;
+      event = [
+        {
+          event = "User";
+          pattern = "LazyFile";
+        }
       ];
-
-      pluginRC.img-clip = entryAnywhere ''
-        require("img-clip").setup(${toLuaObject cfg.setupOpts})
-      '';
+      cmd = ["PasteImage" "ImgClipDebug" "ImgClipConfig"];
     };
   };
 }

--- a/modules/plugins/visuals/highlight-undo/config.nix
+++ b/modules/plugins/visuals/highlight-undo/config.nix
@@ -4,18 +4,15 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.visuals.highlight-undo;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["highlight-undo-nvim"];
-
-      pluginRC.highlight-undo = entryAnywhere ''
-        require("highlight-undo").setup(${toLuaObject cfg.setupOpts})
-      '';
+    vim.lazy.plugins.highlight-undo-nvim = {
+      package = "highlight-undo-nvim";
+      setupModule = "highlight-undo";
+      inherit (cfg) setupOpts;
+      event = ["BufReadPre" "BufNewFile"];
     };
   };
 }

--- a/modules/plugins/visuals/indent-blankline/config.nix
+++ b/modules/plugins/visuals/indent-blankline/config.nix
@@ -4,18 +4,21 @@
   ...
 }: let
   inherit (lib.modules) mkIf;
-  inherit (lib.nvim.lua) toLuaObject;
-  inherit (lib.nvim.dag) entryAnywhere;
 
   cfg = config.vim.visuals.indent-blankline;
 in {
   config = mkIf cfg.enable {
-    vim = {
-      startPlugins = ["indent-blankline-nvim"];
-
-      pluginRC.indent-blankline = entryAnywhere ''
-        require("ibl").setup(${toLuaObject cfg.setupOpts})
-      '';
+    vim.lazy.plugins.indent-blankline-nvim = {
+      package = "indent-blankline-nvim";
+      setupModule = "ibl";
+      inherit (cfg) setupOpts;
+      event = [
+        {
+          event = "User";
+          pattern = "LazyFile";
+        }
+      ];
+      cmd = ["IBLEnable" "IBLDisable" "IBLToggle" "IBLEnableScope" "IBLDisableScope" "IBLToggleScope"];
     };
   };
 }


### PR DESCRIPTION
alpha
colorizer
conform
git-conflict
gitsigns
highlight-undo
img-clip
ibl
otter
smartcolumn
todo-comments
treesitter-context
typst-preview
illuminate
which-key

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- [ ] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [ ] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
