### PR TITLE
plugins/lualine: fix duplicate diagnostic data

### DIFF
--- a/docs/manual/release-notes/rl-0.6.md
+++ b/docs/manual/release-notes/rl-0.6.md
@@ -125,9 +125,9 @@ vim.api.nvim_set_keymap('n', '<leader>a', ':lua camelToSnake()<CR>', { noremap =
 
 - Lualine module now allows customizing `always_divide_middle`, `ignore_focus`
   and `disabled_filetypes` through the new options:
-  {option}`vim.statusline.lualine.alwaysDivideMiddle`,
-  {option}`vim.statusline.lualine.ignoreFocus` and
-  {option}`vim.statusline.lualine.disabledFiletypes.statusline`).
+  `vim.statusline.lualine.alwaysDivideMiddle`,
+  `vim.statusline.lualine.ignoreFocus` and
+  `vim.statusline.lualine.disabledFiletypes.statusline`).
 
 - Updated all plugin inputs to their latest versions (**21.04.2024**) - this
   brought minor color changes to the Catppuccin theme.

--- a/docs/manual/release-notes/rl-26.12.md
+++ b/docs/manual/release-notes/rl-26.12.md
@@ -37,6 +37,33 @@
 - Removed `vim-dirtytalk` from `spellcheck` as it is unmaintained and no longer
   works.
 
+[horriblename](https://github.com/horriblename)
+
+- Fully migrate lualine to setupOpts.
+  - For lualine sections, you can start by adding `map mkLuaInline` (use
+    `mkDefault + mkAfter` if you are converting `extra*Section` instead):
+
+    ```diff
+    vim.statusline.lualine = {
+    # use `map mkLuaInline` to get something working quick, then
+    # nixify each option at your own pace
+    -  activeSection.a = [
+    +  sections.lualine_a = map lib.generators.mkLuaInline [
+        "'filetype'"
+        "{'location', some_option = false}"
+      ];
+
+    # use mkDefault + mkAfter to extend NVF defaults instead of replace
+    -  extraInactiveSection.x =
+    +  inactive_sections.lualine_x =
+    +    mkDefault (mkAfter (map lib.generators.mkLuaInline
+          [
+           "function() return 'something' end"
+    -      ];
+    +      ]));
+    };
+    ```
+
 ## Changelog {#sec-release-26-12-changelog}
 
 [Snoweuph](https://github.com/snoweuph)

--- a/modules/extra/deprecations.nix
+++ b/modules/extra/deprecations.nix
@@ -1,70 +1,7 @@
 {lib, ...}: let
-  inherit (builtins) head;
-  inherit (lib.modules) mkRemovedOptionModule mkRenamedOptionModule doRename;
+  inherit (lib.modules) mkRemovedOptionModule mkRenamedOptionModule;
   inherit (lib.lists) concatLists;
   inherit (lib.nvim.config) batchRenameOptions;
-  inherit (lib.trivial) warn;
-
-  renamedVimOpts = batchRenameOptions ["vim"] ["vim" "options"] {
-    # 2024-12-01
-    colourTerm = "termguicolors";
-    mouseSupport = "mouse";
-    cmdHeight = "cmdheight";
-    updateTime = "updatetime";
-    mapTimeout = "tm";
-    cursorlineOpt = "cursorlineopt";
-    splitBelow = "splitbelow";
-    splitRight = "splitright";
-    autoIndent = "autoindent";
-    wordWrap = "wrap";
-    showSignColumn = "signcolumn";
-
-    # 2025-02-07
-    scrollOffset = "scrolloff";
-  };
-
-  mkRemovedLspOpt = lang: (mkRemovedOptionModule ["vim" "languages" lang "lsp" "opts"] ''
-    `vim.languages.${lang}.lsp.opts` is now moved to `vim.lsp.servers.<server_name>.init_options`
-  '');
-
-  mkRemovedLspPackage = lang: (mkRemovedOptionModule ["vim" "languages" lang "lsp" "package"] ''
-    `vim.languages.${lang}.lsp.package` is now moved to `vim.lsp.servers.<server_name>.cmd`
-  '');
-
-  mkRenamedLspServer = lang:
-    doRename
-    {
-      from = ["vim" "languages" lang "lsp" "server"];
-      to = ["vim" "languages" lang "lsp" "servers"];
-      visible = false;
-      warn = true;
-      use = x:
-        warn
-        "Obsolete option `vim.languages.${lang}.lsp.server` used, use `vim.languages.${lang}.lsp.servers` instead."
-        (head x);
-    };
-
-  mkRemovedFormatPackage = lang: (mkRemovedOptionModule ["vim" "languages" lang "format" "package"] ''
-    `vim.languages.${lang}.format.package` is removed, please use `vim.formatter.conform-nvim.formatters.<formatter_name>.command` instead.
-  '');
-
-  mkRemovedEnumListOption = optionPath: removedValue: msg: {
-    config,
-    lib,
-    ...
-  }: let
-    inherit (lib) elem attrByPath concatStringsSep;
-  in {
-    config.assertions = [
-      {
-        assertion = !(elem removedValue (attrByPath optionPath [] config));
-        message = ''
-          The value `${removedValue}` was removed from `${concatStringsSep "." optionPath}`.
-          ${msg}
-        '';
-      }
-    ];
-  };
 in {
   imports = concatLists [
     # 2026-07-28
@@ -98,6 +35,47 @@ in {
       (mkRemovedOptionModule ["vim" "spellcheck" "vim-dirtytalk" "enable"] ''
         Dirtytalk is unmaintained and no longer works.
       '')
+    ]
+
+    # 2026-09-04
+    (batchRenameOptions
+      ["vim" "statusline" "lualine"]
+      ["vim" "statusline" "lualine" "setupOpts" "options"]
+      {
+        theme = "theme";
+        componentSeparator = "component_separators";
+        sectionSeparator = "section_separators";
+        globalStatus = "globalstatus";
+        refresh = "refresh";
+        alwaysDivideMiddle = "always_divide_middle";
+        ignoreFocus = "ignore_focus";
+        disabledFiletypes = "disabled_filetypes";
+      })
+    [
+      (mkRemovedOptionModule ["vim" "statusline" "lualine" "activeSection"]
+        ''
+          Please use `vim.statusline.lualine.setupOpts.sections` instead.
+        '')
+      (mkRemovedOptionModule ["vim" "statusline" "lualine" "extraActiveSection"]
+        ''
+          Please use `vim.statusline.lualine.setupOpts.sections` with mkDefault
+          and mkAfter instead.
+        '')
+
+      (mkRemovedOptionModule ["vim" "statusline" "lualine" "inactiveSection"]
+        ''
+          Please use `vim.statusline.lualine.setupOpts.inactive_sections`
+          instead.
+        '')
+      (mkRemovedOptionModule ["vim" "statusline" "lualine" "extraInactiveSection"]
+        ''
+          Please use `vim.statusline.lualine.setupOpts.inactive_sections`
+          with mkDefault and mkAfter instead.
+        '')
+    ]
+
+    [
+      (mkRenamedOptionModule ["vim" "statusline" "lualine" "icons" "enable"] ["vim" "statusline" "lualine" "setupOpts" "options" "icons_enabled"])
     ]
   ];
 }

--- a/modules/plugins/statusline/lualine/config.nix
+++ b/modules/plugins/statusline/lualine/config.nix
@@ -277,7 +277,6 @@ in {
         statusline.lualine.setupOpts = {
           options = {
             icons_enabled = mkDefault cfg.icons.enable;
-            theme = mkDefault cfg.theme;
             component_separators = mkDefault cfg.componentSeparator;
             section_separators = mkDefault cfg.sectionSeparator;
             globalstatus = mkDefault cfg.globalStatus;

--- a/modules/plugins/statusline/lualine/config.nix
+++ b/modules/plugins/statusline/lualine/config.nix
@@ -270,40 +270,6 @@ in {
           local lualine = require('lualine')
           lualine.setup ${toLuaObject cfg.setupOpts}
         '';
-
-        # this is for backwards-compatibility
-        # NOTE: since lualine relies heavily on mixed list + key-value table syntax in lua e.g. {1, 2, three = 3}
-        # and we don't have a good syntax for that we're keeping the old options for now
-        statusline.lualine.setupOpts = {
-          options = {
-            icons_enabled = mkDefault cfg.icons.enable;
-            component_separators = mkDefault cfg.componentSeparator;
-            section_separators = mkDefault cfg.sectionSeparator;
-            globalstatus = mkDefault cfg.globalStatus;
-            refresh = mkDefault cfg.refresh;
-            always_divide_middle = mkDefault cfg.alwaysDivideMiddle;
-            ignore_focus = mkDefault cfg.ignoreFocus;
-            disabled_filetypes = mkDefault cfg.disabledFiletypes;
-          };
-
-          sections = {
-            lualine_a = mkDefault (map mkLuaInline (cfg.activeSection.a ++ cfg.extraActiveSection.a));
-            lualine_b = mkDefault (map mkLuaInline (cfg.activeSection.b ++ cfg.extraActiveSection.b));
-            lualine_c = mkDefault (map mkLuaInline (cfg.activeSection.c ++ cfg.extraActiveSection.c));
-            lualine_x = mkDefault (map mkLuaInline (cfg.activeSection.x ++ cfg.extraActiveSection.x));
-            lualine_y = mkDefault (map mkLuaInline (cfg.activeSection.y ++ cfg.extraActiveSection.y));
-            lualine_z = mkDefault (map mkLuaInline (cfg.activeSection.z ++ cfg.extraActiveSection.z));
-          };
-
-          inactive_sections = {
-            lualine_a = mkDefault (map mkLuaInline (cfg.inactiveSection.a ++ cfg.extraInactiveSection.a));
-            lualine_b = mkDefault (map mkLuaInline (cfg.inactiveSection.b ++ cfg.extraInactiveSection.b));
-            lualine_c = mkDefault (map mkLuaInline (cfg.inactiveSection.c ++ cfg.extraInactiveSection.c));
-            lualine_x = mkDefault (map mkLuaInline (cfg.inactiveSection.x ++ cfg.extraInactiveSection.x));
-            lualine_y = mkDefault (map mkLuaInline (cfg.inactiveSection.y ++ cfg.extraInactiveSection.y));
-            lualine_z = mkDefault (map mkLuaInline (cfg.inactiveSection.z ++ cfg.extraInactiveSection.z));
-          };
-        };
       };
     })
   ];

--- a/modules/plugins/statusline/lualine/lualine.nix
+++ b/modules/plugins/statusline/lualine/lualine.nix
@@ -275,7 +275,7 @@ in {
           ''
             {
               "diagnostics",
-              sources = {'nvim_lsp', 'nvim_diagnostic', 'nvim_diagnostic', 'vim_lsp', 'coc'},
+              sources = {'nvim_lsp', 'nvim_diagnostic', 'vim_lsp', 'coc'},
               symbols = {error = '󰅙  ', warn = '  ', info = '  ', hint = '󰌵 '},
               colored = true,
               update_in_insert = false,

--- a/modules/plugins/statusline/lualine/lualine.nix
+++ b/modules/plugins/statusline/lualine/lualine.nix
@@ -3,181 +3,91 @@
   lib,
   ...
 }: let
-  inherit (builtins) elem;
   inherit (lib.options) mkOption mkEnableOption;
-  inherit (lib.types) int bool str listOf enum nullOr;
-  inherit (lib.lists) optional;
+  inherit (lib.types) int bool str listOf enum nullOr anything;
   inherit (lib.nvim.types) mkPluginSetupOption borderType;
+  inherit (lib.generators) mkLuaInline;
   inherit (config.vim.lib) mkMappingOption;
 in {
   options.vim.statusline.lualine = {
     enable = mkEnableOption "lualine statusline plugin";
-    setupOpts = mkPluginSetupOption "Lualine" {};
-
-    icons.enable = mkEnableOption "icons for lualine" // {default = true;};
-
-    refresh = {
-      statusline = mkOption {
-        type = int;
-        description = "Refresh rate for lualine";
-        default = 1000;
-      };
-
-      tabline = mkOption {
-        type = int;
-        description = "Refresh rate for tabline";
-        default = 1000;
-      };
-
-      winbar = mkOption {
-        type = int;
-        description = "Refresh rate for winbar";
-        default = 1000;
-      };
-    };
-
-    globalStatus = mkOption {
-      type = bool;
-      description = "Enable global status for lualine";
-      default = true;
-    };
-
-    alwaysDivideMiddle = mkOption {
-      type = bool;
-      description = "Always divide middle section";
-      default = true;
-    };
-
-    disabledFiletypes = {
-      statusline = mkOption {
-        type = listOf str;
-        default = ["alpha"];
-        description = "Filetypes to disable lualine on for statusline";
-      };
-      winbar = mkOption {
-        type = listOf str;
-        default = [];
-        description = "Filetypes to disable lualine on for winbar";
-      };
-    };
-
-    ignoreFocus = mkOption {
-      type = listOf str;
-      default = ["NvimTree"];
-      description = ''
-        If current filetype is in this list it'll always be drawn as inactive statusline
-        and the last window will be drawn as active statusline.
-      '';
-    };
-
-    sectionSeparator = {
-      left = mkOption {
-        type = str;
-        description = "Section separator for left side";
-        default = "";
-      };
-
-      right = mkOption {
-        type = str;
-        description = "Section separator for right side";
-        default = "";
-      };
-    };
-
-    componentSeparator = {
-      left = mkOption {
-        type = str;
-        description = "Component separator for left side";
-        default = "";
-      };
-
-      right = mkOption {
-        type = str;
-        description = "Component separator for right side";
-        default = "";
-      };
-    };
-
-    activeSection = {
-      a = mkOption {
-        type = listOf str;
+    setupOpts = mkPluginSetupOption "Lualine" {
+      sections.lualine_a = mkOption {
+        type = listOf anything;
         description = "active config for: | (A) | B | C       X | Y | Z |";
         default = [
-          ''
-            {
-              "mode",
-              icons_enabled = true,
-              separator = {
-                left = '▎',
-                right = ''
-              },
-            }
-          ''
-          ''
-            {
-              "",
-              draw_empty = true,
-              separator = { left = '', right = '' }
-            }
-          ''
+          {
+            "@1" = "mode";
+            icons_enabled = true;
+            separator = {
+              left = "▎";
+              right = "";
+            };
+          }
+          {
+            "@1" = "";
+            draw_empty = true;
+            separator = {
+              left = "";
+              right = "";
+            };
+          }
         ];
       };
-
-      b = mkOption {
-        type = listOf str;
+      sections.lualine_b = mkOption {
+        type = listOf anything;
         description = "active config for: | A | (B) | C       X | Y | Z |";
         default = [
-          ''
-            {
-              "filetype",
-              colored = true,
-              icon_only = true,
-              icon = { align = 'left' }
-            }
-          ''
-          ''
-            {
-              "filename",
-              symbols = {modified = ' ', readonly = ' '},
-              separator = {right = ''}
-            }
-          ''
-          ''
-            {
-              "",
-              draw_empty = true,
-              separator = { left = '', right = '' }
-            }
-          ''
+          {
+            "@1" = "filetype";
+            colored = true;
+            icon_only = true;
+            icon = {align = "left";};
+          }
+          {
+            "@1" = "filename";
+            symbols = {
+              modified = " ";
+              readonly = " ";
+            };
+            separator = {right = "";};
+          }
+          {
+            "@1" = "";
+            draw_empty = true;
+            separator = {
+              left = "";
+              right = "";
+            };
+          }
         ];
       };
-
-      c = mkOption {
-        type = listOf str;
+      sections.lualine_c = mkOption {
+        type = listOf anything;
         description = "active config for: | A | B | (C)       X | Y | Z |";
         default = [
-          ''
-            {
-              "diff",
-              colored = false,
-              diff_color = {
-                -- Same color values as the general color option can be used here.
-                added    = 'DiffAdd',    -- Changes the diff's added color
-                modified = 'DiffChange', -- Changes the diff's modified color
-                removed  = 'DiffDelete', -- Changes the diff's removed color you
-              },
-              symbols = {added = '+', modified = '~', removed = '-'}, -- Changes the diff symbols
-              separator = {right = ''}
-            }
-          ''
+          {
+            "@1" = "diff";
+            colored = false;
+            diff_color = {
+              added = "DiffAdd";
+              modified = "DiffChange";
+              removed = "DiffDelete";
+            };
+            symbols = {
+              added = "+";
+              modified = "~";
+              removed = "-";
+            };
+            separator = {right = "";};
+          }
         ];
       };
-
-      x = mkOption {
-        type = listOf str;
+      sections.lualine_x = mkOption {
+        type = listOf anything;
         description = "active config for: | A | B | C       (X) | Y | Z |";
         default = [
-          ''
+          (mkLuaInline ''
             {
               -- Lsp server name
               function()
@@ -202,201 +112,112 @@ in {
 
                 return table.concat(active_clients, ", ")
               end,
-              icon = ' ',
-              separator = {left = ''},
+              icon = " ",
+              separator = {left = ""},
             }
-          ''
-          ''
-            {
-              "diagnostics",
-              sources = {'nvim_lsp', 'nvim_diagnostic', 'vim_lsp', 'coc'},
-              symbols = {error = '󰅙  ', warn = '  ', info = '  ', hint = '󰌵 '},
-              colored = true,
-              update_in_insert = false,
-              always_visible = false,
-              diagnostics_color = {
-                color_error = { fg = 'red' },
-                color_warn = { fg = 'yellow' },
-                color_info = { fg = 'cyan' },
-              },
-            }
-          ''
+          '')
+          {
+            "@1" = "diagnostics";
+            sources = ["nvim_lsp" "nvim_diagnostic" "vim_lsp" "coc"];
+            symbols = {
+              error = "󰅙  ";
+              warn = "  ";
+              info = "  ";
+              hint = "󰌵 ";
+            };
+            colored = true;
+            update_in_insert = false;
+            always_visible = false;
+            diagnostics_color = {
+              color_error = {fg = "red";};
+              color_warn = {fg = "yellow";};
+              color_info = {fg = "cyan";};
+            };
+          }
         ];
       };
-
-      y = mkOption {
-        type = listOf str;
+      sections.lualine_y = mkOption {
+        type = listOf anything;
         description = "active config for: | A | B | C       X | (Y) | Z |";
         default = [
-          ''
-            {
-              "",
-              draw_empty = true,
-              separator = { left = '', right = '' }
-            }
-          ''
-          ''
-            {
-              'searchcount',
-              maxcount = 999,
-              timeout = 120,
-              separator = {left = ''}
-            }
-          ''
-          ''
-            {
-              "branch",
-              icon = ' •',
-              separator = {left = ''}
-            }
-          ''
+          {
+            "@1" = "";
+            draw_empty = true;
+            separator = {
+              left = "";
+              right = "";
+            };
+          }
+          {
+            "@1" = "t";
+            maxcount = 999;
+            timeout = 120;
+            separator = {left = "";};
+          }
+          {
+            "@1" = "branch";
+            icon = "•";
+            separator = {left = "";};
+          }
         ];
       };
-
-      z = mkOption {
-        type = listOf str;
+      sections.lualine_z = mkOption {
+        type = listOf anything;
         description = "active config for: | A | B | C       X | Y | (Z) |";
         default = [
-          ''
-            {
-              "",
-              draw_empty = true,
-              separator = { left = '', right = '' }
-            }
-          ''
-          ''
-            {
-              "progress",
-              separator = {left = ''}
-            }
-          ''
-          ''
-            {"location"}
-          ''
-          ''
-            {
-              "fileformat",
-              color = {fg='black'},
-              symbols = {
-                unix = '', -- e712
-                dos = '',  -- e70f
-                mac = '',  -- e711
-              }
-            }
-          ''
+          {
+            "@1" = "";
+            draw_empty = true;
+            separator = {
+              left = "";
+              right = "";
+            };
+          }
+          {
+            "@1" = "progress";
+            separator = {left = "";};
+          }
+          ["location"]
+          {
+            "@1" = "fileformat";
+            color = {fg = "black";};
+            symbols = {
+              unix = "";
+              dos = "";
+              mac = "";
+            };
+          }
         ];
       };
-    };
 
-    extraActiveSection = {
-      a = mkOption {
-        type = listOf str;
-        description = "Extra entries for activeSection.a";
-        default = [];
-      };
-
-      b = mkOption {
-        type = listOf str;
-        description = "Extra entries for activeSection.b";
-        default = [];
-      };
-
-      c = mkOption {
-        type = listOf str;
-        description = "Extra entries for activeSection.c";
-        default = [];
-      };
-
-      x = mkOption {
-        type = listOf str;
-        description = "Extra entries for activeSection.x";
-        default = [];
-      };
-
-      y = mkOption {
-        type = listOf str;
-        description = "Extra entries for activeSection.y";
-        default = [];
-      };
-
-      z = mkOption {
-        type = listOf str;
-        description = "Extra entries for activeSection.z";
-        default = [];
-      };
-    };
-
-    inactiveSection = {
-      a = mkOption {
-        type = listOf str;
+      inactive_sections.lualine_a = mkOption {
+        type = listOf anything;
         description = "inactive config for: | (A) | B | C       X | Y | Z |";
         default = [];
       };
-
-      b = mkOption {
-        type = listOf str;
+      inactive_sections.lualine_b = mkOption {
+        type = listOf anything;
         description = "inactive config for: | A | (B) | C       X | Y | Z |";
         default = [];
       };
-
-      c = mkOption {
-        type = listOf str;
+      inactive_sections.lualine_c = mkOption {
+        type = listOf anything;
         description = "inactive config for: | A | B | (C)       X | Y | Z |";
-        default = ["'filename'"];
+        default = ["filename"];
       };
-
-      x = mkOption {
-        type = listOf str;
+      inactive_sections.lualine_x = mkOption {
+        type = listOf anything;
         description = "inactive config for: | A | B | C       (X) | Y | Z |";
-        default = ["'location'"];
+        default = ["location"];
       };
-
-      y = mkOption {
-        type = listOf str;
+      inactive_sections.lualine_y = mkOption {
+        type = listOf anything;
         description = "inactive config for: | A | B | C       X | (Y) | Z |";
         default = [];
       };
-
-      z = mkOption {
-        type = listOf str;
+      inactive_sections.lualine_z = mkOption {
+        type = listOf anything;
         description = "inactive config for: | A | B | C       X | Y | (Z) |";
-        default = [];
-      };
-    };
-    extraInactiveSection = {
-      a = mkOption {
-        type = listOf str;
-        description = "Extra entries for inactiveSection.a";
-        default = [];
-      };
-
-      b = mkOption {
-        type = listOf str;
-        description = "Extra entries for inactiveSection.b";
-        default = [];
-      };
-
-      c = mkOption {
-        type = listOf str;
-        description = "Extra entries for inactiveSection.c";
-        default = [];
-      };
-
-      x = mkOption {
-        type = listOf str;
-        description = "Extra entries for inactiveSection.x";
-        default = [];
-      };
-
-      y = mkOption {
-        type = listOf str;
-        description = "Extra entries for inactiveSection.y";
-        default = [];
-      };
-
-      z = mkOption {
-        type = listOf str;
-        description = "Extra entries for inactiveSection.z";
         default = [];
       };
     };

--- a/modules/plugins/statusline/lualine/lualine.nix
+++ b/modules/plugins/statusline/lualine/lualine.nix
@@ -9,61 +9,6 @@
   inherit (lib.lists) optional;
   inherit (lib.nvim.types) mkPluginSetupOption borderType;
   inherit (config.vim.lib) mkMappingOption;
-
-  supported_themes = import ./supported_themes.nix;
-  builtin_themes = [
-    "auto"
-    "16color"
-    "ayu_dark"
-    "ayu_light"
-    "ayu_mirage"
-    "ayu"
-    "base16"
-    "codedark"
-    "dracula"
-    "everforest"
-    "github_dark"
-    "github_light"
-    "github_dark_dimmed"
-    "github_dark_default"
-    "github_light_default"
-    "github_dark_high_contrast"
-    "github_light_high_contrast"
-    "github_dark_colorblind"
-    "github_light_colorblind"
-    "github_dark_tritanopia"
-    "github_light_tritanopia"
-    "gruvbox"
-    "gruvbox_dark"
-    "gruvbox_light"
-    "gruvbox-material"
-    "horizon"
-    "iceberg_dark"
-    "iceberg_light"
-    "iceberg"
-    "jellybeans"
-    "material"
-    "modus-vivendi"
-    "molokai"
-    "moonfly"
-    "nightfly"
-    "nord"
-    "OceanicNext"
-    "onedark"
-    "onelight"
-    "palenight"
-    "papercolor_dark"
-    "papercolor_light"
-    "PaperColor"
-    "powerline_dark"
-    "powerline"
-    "pywal"
-    "seoul256"
-    "solarized_dark"
-    "solarized_light"
-    "Tomorrow"
-    "wombat"
-  ];
 in {
   options.vim.statusline.lualine = {
     enable = mkEnableOption "lualine statusline plugin";
@@ -124,17 +69,6 @@ in {
         and the last window will be drawn as active statusline.
       '';
     };
-
-    theme = let
-      themeSupported = elem config.vim.theme.name supported_themes;
-      themesConcatted = builtin_themes ++ optional themeSupported config.vim.theme.name;
-    in
-      mkOption {
-        type = enum themesConcatted;
-        default = "auto";
-        defaultText = ''`config.vim.theme.name` if theme supports lualine else "auto"'';
-        description = "Theme for lualine";
-      };
 
     sectionSeparator = {
       left = mkOption {

--- a/modules/plugins/statusline/lualine/lualine.nix
+++ b/modules/plugins/statusline/lualine/lualine.nix
@@ -12,213 +12,217 @@ in {
   options.vim.statusline.lualine = {
     enable = mkEnableOption "lualine statusline plugin";
     setupOpts = mkPluginSetupOption "Lualine" {
-      sections.lualine_a = mkOption {
-        type = listOf anything;
-        description = "active config for: | (A) | B | C       X | Y | Z |";
-        default = [
-          {
-            "@1" = "mode";
-            icons_enabled = true;
-            separator = {
-              left = "▎";
-              right = "";
-            };
-          }
-          {
-            "@1" = "";
-            draw_empty = true;
-            separator = {
-              left = "";
-              right = "";
-            };
-          }
-        ];
-      };
-      sections.lualine_b = mkOption {
-        type = listOf anything;
-        description = "active config for: | A | (B) | C       X | Y | Z |";
-        default = [
-          {
-            "@1" = "filetype";
-            colored = true;
-            icon_only = true;
-            icon = {align = "left";};
-          }
-          {
-            "@1" = "filename";
-            symbols = {
-              modified = " ";
-              readonly = " ";
-            };
-            separator = {right = "";};
-          }
-          {
-            "@1" = "";
-            draw_empty = true;
-            separator = {
-              left = "";
-              right = "";
-            };
-          }
-        ];
-      };
-      sections.lualine_c = mkOption {
-        type = listOf anything;
-        description = "active config for: | A | B | (C)       X | Y | Z |";
-        default = [
-          {
-            "@1" = "diff";
-            colored = false;
-            diff_color = {
-              added = "DiffAdd";
-              modified = "DiffChange";
-              removed = "DiffDelete";
-            };
-            symbols = {
-              added = "+";
-              modified = "~";
-              removed = "-";
-            };
-            separator = {right = "";};
-          }
-        ];
-      };
-      sections.lualine_x = mkOption {
-        type = listOf anything;
-        description = "active config for: | A | B | C       (X) | Y | Z |";
-        default = [
-          (mkLuaInline ''
+      sections = {
+        lualine_a = mkOption {
+          type = listOf anything;
+          description = "active config for: | (A) | B | C       X | Y | Z |";
+          default = [
             {
-              -- Lsp server name
-              function()
-                local buf_ft = vim.bo.filetype
-                local excluded_buf_ft = { toggleterm = true, NvimTree = true, ["neo-tree"] = true, TelescopePrompt = true }
+              "@1" = "mode";
+              icons_enabled = true;
+              separator = {
+                left = "▎";
+                right = "";
+              };
+            }
+            {
+              "@1" = "";
+              draw_empty = true;
+              separator = {
+                left = "";
+                right = "";
+              };
+            }
+          ];
+        };
+        lualine_b = mkOption {
+          type = listOf anything;
+          description = "active config for: | A | (B) | C       X | Y | Z |";
+          default = [
+            {
+              "@1" = "filetype";
+              colored = true;
+              icon_only = true;
+              icon = {align = "left";};
+            }
+            {
+              "@1" = "filename";
+              symbols = {
+                modified = " ";
+                readonly = " ";
+              };
+              separator = {right = "";};
+            }
+            {
+              "@1" = "";
+              draw_empty = true;
+              separator = {
+                left = "";
+                right = "";
+              };
+            }
+          ];
+        };
+        lualine_c = mkOption {
+          type = listOf anything;
+          description = "active config for: | A | B | (C)       X | Y | Z |";
+          default = [
+            {
+              "@1" = "diff";
+              colored = false;
+              diff_color = {
+                added = "DiffAdd";
+                modified = "DiffChange";
+                removed = "DiffDelete";
+              };
+              symbols = {
+                added = "+";
+                modified = "~";
+                removed = "-";
+              };
+              separator = {right = "";};
+            }
+          ];
+        };
+        lualine_x = mkOption {
+          type = listOf anything;
+          description = "active config for: | A | B | C       (X) | Y | Z |";
+          default = [
+            (mkLuaInline ''
+              {
+                -- Lsp server name
+                function()
+                  local buf_ft = vim.bo.filetype
+                  local excluded_buf_ft = { toggleterm = true, NvimTree = true, ["neo-tree"] = true, TelescopePrompt = true }
 
-                if excluded_buf_ft[buf_ft] then
-                  return ""
+                  if excluded_buf_ft[buf_ft] then
+                    return ""
+                    end
+
+                  local bufnr = vim.api.nvim_get_current_buf()
+                  local clients = vim.lsp.get_clients({ bufnr = bufnr })
+
+                  if vim.tbl_isempty(clients) then
+                    return "No Active LSP"
                   end
 
-                local bufnr = vim.api.nvim_get_current_buf()
-                local clients = vim.lsp.get_clients({ bufnr = bufnr })
+                  local active_clients = {}
+                  for _, client in ipairs(clients) do
+                    table.insert(active_clients, client.name)
+                  end
 
-                if vim.tbl_isempty(clients) then
-                  return "No Active LSP"
-                end
-
-                local active_clients = {}
-                for _, client in ipairs(clients) do
-                  table.insert(active_clients, client.name)
-                end
-
-                return table.concat(active_clients, ", ")
-              end,
-              icon = " ",
-              separator = {left = ""},
+                  return table.concat(active_clients, ", ")
+                end,
+                icon = " ",
+                separator = {left = ""},
+              }
+            '')
+            {
+              "@1" = "diagnostics";
+              sources = ["nvim_lsp" "nvim_diagnostic" "vim_lsp" "coc"];
+              symbols = {
+                error = "󰅙  ";
+                warn = "  ";
+                info = "  ";
+                hint = "󰌵 ";
+              };
+              colored = true;
+              update_in_insert = false;
+              always_visible = false;
+              diagnostics_color = {
+                color_error = {fg = "red";};
+                color_warn = {fg = "yellow";};
+                color_info = {fg = "cyan";};
+              };
             }
-          '')
-          {
-            "@1" = "diagnostics";
-            sources = ["nvim_lsp" "nvim_diagnostic" "vim_lsp" "coc"];
-            symbols = {
-              error = "󰅙  ";
-              warn = "  ";
-              info = "  ";
-              hint = "󰌵 ";
-            };
-            colored = true;
-            update_in_insert = false;
-            always_visible = false;
-            diagnostics_color = {
-              color_error = {fg = "red";};
-              color_warn = {fg = "yellow";};
-              color_info = {fg = "cyan";};
-            };
-          }
-        ];
-      };
-      sections.lualine_y = mkOption {
-        type = listOf anything;
-        description = "active config for: | A | B | C       X | (Y) | Z |";
-        default = [
-          {
-            "@1" = "";
-            draw_empty = true;
-            separator = {
-              left = "";
-              right = "";
-            };
-          }
-          {
-            "@1" = "t";
-            maxcount = 999;
-            timeout = 120;
-            separator = {left = "";};
-          }
-          {
-            "@1" = "branch";
-            icon = "•";
-            separator = {left = "";};
-          }
-        ];
-      };
-      sections.lualine_z = mkOption {
-        type = listOf anything;
-        description = "active config for: | A | B | C       X | Y | (Z) |";
-        default = [
-          {
-            "@1" = "";
-            draw_empty = true;
-            separator = {
-              left = "";
-              right = "";
-            };
-          }
-          {
-            "@1" = "progress";
-            separator = {left = "";};
-          }
-          ["location"]
-          {
-            "@1" = "fileformat";
-            color = {fg = "black";};
-            symbols = {
-              unix = "";
-              dos = "";
-              mac = "";
-            };
-          }
-        ];
+          ];
+        };
+        lualine_y = mkOption {
+          type = listOf anything;
+          description = "active config for: | A | B | C       X | (Y) | Z |";
+          default = [
+            {
+              "@1" = "";
+              draw_empty = true;
+              separator = {
+                left = "";
+                right = "";
+              };
+            }
+            {
+              "@1" = "t";
+              maxcount = 999;
+              timeout = 120;
+              separator = {left = "";};
+            }
+            {
+              "@1" = "branch";
+              icon = "•";
+              separator = {left = "";};
+            }
+          ];
+        };
+        lualine_z = mkOption {
+          type = listOf anything;
+          description = "active config for: | A | B | C       X | Y | (Z) |";
+          default = [
+            {
+              "@1" = "";
+              draw_empty = true;
+              separator = {
+                left = "";
+                right = "";
+              };
+            }
+            {
+              "@1" = "progress";
+              separator = {left = "";};
+            }
+            ["location"]
+            {
+              "@1" = "fileformat";
+              color = {fg = "black";};
+              symbols = {
+                unix = "";
+                dos = "";
+                mac = "";
+              };
+            }
+          ];
+        };
       };
 
-      inactive_sections.lualine_a = mkOption {
-        type = listOf anything;
-        description = "inactive config for: | (A) | B | C       X | Y | Z |";
-        default = [];
-      };
-      inactive_sections.lualine_b = mkOption {
-        type = listOf anything;
-        description = "inactive config for: | A | (B) | C       X | Y | Z |";
-        default = [];
-      };
-      inactive_sections.lualine_c = mkOption {
-        type = listOf anything;
-        description = "inactive config for: | A | B | (C)       X | Y | Z |";
-        default = ["filename"];
-      };
-      inactive_sections.lualine_x = mkOption {
-        type = listOf anything;
-        description = "inactive config for: | A | B | C       (X) | Y | Z |";
-        default = ["location"];
-      };
-      inactive_sections.lualine_y = mkOption {
-        type = listOf anything;
-        description = "inactive config for: | A | B | C       X | (Y) | Z |";
-        default = [];
-      };
-      inactive_sections.lualine_z = mkOption {
-        type = listOf anything;
-        description = "inactive config for: | A | B | C       X | Y | (Z) |";
-        default = [];
+      inactive_sections = {
+        lualine_a = mkOption {
+          type = listOf anything;
+          description = "inactive config for: | (A) | B | C       X | Y | Z |";
+          default = [];
+        };
+        lualine_b = mkOption {
+          type = listOf anything;
+          description = "inactive config for: | A | (B) | C       X | Y | Z |";
+          default = [];
+        };
+        lualine_c = mkOption {
+          type = listOf anything;
+          description = "inactive config for: | A | B | (C)       X | Y | Z |";
+          default = ["filename"];
+        };
+        lualine_x = mkOption {
+          type = listOf anything;
+          description = "inactive config for: | A | B | C       (X) | Y | Z |";
+          default = ["location"];
+        };
+        lualine_y = mkOption {
+          type = listOf anything;
+          description = "inactive config for: | A | B | C       X | (Y) | Z |";
+          default = [];
+        };
+        lualine_z = mkOption {
+          type = listOf anything;
+          description = "inactive config for: | A | B | C       X | Y | (Z) |";
+          default = [];
+        };
       };
     };
 

--- a/modules/plugins/statusline/lualine/supported_themes.nix
+++ b/modules/plugins/statusline/lualine/supported_themes.nix
@@ -1,9 +1,0 @@
-[
-  "tokyonight"
-  "onedark"
-  "catppuccin"
-  "oxocarbon"
-  "gruvbox"
-  "nord"
-  "mellow"
-]


### PR DESCRIPTION
closes #1810 and #1801

thanks @alexperreault

fully migrates lualine to setupOpts. Gets rid of option definitions that aren't that important. On the point of #1801, the theme names are "catppuccin-mocha" etc and not "catppuccin". I don't think there's any need to add more nix code to handle that, "auto" works just fine.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link of the added plugin
or dependency in this section.

If your pull request aims to fix an open issue or a please bug, please also link the relevant issue
below this line. You may attach an issue to your pull request with `Fixes #<issue number>` outside
this comment, and it will be closed when your pull request is merged.

A developer package template is provided in flake/develop.nix. If working on a module, you may use
it to test your changes with minimal dependency changes.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement but checklists with more checked
items are likely to be merged faster. You may save some time in maintainer reviews by performing self-reviews
here before submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below, please do make sure to include
it above in your description.
-->

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [ ] I ran **Alejandra** to format my code (`nix fmt`)
  - [ ] My code conforms to the [editorconfig] configuration of the project
  - [ ] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas
  - [ ] I have added a section in the manual
  - [ ] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [ ] `.#maximal`
  - [ ] `.#docs-html` _(manual, must build)_
  - [ ] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

<!--
If your changes touch upon a portion of the codebase that you do not understand well, please make sure to consult
the maintainers on your changes. In most cases, making an issue before creating your PR will help you avoid duplicate
efforts in the long run. `git blame` might help you find out who is the "author" or the "maintainer" of a current
module by showing who worked on it the most.
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
