### PR TITLE
utility/preview/live-preview: init

### DIFF
--- a/modules/plugins/utility/preview/default.nix
+++ b/modules/plugins/utility/preview/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./markdown-preview
+    ./live-preview
     ./glow
   ];
 }

--- a/modules/plugins/utility/preview/live-preview/config.nix
+++ b/modules/plugins/utility/preview/live-preview/config.nix
@@ -1,0 +1,18 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.nvim.lua) toLuaObject;
+
+  cfg = config.vim.utility.preview.livePreview;
+in {
+  config.vim.lazy.plugins."live-preview-nvim" = mkIf cfg.enable {
+    package = "live-preview-nvim";
+    cmd = ["LivePreview"];
+    after = ''
+      require("livepreview.config").set(${toLuaObject cfg.setupOpts})
+    '';
+  };
+}

--- a/modules/plugins/utility/preview/live-preview/default.nix
+++ b/modules/plugins/utility/preview/live-preview/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./live-preview.nix
+    ./config.nix
+  ];
+}

--- a/modules/plugins/utility/preview/live-preview/live-preview.nix
+++ b/modules/plugins/utility/preview/live-preview/live-preview.nix
@@ -1,0 +1,61 @@
+{lib, ...}: let
+  inherit (lib.options) mkEnableOption mkOption;
+  inherit
+    (lib.types)
+    bool
+    enum
+    int
+    str
+    ;
+  inherit (lib.nvim.types) mkPluginSetupOption;
+in {
+  options.vim.utility.preview.livePreview = {
+    enable = mkEnableOption "live preview in a web browser with live-preview.nvim";
+
+    setupOpts = mkPluginSetupOption "live-preview.nvim" {
+      port = mkOption {
+        type = int;
+        default = 5500;
+        description = "Port to run the live preview server on.";
+      };
+
+      browser = mkOption {
+        type = str;
+        default = "default";
+        example = "firefox";
+        description = "Terminal command to open the browser for live-previewing (eg. `firefox`, `flatpak run com.vivaldi.Vivaldi`). By default, it will use the system's default browser.";
+      };
+
+      dynamic_root = mkOption {
+        type = bool;
+        default = false;
+        description = "If `true`, the root directory of the server will be the parent directory of the current file. Otherwise, it will be the current directory.";
+      };
+
+      sync_scroll = mkOption {
+        type = bool;
+        default = true;
+        description = "If `true`, the plugin will sync the scrolling in the browser as you scroll in the Markdown files in Neovim.";
+      };
+
+      picker = mkOption {
+        type = enum [
+          ""
+          "telescope"
+          "fzf-lua"
+          "mini.pick"
+          "snacks.picker"
+          "vim.ui.select"
+        ];
+        default = "";
+        description = "Picker to use for opening files. 5 choices are available: `telescope`, `fzf-lua`, `mini.pick`, `snacks.picker` or `vim.ui.select`. If `\"\"`, the plugin looks for the first available picker when you call the `pick` command.";
+      };
+
+      address = mkOption {
+        type = str;
+        default = "127.0.0.1";
+        description = "Hostname/IP-address to bind the server to. Default: `127.0.0.1`.";
+      };
+    };
+  };
+}

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1030,6 +1030,19 @@
       "url": "https://github.com/kawre/leetcode.nvim/archive/4e8b3683940a8377379ce9398e7f329e3560b42c.tar.gz",
       "hash": "sha256-82ppJQURAJcffgWwPHjrU9hROIKgk1hVITxNTzGtY5o="
     },
+    "live-preview-nvim": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "brianhuster",
+        "repo": "live-preview.nvim"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "a6307fa340ed7c0d96f5c567afc8c991aad94ce0",
+      "url": "https://github.com/brianhuster/live-preview.nvim/archive/a6307fa340ed7c0d96f5c567afc8c991aad94ce0.tar.gz",
+      "hash": "sha256-xyeoz4lEqrinkqY5U4Fu1S2HlmCyXiNQ2l2+AJFozIc="
+    },
     "lsp-signature-nvim": {
       "type": "Git",
       "repository": {


### PR DESCRIPTION
Add support for [live-preview.nvim](https://github.com/brianhuster/live-preview.nvim), a live preview plugin to preview markdown, HTML, AsciiDoc and SVG files in a web browser with live updates.

~~Additional note: Since nixpkgs packages the latest tagged release (v0.9.6), it calls a `vim.uv.run()` from inside nvim's active event loop, causing the editor to freeze when the server starts. I'm directly doing a `fetchFromGitHub()` to pin the version to the latest commit as that applies the fix. However, I did not see this being done in any other plugins, so I would love to know the correct approach here :)~~
Using `npins` now.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [x] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc