### PR TITLE
mappings: add ft option for filetype-scoped keymaps

### DIFF
--- a/docs/manual/configuring/keybinds.md
+++ b/docs/manual/configuring/keybinds.md
@@ -6,10 +6,6 @@ to disable individual keymaps with options by setting them to `null`. If a
 keymap is not provided by a module, you may easily register your own custom
 keymaps via {option}`vim.keymaps`.
 
-Keymaps can be restricted to specific filetypes by setting `ft`. When `ft` is
-non-empty (it defaults to an empty list), the mapping is not created globally;
-instead, a `FileType` autocmd registers a buffer-local mapping.
-
 ```nix
 {
   config.vim.keymaps = [

--- a/docs/manual/configuring/keybinds.md
+++ b/docs/manual/configuring/keybinds.md
@@ -6,6 +6,10 @@ to disable individual keymaps with options by setting them to `null`. If a
 keymap is not provided by a module, you may easily register your own custom
 keymaps via {option}`vim.keymaps`.
 
+Keymaps can be restricted to specific filetypes by setting `ft`. When `ft` is
+non-empty (it defaults to an empty list), the mapping is not created globally;
+instead, a `FileType` autocmd registers a buffer-local mapping.
+
 ```nix
 {
   config.vim.keymaps = [
@@ -34,6 +38,16 @@ keymaps via {option}`vim.keymaps`.
           print('did thing')
         end
       '';
+    }
+    {
+      # `ft` restricts the keymap to buffers of the given filetypes.
+      # Instead of a global mapping, a `FileType` autocmd creates a
+      # buffer-local mapping when such a buffer is opened.
+      key = "<leader>p";
+      mode = "n";
+      action = "<cmd>Git push<CR>";
+      desc = "Push commit";
+      ft = ["fugitive"];
     }
   ];
 }

--- a/docs/manual/release-notes/rl-26.12.md
+++ b/docs/manual/release-notes/rl-26.12.md
@@ -66,6 +66,12 @@
 
 ## Changelog {#sec-release-26-12-changelog}
 
+[theol-git](https://github.com/theol-git):
+
+- Added an `ft` option to {option}`vim.keymaps`, scoping a keymap to the given
+  filetypes via a `FileType` autocmd. Defaults to an empty list, i.e. a global
+  mapping.
+
 [Snoweuph](https://github.com/snoweuph)
 
 [bun ORM]: https://bun.uptrace.dev/

--- a/modules/neovim/init/mappings.nix
+++ b/modules/neovim/init/mappings.nix
@@ -38,6 +38,20 @@
     expr = mkBool false "Means that the action is actually an expression. Equivalent to adding <expr> to a map.";
     unique = mkBool false "Whether to fail if the map is already defined. Equivalent to adding <unique> to a map.";
     noremap = mkBool true "Whether to use the 'noremap' variant of the command, ignoring any custom mappings on the defined action. It is highly advised to keep this on, which is the default.";
+
+    ft = mkOption {
+      type = listOf str;
+      default = [];
+      description = ''
+        The filetypes that this keybind should apply to, e.g. `[ "fugitive" ]`.
+        Defaults to an empty list.
+
+        When non-empty, the keybind will not be created as a global mapping.
+        Instead, a `FileType` autocmd is registered for the given filetypes that
+        creates a buffer-local mapping whenever a buffer with one of these
+        filetypes is opened.
+      '';
+    };
   };
 
   mapType = submodule {
@@ -109,6 +123,13 @@ in {
             mode = ["n" "x"];
             silent = true;
             action = "<cmd>cnext<CR>";
+          }
+          {
+            key = "<leader>p";
+            mode = "n";
+            action = "<cmd>Git push<CR>";
+            desc = "Push commit";
+            ft = ["fugitive"];
           }
         ];
       '';

--- a/modules/neovim/init/mappings.nix
+++ b/modules/neovim/init/mappings.nix
@@ -44,12 +44,8 @@
       default = [];
       description = ''
         The filetypes that this keybind should apply to, e.g. `[ "fugitive" ]`.
-        Defaults to an empty list.
-
-        When non-empty, the keybind will not be created as a global mapping.
-        Instead, a `FileType` autocmd is registered for the given filetypes that
-        creates a buffer-local mapping whenever a buffer with one of these
-        filetypes is opened.
+        When non-empty, the keymap is created buffer-locally via a FileType
+        autocmd instead of globally.
       '';
     };
   };

--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -5,7 +5,7 @@
 }: let
   inherit (builtins) map mapAttrs filter;
   inherit (lib.lists) partition;
-  inherit (lib.attrsets) mapAttrsToList;
+  inherit (lib.attrsets) mapAttrsToList optionalAttrs;
   inherit (lib.strings) concatLines concatMapStringsSep optionalString;
   inherit (lib.trivial) showWarnings;
   inherit (lib.generators) mkLuaInline;
@@ -43,7 +43,19 @@ in {
       remap = !keymap.noremap;
     };
 
-    toLuaKeymap = bind: "vim.keymap.set(${toLuaObject bind.mode}, ${toLuaObject bind.key}, ${toLuaObject (getAction bind)}, ${toLuaObject (getOpts bind)})";
+    toLuaKeymap = keymap: let
+      isFtKeymap = keymap.ft != [];
+      setKeymapLua = "vim.keymap.set(${toLuaObject keymap.mode}, ${toLuaObject keymap.key}, ${toLuaObject (getAction keymap)}, ${toLuaObject (getOpts keymap // optionalAttrs isFtKeymap {buffer = true;})})";
+    in
+      if isFtKeymap
+      then ''
+        vim.api.nvim_create_autocmd("FileType", {
+          pattern = ${toLuaObject keymap.ft},
+          callback = function()
+            ${setKeymapLua}
+          end,
+        })''
+      else setKeymapLua;
 
     keymaps = concatLines (map toLuaKeymap (filter (x: x.key != null) cfg.keymaps));
   in {

--- a/modules/wrapper/rc/config.nix
+++ b/modules/wrapper/rc/config.nix
@@ -45,7 +45,8 @@ in {
 
     toLuaKeymap = keymap: let
       isFtKeymap = keymap.ft != [];
-      setKeymapLua = "vim.keymap.set(${toLuaObject keymap.mode}, ${toLuaObject keymap.key}, ${toLuaObject (getAction keymap)}, ${toLuaObject (getOpts keymap // optionalAttrs isFtKeymap {buffer = true;})})";
+      opts = getOpts keymap // optionalAttrs isFtKeymap {buffer = true;};
+      setKeymapLua = "vim.keymap.set(${toLuaObject keymap.mode}, ${toLuaObject keymap.key}, ${toLuaObject (getAction keymap)}, ${toLuaObject opts})";
     in
       if isFtKeymap
       then ''


### PR DESCRIPTION
## Aim

Adds an `ft` option to `vim.keymaps`, so a keymap can be scoped to specific
filetypes while keeping the configuration declarative inside `vim.keymaps`.

Today `vim.keymaps` only emits global mappings. With `ft`, nvf instead generates
a `FileType` autocmd that creates a buffer-local mapping whenever a buffer of one
of the given filetypes is opened. `ft` defaults to an empty list, which keeps the
mapping global. This is not lazy loading — it only makes keymaps active for
specific filetypes.

Example:

```nix
vim.keymaps = [
  {
    mode = "n";
    key = "<leader>p";
    action = "<cmd>Git push<CR>";
    desc = "Push commit";
    ft = [ "fugitive" ];
  }
];
```

generates:

```lua
vim.api.nvim_create_autocmd("FileType", {
  pattern = { "fugitive" },
  callback = function()
    vim.keymap.set("n", "<leader>p", "<cmd>Git push<CR>", {
      buffer = true,
      desc = "Push commit",
    })
  end,
})
```

## Testing

- Verified the generated Lua through module evaluation
  (`config.vim.builtLuaConfigRC`) for global, `ft = [...]`, and `ft = []` cases.
- Tested in a real nvf build using a filetype-scoped keymap; confirmed the buffer-local mapping appears only on buffers of the matching filetype.
- Built `.#nix`, `.#maximal`, and `.#docs-html` successfully.

## Sanity Checking

[editorconfig]: https://editorconfig.org
[changelog]: https://github.com/NotAShelf/nvf/tree/main/docs/manual/release-notes
[hacking nvf]: https://nvf.notashelf.dev/hacking.html#sec-guidelines

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- [x] My changes fit guidelines found in [hacking nvf]
- Style and consistency
  - [x] I ran **Alejandra** to format my code (`nix fmt`)
  - [x] My code conforms to the [editorconfig] configuration of the project
  - [x] My changes are consistent with the rest of the codebase
- If new changes are particularly complex:
  - [N/A] My code includes comments in particularly complex areas
  - [x] I have added a section in the manual
  - [N/A] _(For breaking changes)_ I have included a migration guide
- Package(s) built:
  - [x] `.#nix` _(default package)_
  - [x] `.#maximal`
  - [x] `.#docs-html` _(manual, must build)_
  - [N/A] `.#docs-linkcheck` _(optional, please build if adding links)_
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [] `aarch64-linux`
  - [] `x86_64-darwin`
  - [] `aarch64-darwin`